### PR TITLE
Remove "overflow: hidden" from the CSS to avoid hiding content in admin pages, etc.

### DIFF
--- a/app/resources/css-default.template
+++ b/app/resources/css-default.template
@@ -25,7 +25,6 @@ body {
   font-size: 13px;
   margin: auto;
   max-width: 800px;
-  overflow-x: hidden;
   width: 100%;
 }
 
@@ -56,7 +55,6 @@ h3 {
 
 .header {
   border-bottom: 1px solid #dadada;
-  overflow: hidden;
   padding: 1em 0;
 }
 
@@ -66,7 +64,6 @@ h3 {
 
 .container {
   clear: both;
-  overflow: hidden;
 }
 
 .hidden {


### PR DESCRIPTION
Verified that major pages look fine after this change on mobile. Verified with Rupert that this is probably OK.