### PR TITLE
Automatically cd to the root directory on tests.

### DIFF
--- a/tools/server_tests
+++ b/tools/server_tests
@@ -12,6 +12,10 @@
 
 pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 
+# Some tests assumes that the current directory is the root of the working
+# directory.
+cd "$(dirname $0)/.."
+
 echo
 echo "--- Updating translations"
 $TOOLS_DIR/update_messages

--- a/tools/unit_tests
+++ b/tools/unit_tests
@@ -10,6 +10,10 @@
 
 pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 
+# Some tests assumes that the current directory is the root of the working
+# directory.
+cd "$(dirname $0)/.."
+
 echo
 echo "--- Running unit tests"
 TZ=UTC $PYTHON $TESTS_DIR/unit_tests.py --pyargs --tb=short "$@"


### PR DESCRIPTION
Because some tests assumes the current directory is the root directory.