### PR TITLE
Highlight newly shown duplicate notes.

### DIFF
--- a/app/resources/css-default.template
+++ b/app/resources/css-default.template
@@ -447,6 +447,10 @@ img.icon {
   color: #888;
 }
 
+.view.note.duplicate {
+  background: #fe8;
+}
+
 .note .author {
   font-weight: bold;
   color: #000;

--- a/app/resources/css-default.template
+++ b/app/resources/css-default.template
@@ -447,7 +447,7 @@ img.icon {
   color: #888;
 }
 
-.view.note.duplicate {
+.self-notes .view.note.duplicate {
   background: #fe8;
 }
 

--- a/app/resources/note.html.template
+++ b/app/resources/note.html.template
@@ -12,7 +12,7 @@
 
 {% load i18n %}
 
-<div class="view note">
+<div class="view note{% if params.dupe_notes and note.linked_person_record_id %} duplicate{% endif %}">
 
 <div class="source">
   {% trans "Posted by" %}

--- a/app/resources/note.html.template
+++ b/app/resources/note.html.template
@@ -12,7 +12,7 @@
 
 {% load i18n %}
 
-<div class="view note{% if params.dupe_notes and note.linked_person_record_id %} duplicate{% endif %}">
+<div class="view note{% if note.linked_person_record_id %} duplicate{% endif %}">
 
 <div class="source">
   {% trans "Posted by" %}


### PR DESCRIPTION
Highlights notes revealed by the "Show who marked these duplicates" link with a yellow background, to make them more visible.

![duplicate](https://cloud.githubusercontent.com/assets/193629/9516686/3f77d1ae-4ce5-11e5-9944-747d51a0dd79.png)

Fixes #80.