### PR TITLE
edit tests/unit_tests.py to fix error for new pytest version(2.9.2)

### DIFF
--- a/app/locale/en/LC_MESSAGES/django.po
+++ b/app/locale/en/LC_MESSAGES/django.po
@@ -19,7 +19,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.2.0\n"
+"Generated-By: Babel None\n"
 
 msgid ""
 "\n"

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -40,8 +40,8 @@ os.chdir(os.environ['APP_DIR'])
 # So, when no arguments are given, we make the option parser return TESTS_DIR.
 import _pytest.config
 original_parse_setoption = _pytest.config.Parser.parse_setoption
-_pytest.config.Parser.parse_setoption = \
-    lambda *args, **kwargs: original_parse_setoption(*args, **kwargs) or [os.environ['TESTS_DIR']]
+_pytest.config.Parser.parse_setoption = (lambda *args, **kwargs: 
+    original_parse_setoption(*args, **kwargs) or [os.environ['TESTS_DIR']])
 
 # Run the tests, using sys.exit to set exit status (nonzero for failure).
 sys.exit(pytest.main())

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -41,7 +41,7 @@ os.chdir(os.environ['APP_DIR'])
 import _pytest.config
 original_parse_setoption = _pytest.config.Parser.parse_setoption
 _pytest.config.Parser.parse_setoption = \
-    lambda *args: original_parse_setoption(*args) or [os.environ['TESTS_DIR']]
+    lambda *args, **kwargs: original_parse_setoption(*args, **kwargs) or [os.environ['TESTS_DIR']]
 
 # Run the tests, using sys.exit to set exit status (nonzero for failure).
 sys.exit(pytest.main())


### PR DESCRIPTION
Update py.test version from 2.6.4 to 2.9.2 and appear the following error:
```
TypeError: <lambda>() got an unexpected keyword argument 'namespace'
```
This error is fixed by edited the code in tests/unit_tests.py:
Change the line 44 from
```
 lambda *args: original_parse_setoption(*args) or [os.environ['TESTS_DIR']]
```
to
```
lambda *args, **kwargs: original_parse_setoption(*args, **kwargs) or [os.environ['TESTS_DIR']]
```

