### PR TITLE
Support global API keys (with repo='*') in web admin page. #37

### DIFF
--- a/app/resources/admin.html.template
+++ b/app/resources/admin.html.template
@@ -224,7 +224,6 @@
   <li><a href="admin/review">Review notes</a></li>
   <li><a href="admin/api_keys">Create an API key</a></li>
   <li><a href="admin/api_keys/list">List API keys</a></li>
-  <li><a href="admin/resources">Manage resources</a></li>
 </ul>
 
 <h2>Edit settings for <a href="{{env.repo_url}}">{{env.repo}}</a></h2>
@@ -773,6 +772,13 @@
 </form>
 
 {% else %}
+
+<h2>Global admin tools</h2>
+<ul>
+  <li><a href="admin/resources">Manage resources</a></li>
+  <li><a href="admin/api_keys">Create an API key to access all repositories</a></li>
+  <li><a href="admin/api_keys/list">List API keys to access all repositories</a></li>
+</ul>
 
 <h2>Edit global settings</h2>
 

--- a/app/resources/admin_api_keys.html.template
+++ b/app/resources/admin_api_keys.html.template
@@ -25,7 +25,11 @@
 {% if message %}
   <div class="info"><strong>{{ message }}</strong></div>
 {% endif %}
-<h2>Detailed information of an API key for {{ env.repo }}.{{env.parent_domain}}</h2>
+{% if env.repo %}
+  <h2>Detailed information of an API key for {{ env.repo }} repository</h2>
+{% else %}
+  <h2>Detailed information of an API key to access all repositories</h2>
+{% endif %}
 {% if target_key.key %}
   API key: <span id="actual_key">{{ target_key.api_key }}</span>
 {% endif %}

--- a/app/resources/admin_api_keys_list.html.template
+++ b/app/resources/admin_api_keys_list.html.template
@@ -12,7 +12,12 @@
 {% load i18n %}
 
 {% block content %}
-<h2>Listing API keys for {{env.repo}}.{{env.parent_domain}}</h2>
+{% if env.repo %}
+  <h2>API keys for {{env.repo}} repository</h2>
+{% else %}
+  <h2>API keys to access all repositories</h2>
+{% endif %}
+
 <p>
 {% if user %}
   {% blocktrans with user_email_with_tags|safe as user_email %}You are currently signed in as {{user_email}}.{% endblocktrans %}


### PR DESCRIPTION
Also move the link to the resource management page from the per-repository admin page to the global admin page, because it's not repo-specific.