### PR TITLE
Fix server test failures.

### DIFF
--- a/tests/server_tests.py
+++ b/tests/server_tests.py
@@ -281,8 +281,12 @@ def reset_data():
         Authorization.create(
             '*', 'global_test_key',
             domain_write_permission='globaltestdomain.com'),
+        # An API key which can be used for SMS API.
         Authorization.create(
-            '*', 'global_search_key', search_permission=True),
+            '*',
+            'sms_key',
+            search_permission=True,
+            domain_write_permission='*'),
     ])
 
 def monkeypatch_pytest_terminal_reporter():


### PR DESCRIPTION
Set domain_write_permission='*' (now required) for the API key used for SMS API.
Dump error message in the admin page when the test fails. The actual fix will be in a separated pull request.