### PR TITLE
A fix for https://github.com/google/personfinder/issues/142

### DIFF
--- a/app/model.py
+++ b/app/model.py
@@ -581,7 +581,7 @@ class Note(Base):
     author_made_contact = db.BooleanProperty()
     email_of_found_person = db.StringProperty(default='')
     phone_of_found_person = db.StringProperty(default='')
-    last_known_location = db.StringProperty(default='')
+    last_known_location = db.StringProperty(default='', multiline=True)
     text = db.TextProperty(default='')
     photo_url = db.TextProperty(default='')
 


### PR DESCRIPTION
This change allows multiline text in the last known location.
I am not sure how this could affect existing records. If this isn't good,
please let me know. I will try to escape line separaters instead.