### PR TITLE
Remove fuzzy entries in English django.po.

### DIFF
--- a/app/locale/en/LC_MESSAGES/django.po
+++ b/app/locale/en/LC_MESSAGES/django.po
@@ -387,15 +387,11 @@ msgstr ""
 msgid "Age"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "All data entered in Person Finder is available to the public and usable "
 "by anyone. Google does not review or verify the accuracy of this data "
 "google.org/personfinder/global/tos"
 msgstr ""
-"PLEASE NOTE: All data entered will be available to the public and "
-"viewable and usable by anyone.  Google does not review or verify the "
-"accuracy of this data."
 
 msgid "Alternate family names"
 msgstr ""
@@ -846,14 +842,10 @@ msgstr ""
 msgid "Other website"
 msgstr ""
 
-#, fuzzy
 msgid ""
 "PLEASE NOTE: All data entered is available to the public and usable by "
 "anyone.  Google does not review or verify the accuracy of this data."
 msgstr ""
-"PLEASE NOTE: All data entered will be available to the public and "
-"viewable and usable by anyone.  Google does not review or verify the "
-"accuracy of this data."
 
 msgid "Person Finder"
 msgstr ""


### PR DESCRIPTION
I'm not really sure why these were produced, but reading this one:
https://www.gnu.org/software/gettext/manual/html_node/Fuzzy-Entries.html
These may be produced when the tool considers that the message is similar to the old message and may reuse the old translation.