### PR TITLE
Contains the bugfix for issue #123

### DIFF
--- a/app/resources/admin_api_key_form.html.template
+++ b/app/resources/admin_api_key_form.html.template
@@ -14,14 +14,11 @@
   function $(id) {
     return document.getElementById(id);
   }
-  function updateWriteDomain() {
+  function update_write_domain() {
     var write_field = $('write_permission');
-    var domain_write_field = $('domain_write_permission');
-    if(write_field.checked) {
-      $('domain_write_permission').disabled = false;
-    }
-    else {
-      $('domain_write_permission').disabled = true;
+    $('domain_write_permission').disabled = !write_field.checked;
+    if(!write_field.checked) {
+      $('domain_write_permission').value = "";
     }
   }
   function validate_fields() {
@@ -41,7 +38,7 @@
     // Check for explicit write permission
     var write_field = $('write_permission');
     var domain_write_field = $('domain_write_permission');
-    if(write_field.checked && domain_write_field.value.length == 0) {
+    if (write_field.checked && domain_write_field.value.length == 0) {
        alert('Enter proper value for domain name');
        domain_write_field.focus();
        $('domain_write_label').setAttribute('class', 'mandatory');
@@ -104,9 +101,9 @@
 	Permission flags
       </label>
       <div class="response">
-        <input type="checkbox" name="write_permission" id="write_permission" onChange="updateWriteDomain();">
+        <input type="checkbox" name="write_permission" id="write_permission" onChange="update_write_domain();">
         Write permission
-	<span class="warning">This permission should go with domain write permission.</span>
+	<span class="warning">This permission should go with the domain name above.</span>
       </div>
       <div class="response">
         <input type="checkbox" name="read_permission" id="read_permission"

--- a/app/resources/admin_api_key_form.html.template
+++ b/app/resources/admin_api_key_form.html.template
@@ -14,6 +14,16 @@
   function $(id) {
     return document.getElementById(id);
   }
+  function updateWriteDomain() {
+    var write_field = $('write_permission');
+    var domain_write_field = $('domain_write_permission');
+    if(write_field.checked) {
+      $('domain_write_permission').disabled = false;
+    }
+    else {
+      $('domain_write_permission').disabled = true;
+    }
+  }
   function validate_fields() {
     $('submit').disabled = true;
     // Check that mandatory fields are filled in.
@@ -28,6 +38,17 @@
         return false;
       }
     }
+    // Check for explicit write permission
+    var write_field = $('write_permission');
+    var domain_write_field = $('domain_write_permission');
+    if(write_field.checked && domain_write_field.value.length == 0) {
+       alert('Enter proper value for domain name');
+       domain_write_field.focus();
+       $('domain_write_label').setAttribute('class', 'mandatory');
+       $('submit').disabled = false;
+       return false;
+    }
+
     $('mandatory_field_missing').setAttribute('style', 'display: none');
     $('submit').disabled = false;
     return true;
@@ -68,19 +89,25 @@
   <fieldset>
     <legend>Permissions</legend>
     <div class="config">
-      <label for="domain_write_permission">
+      <label for="domain_write_permission" id="domain_write_label">
         A domain name when writing with the API.
         Leave it blank if you don't want to give a write permission.
       </label>
       <div class="response">
         <input name="domain_write_permission" id="domain_write_permission"
-               size="40" value="{{target_key.domain_write_permission|default_if_none:""}}">
+               size="40" value="{{target_key.domain_write_permission|default_if_none:""}}" 
+               disabled="true">
       </div>
     </div>
     <div class="config">
       <label>
 	Permission flags
       </label>
+      <div class="response">
+        <input type="checkbox" name="write_permission" id="write_permission" onChange="updateWriteDomain();">
+        Write permission
+	<span class="warning">This permission should go with domain write permission.</span>
+      </div>
       <div class="response">
         <input type="checkbox" name="read_permission" id="read_permission"
                {{target_key.read_permission|yesno:"checked,"}}>

--- a/app/resources/admin_api_key_form.html.template
+++ b/app/resources/admin_api_key_form.html.template
@@ -17,7 +17,7 @@
   function update_write_domain() {
     var write_field = $('write_permission');
     $('domain_write_permission').disabled = !write_field.checked;
-    if(!write_field.checked) {
+    if (!write_field.checked) {
       $('domain_write_permission').value = "";
     }
   }

--- a/app/resources/admin_api_key_form.html.template
+++ b/app/resources/admin_api_key_form.html.template
@@ -103,7 +103,7 @@
       <div class="response">
         <input type="checkbox" name="write_permission" id="write_permission" onChange="update_write_domain();">
         Write permission
-	<span class="warning">This permission should go with the domain name above.</span>
+        <span class="warning">This permission should go with the domain name above.</span>
       </div>
       <div class="response">
         <input type="checkbox" name="read_permission" id="read_permission"


### PR DESCRIPTION
Added an explicit **Write Permission** checkbox to work-along with **Domain write permission**.

Following are the highlights of this new feature.

*  **By default, *domain write permission*  field will be disabled and this will be toggled with *Write Permission* checkbox**

   * **Default position**
![image](https://cloud.githubusercontent.com/assets/7476271/9425322/f5d6cbf4-4929-11e5-93e2-e5b484ebf32d.png)

   * **Upon toggling the *Write permission* checkbox**
   ![image](https://cloud.githubusercontent.com/assets/7476271/9425330/1f29680e-492a-11e5-8892-312db190338c.png)

   ![image](https://cloud.githubusercontent.com/assets/7476271/9425337/37034b2a-492a-11e5-89e7-174da57c8e10.png)

*  **If *Write permission* checkbox is *checked* & no input is given for *Write domain text field*, the field will be highlighted with *red* color and *error* will be *alerted*.**

    *  ![image](https://cloud.githubusercontent.com/assets/7476271/9425370/96afd358-492b-11e5-9a3d-97162256767a.png)

   *  ![image](https://cloud.githubusercontent.com/assets/7476271/9425377/bf6c5942-492b-11e5-9442-aaf4628bf7df.png)

*  **If *Write permission* is checked & *domain write value* is provided, the normal work flow goes-on.**

   *  ![image](https://cloud.githubusercontent.com/assets/7476271/9425384/17c5b458-492c-11e5-83c3-05ea2e5fc241.png)

Please review the changelist & approve this merge request if deemed fit.

