### PR TITLE
Fix an issue that /reveal can still redirect users to other domains.

### DIFF
--- a/app/reveal.py
+++ b/app/reveal.py
@@ -110,7 +110,7 @@ class Handler(BaseHandler):
             # These two are required to allow only URLs in our domain as the
             # target, avoiding this to be used as a redirector to aid phishing
             # attacks.
-            if not self.params.target or self.params.target[0] != '/':
+            if not self.params.target.startswith('/'):
                 return self.error(400, 'Invalid target parameter')
             scheme, netloc, _, _, _ = urlparse.urlsplit(self.request.url)
             target = '%s://%s%s' % (scheme, netloc, self.params.target)


### PR DESCRIPTION
I tried to fix it in #57 but it was incomplete. It's still possible to specify target=.malicious.com to redirect users to google.org.malicious.com.