### PR TITLE
Fix a bug that repository admin page rendering is broken if one of the config contains "</script>". #214

### DIFF
--- a/app/resources/admin.html.template
+++ b/app/resources/admin.html.template
@@ -42,7 +42,11 @@
 
 //TODO: move to object-oriented!!
 
-  var LANGUAGE_EXONYMS = {{language_exonyms_json|safe}};
+  var LANGUAGES = JSON.parse(
+      "{{view_config_json.language_menu_options|default:'[]'|escapejs}}");
+  var LANGUAGE_EXONYMS = JSON.parse("{{language_exonyms_json|escapejs}}");
+  var ALL_VIEW_CONFIG =
+      JSON.parse("{{all_view_config_json|default:'[]'|escapejs}}");
   var MULTILINGUAL_TABLE_IDS = [
     'start_page_custom_htmls', 
     'results_page_custom_htmls', 
@@ -257,10 +261,8 @@
   // Adds rows to the languages table for each language already in the database
   function add_initial_languages() {
     // Saved languages and titles for this repository
-    var all_view_config = {{all_view_config_json|safe|default:'[]'}};
-    var LANGUAGES = {{view_config_json.language_menu_options|safe|default:'[]'}};
     //foreach language, add that language, its title and optional custom messages
-    var repo_title_values = all_view_config['repo_titles']
+    var repo_title_values = ALL_VIEW_CONFIG['repo_titles']
     for (var lang_num = 0; lang_num < LANGUAGES.length; lang_num++) {
       var row_number = add_language_to_repo_titles_table();
       var language = LANGUAGES[lang_num];
@@ -273,7 +275,7 @@
 
     for (var id_num = 0; id_num < MULTILINGUAL_TABLE_IDS.length; id_num++) {
       var table_id = MULTILINGUAL_TABLE_IDS[id_num];
-      var table_values = all_view_config[table_id];
+      var table_values = ALL_VIEW_CONFIG[table_id];
       for (var lang_num = 0; lang_num < LANGUAGES.length; lang_num++) {
         var language = LANGUAGES[lang_num];
         var row_number = 

--- a/app/resources/admin.html.template
+++ b/app/resources/admin.html.template
@@ -41,7 +41,12 @@
 <script>
 
 //TODO: move to object-oriented!!
+//TODO: Put all JSON data into a single JSON e.g., var JSON_DATA.
 
+  {# NOTE: Directly embedding JSON like this can cause an XSS vulnerability: #}
+  {#     var ALL_VIEW_CONFIG = {{all_view_config_json|safe|default:'[]'}}; #}
+  {#   If the JSON contains "<\/script>", it is interpreted as the end of #}
+  {#   the script tag. "escapejs" filter escapes the tag. #}
   var LANGUAGES = JSON.parse(
       "{{view_config_json.language_menu_options|default:'[]'|escapejs}}");
   var LANGUAGE_EXONYMS = JSON.parse("{{language_exonyms_json|escapejs}}");


### PR DESCRIPTION
We need to escape ```"</script>"``` to avoid terminating ```<script>``` tag unintentionally.
"escapejs" filter escapes it to "\u003C/script\u003E\u0022".

Also moved the constants outside the function to avoid parsing it for every function call.