### PR TITLE
Pushing the changes containing bugfix for issue #128

### DIFF
--- a/app/resources/add_note.html.template
+++ b/app/resources/add_note.html.template
@@ -17,6 +17,10 @@
   <input type="hidden" name="id" value="{{params.id}}">
 {% endif %}
 
+{% if markdup %}
+  <div class="column middle">
+{% endif %}
+
 <div class="fields-table note" role="complementary">
   <h2>
     {% if not markdup %}
@@ -286,3 +290,7 @@
     {% include "errors.html.template" %}
   </div>
 </div>
+
+{% if markdup %}
+  </div>
+{% endif %}


### PR DESCRIPTION
**Root Cause:**

The `add_note.html.template` is used for *2-in-1* purpose. It is used for showing the notes page in the create_person view & also for showing the form in the duplicate entry page.

By default, the form in  `add_note.html.template` does not have any div alignment or div class. In case of create_person results view, the notes page is tagged with `<div class="column end">`, where as the actual person information is tagged with `<div class="column start">`. However in case of duplicate records view, the  `add_note.html.template`  does not form under any *parent <div>*. Hence you are getting the *weird*  look and feel .

Since the  `add_note.html.template` has been used for both create_person and duplicate record, the fix has to be done carefully, so that it does not affect the create_person results view.

**Fix:**

The fix is to add a `<div class>` especially for duplicate records view, so that the view is rendered correctly

**Unit Testing:**

Duplicate record view, after fixing the bug.
![image](https://cloud.githubusercontent.com/assets/7476271/9692248/653e28c6-5365-11e5-8881-0d27f0d0bc43.png)

Create person results view, after fixing the bug.
![image](https://cloud.githubusercontent.com/assets/7476271/9692278/9b94a6a2-5365-11e5-9028-1372b1a35041.png)
