### PR TITLE
Contains fix for bug #9

### DIFF
--- a/app/resources/errors.html.template
+++ b/app/resources/errors.html.template
@@ -8,6 +8,10 @@
       class="mandatory" style="display: none">
     {% trans "Please fill in all the required fields." %}
   </div>
+  <div id="email_id_improper_format"
+      class="mandatory" style="display: none">
+    {% trans "The Email-ID you entered doesn't look like valid. Please correct it and try again" %}
+  </div>
   <div id="status_inconsistent_with_author_made_contact"
       class="mandatory" style="display: none">
     {% trans "The status you selected indicates that you are this person.  If this is true, please also select 'Yes' to indicate that you have contacted this person." %}

--- a/app/resources/errors.html.template
+++ b/app/resources/errors.html.template
@@ -10,7 +10,10 @@
   </div>
   <div id="email_id_improper_format"
       class="mandatory" style="display: none">
-    {% trans "The Email-ID you entered doesn't look like valid. Please correct it and try again" %}
+  {% blocktrans %}
+  The Email address you entered doesn't look like valid address.
+  Please correct it and try again.
+  {% endblocktrans %}
   </div>
   <div id="status_inconsistent_with_author_made_contact"
       class="mandatory" style="display: none">

--- a/app/resources/errors.html.template
+++ b/app/resources/errors.html.template
@@ -11,8 +11,7 @@
   <div id="email_id_improper_format"
       class="mandatory" style="display: none">
   {% blocktrans %}
-  The Email address you entered doesn't look like valid address.
-  Please correct it and try again.
+  The Email address you entered is not valid.
   {% endblocktrans %}
   </div>
   <div id="status_inconsistent_with_author_made_contact"

--- a/app/resources/forms.js
+++ b/app/resources/forms.js
@@ -284,6 +284,22 @@ function validate_fields() {
   }
   hide($('mandatory_field_missing'));
 
+  //Validate email-id
+  var email_field = $('author_email');
+  var email_id = $('author_email').value;
+  if (email_id !== "")
+  {
+     var emailfilter=/^\w+[\+\.\w-]*@([\w-]+\.)*\w+[\w-]*\.([a-z]{2,4}|\d+)$/i;
+     if (!emailfilter.test(email_id))
+     {
+        show($('email_id_improper_format'));
+        email_field.focus();
+        return false;
+     }
+   }
+
+  hide($('email_id_improper_format'));
+
   // Check that the status and author_made_contact values are not inconsistent.
   if ($('status') && $('status').value == 'is_note_author' &&
       $('author_made_contact_no') && $('author_made_contact_no').checked) {

--- a/app/resources/forms.js
+++ b/app/resources/forms.js
@@ -288,7 +288,6 @@ function validate_fields() {
   var email_field = $('author_email');
   var email_id = $('author_email').value;
   if (email_id !== ""){
-     //var emailfilter=/^\w+[\+\.\w-]*@([\w-]+\.)*\w+[\w-]*\.([a-z]{2,4}|\d+)$/i;
      var emailfilter=/(?:^|\s)[-a-z0-9_.%$+]+@(?:[-a-z0-9]+\.)[a-z]{2,6}(?:\s|$)/i;
      if (!emailfilter.test(email_id)){
         show($('email_id_improper_format'));

--- a/app/resources/forms.js
+++ b/app/resources/forms.js
@@ -288,7 +288,7 @@ function validate_fields() {
   var email_field = $('author_email');
   var email_id = $('author_email').value;
   if (email_id !== ""){
-     var emailfilter=/(?:^|\s)[-a-z0-9_.%$+]+@(?:[-a-z0-9]+\.)[a-z]{2,6}(?:\s|$)/i;
+     var emailfilter=/(?:^|\s)[-a-z0-9_.%$+]+@(?:[-a-z0-9]+\.)+[a-z]{2,6}(?:\s|$)/i;
      if (!emailfilter.test(email_id)){
         show($('email_id_improper_format'));
         email_field.focus();

--- a/app/resources/forms.js
+++ b/app/resources/forms.js
@@ -287,11 +287,10 @@ function validate_fields() {
   //Validate email-id
   var email_field = $('author_email');
   var email_id = $('author_email').value;
-  if (email_id !== "")
-  {
-     var emailfilter=/^\w+[\+\.\w-]*@([\w-]+\.)*\w+[\w-]*\.([a-z]{2,4}|\d+)$/i;
-     if (!emailfilter.test(email_id))
-     {
+  if (email_id !== ""){
+     //var emailfilter=/^\w+[\+\.\w-]*@([\w-]+\.)*\w+[\w-]*\.([a-z]{2,4}|\d+)$/i;
+     var emailfilter=/(?:^|\s)[-a-z0-9_.%$+]+@(?:[-a-z0-9]+\.)[a-z]{2,6}(?:\s|$)/i;
+     if (!emailfilter.test(email_id)){
         show($('email_id_improper_format'));
         email_field.focus();
         return false;


### PR DESCRIPTION
# Contains fix for bug #9 .

## Explanation

Email-ID validation can be done at client itself. In-order to support it, I had extended `validate_fields()` in `forms.js` file. The given email-id will be compared with valid format and if found correct, the form will be submitted. Else a error string will be displayed. In order to support the error string, `errors.html.template` has been modified and new `<div>` element has been introduced. Basic unit testing has been completed. 

### Sample test result
![image](https://cloud.githubusercontent.com/assets/7476271/7419696/79cdc2f4-ef94-11e4-85b5-8f28d9f41144.png)