### PR TITLE
Stop bolding the link texts in the home page ("I'm looking for someone" etc.).

### DIFF
--- a/app/resources/css-default.template
+++ b/app/resources/css-default.template
@@ -455,10 +455,6 @@ td.submit {
   text-align: center;
 }
 
-.main .action-outer a {
-  font-weight: bold;
-}
-
 .custom-message {
   width: 500px;
   margin: 1em 0;


### PR DESCRIPTION
@nmakida suggested this because it looks more readable for languages with complicated characters e.g., CJK, Hindi.