### PR TITLE
Simple SMS interface to add a found person.

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -629,7 +629,9 @@ class HandleSMS(utils.BaseHandler):
             person = Person.create_original(
                 repo,
                 entry_date=utils.get_utcnow(),
-                full_name=name_string)
+                full_name=name_string,
+                family_name='',
+                given_name='')
             person.update_index(['old', 'new'])
             note = Note.create_original(
                 repo,

--- a/app/api.py
+++ b/app/api.py
@@ -632,9 +632,8 @@ class HandleSMS(utils.BaseHandler):
             # sender phone number and be safe with names with whitespace).
             person_record_id = '%s.%s/%s.%s-%s' % (
                 repo, HOME_DOMAIN, 'person', sender_phone_number, name_string)
-            person = Person.create_original_with_record_id(
+            person = Person.create_original(
                 repo,
-                person_record_id,
                 entry_date=utils.get_utcnow(),
                 full_name=name_string)
             person.update_index(['old', 'new'])

--- a/app/api.py
+++ b/app/api.py
@@ -37,7 +37,6 @@ import simplejson
 import subscribe
 import utils
 import xlrd
-from const import HOME_DOMAIN
 from model import Person, Note, ApiActionLog
 from text_query import TextQuery
 from utils import Struct
@@ -651,7 +650,7 @@ class HandleSMS(utils.BaseHandler):
             model.UserActionLog.put_new('add', person, copy_properties=False)
             responses.append('Added record for found person: %s' % name_string)
         else:
-            usage_str = 'Usage: Search John'
+            usage_str = 'Usage: "Search John"'
             if self.config.enable_sms_record_input:
               usage_str += ' OR "I am John"'
             responses.append(usage_str)

--- a/app/api.py
+++ b/app/api.py
@@ -565,13 +565,15 @@ class HandleSMS(utils.BaseHandler):
     MAX_RESULTS = 3
 
     def post(self):
-        if not (self.auth and self.auth.search_permission):
+        if not (self.auth and self.auth.search_permission
+                and self.auth.domain_write_permission):
             self.info(
                 403,
                 message=
                     '"key" URL parameter is either missing, invalid or '
-                    'lacks required permissions. The key\'s repo must be "*" '
-                    'and search_permission must be True.',
+                    'lacks required permissions. The key\'s repo must be "*", '
+                    'search_permission must be True, and it must have write '
+                    'permission.',
                 style='plain')
             return
 

--- a/app/api.py
+++ b/app/api.py
@@ -580,8 +580,6 @@ class HandleSMS(utils.BaseHandler):
         message_text = self.get_element_text(doc, 'message_text')
         receiver_phone_number = self.get_element_text(
             doc, 'receiver_phone_number')
-        sender_phone_number = self.get_element_text(
-            doc, 'sender_phone_number')
 
         if message_text is None:
             self.info(
@@ -628,10 +626,6 @@ class HandleSMS(utils.BaseHandler):
                 'accuracy of this data google.org/personfinder/global/tos.html')
         elif self.config.enable_sms_record_input and add_self_m:
             name_string = add_self_m.group(1).strip()
-            # TODO(nworden): Figure out a better sort of ID (needs to hide the
-            # sender phone number and be safe with names with whitespace).
-            person_record_id = '%s.%s/%s.%s-%s' % (
-                repo, HOME_DOMAIN, 'person', sender_phone_number, name_string)
             person = Person.create_original(
                 repo,
                 entry_date=utils.get_utcnow(),

--- a/app/api.py
+++ b/app/api.py
@@ -565,7 +565,7 @@ class HandleSMS(utils.BaseHandler):
 
     def post(self):
         if not (self.auth and self.auth.search_permission
-                and self.auth.domain_write_permission):
+                and self.auth.domain_write_permission == '*'):
             self.info(
                 403,
                 message=


### PR DESCRIPTION
I tested this by setting up the config to enable SMS self-additions and to add "+12345678901" as a receiver phone number, adding an API key for it, then running this small Python script with a command like:
`python sms_tester.py "i am nick"`
```
import scrape
import sys

RD = '<?xml version="1.0" encoding="utf-8"?><request>    <message_text>%s</message_text>    <receiver_phone_number>+12345678901</receiver_phone_number></request>'
URL='http://localhost:8000/testrepo1/api/handle_sms?key=API_KEY&lang=en'
s = scrape.Session(verbose=1)
doc = s.go(URL, data=RD % sys.argv[1], type='application/xml')
print doc.content
```

Could you let me know which fields are required for Person records? I found that indexing.py seems to require family_name (and, I think, given_name): if I have two people that match a search, it tries to rank them, and fails on line 129 of indexing.py (because re.match doesn't want a None argument), but there's a comment on line 118 that say those fields are optional. I am currently only filling in full_name, but I'll either need to fill in the other fields somehow or change indexing.py.