### PR TITLE
Hide some part of the form if the person is inputing his/her own info…

### DIFF
--- a/app/create.py
+++ b/app/create.py
@@ -58,8 +58,13 @@ class Handler(BaseHandler):
         else:
             if not self.params.given_name:
                 return self.error(400, _('Name is required.  Please go back and try again.'))
-        
-        if not self.params.own_info:
+
+        if self.params.own_info == 'yes':
+            self.params.author_name = self.params.given_name
+            self.params.status = 'is_note_author' 
+            self.params.author_made_contact = 'yes'
+
+        else:
             if not self.params.author_name:
                 if self.params.clone:
                     return self.error(400, _('The Original author\'s name is required.  Please go back and try again.'))

--- a/app/create.py
+++ b/app/create.py
@@ -58,11 +58,13 @@ class Handler(BaseHandler):
         else:
             if not self.params.given_name:
                 return self.error(400, _('Name is required.  Please go back and try again.'))
-        if not self.params.author_name:
-            if self.params.clone:
-                return self.error(400, _('The Original author\'s name is required.  Please go back and try again.'))
-            else:
-                return self.error(400, _('Your name is required in the "Source" section.  Please go back and try again.'))
+        
+        if not self.params.own_info:
+            if not self.params.author_name:
+                if self.params.clone:
+                    return self.error(400, _('The Original author\'s name is required.  Please go back and try again.'))
+                else:
+                    return self.error(400, _('Your name is required in the "Source" section.  Please go back and try again.'))
 
         if self.params.add_note:
             if not self.params.text:

--- a/app/locale/af/LC_MESSAGES/django.po
+++ b/app/locale/af/LC_MESSAGES/django.po
@@ -538,9 +538,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -557,9 +554,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -862,6 +856,9 @@ msgstr "Ek is op soek na inligting"
 msgid "I am this person"
 msgstr "Ek is hierdie persoon"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Ek wil nie enige verdere opdaterings oor hierdie rekord hê nie."
 
@@ -888,6 +885,9 @@ msgstr "Ek het strooipos gekry."
 
 msgid "I prefer not to specify."
 msgstr "Ek verkies om nie te spesifiseer nie."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Ek is op soek na iemand"
@@ -1195,6 +1195,9 @@ msgstr "Rede waarom dit uitgevee word:"
 
 msgid "Reason for disabling notes:"
 msgstr "Rede waarom notas gedeaktiveer word:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1508,6 +1511,9 @@ msgstr "Wanneer moet hierdie rekord verdwyn?"
 
 msgid "Where did this information come from?"
 msgstr "Waar kom hierdie inligting vandaan?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/am/LC_MESSAGES/django.po
+++ b/app/locale/am/LC_MESSAGES/django.po
@@ -530,9 +530,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -549,9 +546,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -845,6 +839,9 @@ msgstr "መረጃ እየፈለግሁ ነኝ"
 msgid "I am this person"
 msgstr "ይህ ሰው ነኝ"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "በዚህ መዝገብ ላይ ተጨማሪ ዝማኔዎችን አልፈልግም።"
 
@@ -871,6 +868,9 @@ msgstr "አይፈለጌ መልዕክት መጥቶብኛል።"
 
 msgid "I prefer not to specify."
 msgstr "ባልገልጽ እመርጣለሁ።"
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "የሆነ ሰው እየፈለግኩኝ ነኝ"
@@ -1168,6 +1168,9 @@ msgstr "የስረዛ ምክንያት፦"
 
 msgid "Reason for disabling notes:"
 msgstr "ማስታወሻዎች የሚሰናከሉበት ምክንያት፦"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1477,6 +1480,9 @@ msgstr "መቼ ነው ይህ መዝገብ መጥፋት ያለበት?"
 
 msgid "Where did this information come from?"
 msgstr "ይህ መረጃ ከዬት ነው የመጣው?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/ar/LC_MESSAGES/django.po
+++ b/app/locale/ar/LC_MESSAGES/django.po
@@ -537,9 +537,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -556,9 +553,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -857,6 +851,9 @@ msgstr "أسعى للحصول على معلومات"
 msgid "I am this person"
 msgstr "أنا هذا الشخص"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "لا أريد المزيد من التحديثات عن هذا السجل."
 
@@ -883,6 +880,9 @@ msgstr "لقد تلقيت رسالة غير مرغوب فيها."
 
 msgid "I prefer not to specify."
 msgstr "أفضل عدم التحديد."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "أبحث عن شخص ما"
@@ -1184,6 +1184,9 @@ msgstr "أسباب الحذف:"
 
 msgid "Reason for disabling notes:"
 msgstr "سبب تعطيل الملاحظات:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1495,6 +1498,9 @@ msgstr "متى يُفترض أن يختفي هذا السجل؟"
 
 msgid "Where did this information come from?"
 msgstr "ما مصدر هذه المعلومات؟"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/az/LC_MESSAGES/django.po
+++ b/app/locale/az/LC_MESSAGES/django.po
@@ -545,9 +545,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -564,9 +561,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -869,6 +863,9 @@ msgstr "Məlumat axtarıram"
 msgid "I am this person"
 msgstr "Bu şəxs mənəm"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Mən bu qeydlə əlaqəli daha heç bir yenilənmə istəmirəm."
 
@@ -895,6 +892,9 @@ msgstr "Mənə spam gəlib"
 
 msgid "I prefer not to specify."
 msgstr "Mən dəqiqləşdirməməyi tərcih edirəm."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Bir nəfəri axtarıram"
@@ -1206,6 +1206,9 @@ msgstr "Silinmə səbəbi:"
 
 msgid "Reason for disabling notes:"
 msgstr "Notların deaktivləşmə səbəbi:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1522,6 +1525,9 @@ msgstr "Bu qeyd nə vaxt silinsin?"
 
 msgid "Where did this information come from?"
 msgstr "Bu məlumat haradan gəlib?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/bg/LC_MESSAGES/django.po
+++ b/app/locale/bg/LC_MESSAGES/django.po
@@ -543,9 +543,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -562,9 +559,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -869,6 +863,9 @@ msgstr "Търся информация"
 msgid "I am this person"
 msgstr "Аз съм този човек"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Не искам повече актуализации за този запис."
 
@@ -895,6 +892,9 @@ msgstr "Получавам спам."
 
 msgid "I prefer not to specify."
 msgstr "Предпочитам да не уточнявам."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Търся някого"
@@ -1206,6 +1206,9 @@ msgstr "Причина за изтриването:"
 
 msgid "Reason for disabling notes:"
 msgstr "Причина за деактивиране на бележките:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1526,6 +1529,9 @@ msgstr "Кога трябва да изчезне този запис?"
 
 msgid "Where did this information come from?"
 msgstr "Откъде идва тази информация?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/bn/LC_MESSAGES/django.po
+++ b/app/locale/bn/LC_MESSAGES/django.po
@@ -547,9 +547,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -566,9 +563,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -873,6 +867,9 @@ msgstr "আমি তথ্য খুজঁছি"
 msgid "I am this person"
 msgstr "আমি এই ব্যক্তি"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "আমি এই রেকর্ডে আর কোনো আপডেট চাই না৷"
 
@@ -899,6 +896,9 @@ msgstr "আমি স্প্যাম পেয়েছি৷"
 
 msgid "I prefer not to specify."
 msgstr "নির্দিষ্ট না করতে আমি পছন্দ করি৷"
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "আমি কাউকে খুঁজছি"
@@ -1210,6 +1210,9 @@ msgstr "মুছে ফেলার কারণ:"
 
 msgid "Reason for disabling notes:"
 msgstr "নোটগুলি অক্ষম করার কারণ:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1529,6 +1532,9 @@ msgstr "কখন এই রেকর্ডটির অদৃশ্য হও�
 
 msgid "Where did this information come from?"
 msgstr "এই তথ্য কোথায় থেকে এসেছে?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/ca/LC_MESSAGES/django.po
+++ b/app/locale/ca/LC_MESSAGES/django.po
@@ -545,9 +545,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -564,9 +561,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -879,6 +873,9 @@ msgstr "Cerco informació"
 msgid "I am this person"
 msgstr "Sóc aquesta persona"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "No vull rebre cap novetat més sobre aquest registre."
 
@@ -905,6 +902,9 @@ msgstr "He rebut contingut brossa."
 
 msgid "I prefer not to specify."
 msgstr "Prefereixo no especificar-ho."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Cerco algú"
@@ -1216,6 +1216,9 @@ msgstr "Motiu de la supressió:"
 
 msgid "Reason for disabling notes:"
 msgstr "Motiu per a la desactivació de les notes:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1537,6 +1540,9 @@ msgstr "Quan ha de desaparèixer aquest registre?"
 
 msgid "Where did this information come from?"
 msgstr "D'on prové aquesta informació?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/cs/LC_MESSAGES/django.po
+++ b/app/locale/cs/LC_MESSAGES/django.po
@@ -533,9 +533,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -552,9 +549,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -859,6 +853,9 @@ msgstr "Hledám informace"
 msgid "I am this person"
 msgstr "Jsem tato osoba"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Nechci žádné další aktualizace o tomto záznamu."
 
@@ -885,6 +882,9 @@ msgstr "Obdržel(a) jsem spam."
 
 msgid "I prefer not to specify."
 msgstr "Tyto informace nechci uvést."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Někoho hledám"
@@ -1196,6 +1196,9 @@ msgstr "Důvod vymazání:"
 
 msgid "Reason for disabling notes:"
 msgstr "Důvod zakázání poznámek:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1512,6 +1515,9 @@ msgstr "Kdy by měl tento záznam zmizet?"
 
 msgid "Where did this information come from?"
 msgstr "Odkud pocházejí tyto informace?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/da/LC_MESSAGES/django.po
+++ b/app/locale/da/LC_MESSAGES/django.po
@@ -546,9 +546,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -565,9 +562,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -873,6 +867,9 @@ msgstr "Jeg søger oplysninger"
 msgid "I am this person"
 msgstr "Jeg er denne person"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Jeg vil ikke have flere opdateringer om denne journal."
 
@@ -899,6 +896,9 @@ msgstr "Jeg har modtaget spam."
 
 msgid "I prefer not to specify."
 msgstr "Jeg vil ikke præcisere."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Jeg søger efter en person"
@@ -1210,6 +1210,9 @@ msgstr "Årsag til sletning:"
 
 msgid "Reason for disabling notes:"
 msgstr "Årsag til deaktivering af noter:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1529,6 +1532,9 @@ msgstr "Hvornår bør denne journal forsvinde?"
 
 msgid "Where did this information come from?"
 msgstr "Hvor stammer disse oplysninger fra?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/de/LC_MESSAGES/django.po
+++ b/app/locale/de/LC_MESSAGES/django.po
@@ -544,9 +544,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -563,9 +560,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -876,6 +870,9 @@ msgstr "Ich suche nach Informationen."
 msgid "I am this person"
 msgstr "Ich bin diese Person."
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Ich möchte keine weiteren Updates zu diesem Datensatz erhalten."
 
@@ -902,6 +899,9 @@ msgstr "Ich habe Spam erhalten."
 
 msgid "I prefer not to specify."
 msgstr "Ich möchte keine näheren Angaben machen."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Ich suche jemanden."
@@ -1224,6 +1224,9 @@ msgstr "Grund für die Löschung:"
 
 msgid "Reason for disabling notes:"
 msgstr "Grund für die Deaktivierung von Notizen:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1551,6 +1554,9 @@ msgstr "Wann soll dieser Datensatz nicht mehr angezeigt werden?"
 
 msgid "Where did this information come from?"
 msgstr "Woher stammen diese Informationen?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/el/LC_MESSAGES/django.po
+++ b/app/locale/el/LC_MESSAGES/django.po
@@ -572,9 +572,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -591,9 +588,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -905,6 +899,9 @@ msgstr "Αναζητώ πληροφορίες"
 msgid "I am this person"
 msgstr "Εγώ είμαι αυτός/ή"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Δεν θέλω επιπλέον ενημερώσεις σε αυτήν την εγγραφή."
 
@@ -931,6 +928,9 @@ msgstr "Έλαβα ανεπιθύμητα μηνύματα."
 
 msgid "I prefer not to specify."
 msgstr "Προτιμώ να μην το προσδιορίσω."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Ψάχνω κάποιον"
@@ -1254,6 +1254,9 @@ msgstr "Αιτία διαγραφής:"
 
 msgid "Reason for disabling notes:"
 msgstr "Λόγος για την απενεργοποίηση σημειώσεων:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1582,6 +1585,9 @@ msgstr "Πότε θα εξαφανιστεί αυτή η εγγραφή;"
 
 msgid "Where did this information come from?"
 msgstr "Από πού προέρχονται αυτές οι πληροφορίες;"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/en/LC_MESSAGES/django.po
+++ b/app/locale/en/LC_MESSAGES/django.po
@@ -658,6 +658,9 @@ msgstr ""
 msgid "I am this person"
 msgstr ""
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr ""
 
@@ -683,6 +686,9 @@ msgid "I have received spam."
 msgstr ""
 
 msgid "I prefer not to specify."
+msgstr ""
+
+msgid "I want to input information about this person."
 msgstr ""
 
 msgid "I'm looking for someone"
@@ -962,6 +968,9 @@ msgid "Reason for deletion:"
 msgstr ""
 
 msgid "Reason for disabling notes:"
+msgstr ""
+
+msgid "Record information"
 msgstr ""
 
 #, python-format
@@ -1263,6 +1272,9 @@ msgid "When should this record disappear?"
 msgstr ""
 
 msgid "Where did this information come from?"
+msgstr ""
+
+msgid "Where did this record come from?"
 msgstr ""
 
 msgid ""

--- a/app/locale/en_GB/LC_MESSAGES/django.po
+++ b/app/locale/en_GB/LC_MESSAGES/django.po
@@ -547,9 +547,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -566,9 +563,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -865,6 +859,9 @@ msgstr "I am seeking information"
 msgid "I am this person"
 msgstr "I am this person"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "I do not want any more updates on this record."
 
@@ -891,6 +888,9 @@ msgstr "I have received spam."
 
 msgid "I prefer not to specify."
 msgstr "I prefer not to specify."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "I'm looking for someone"
@@ -1194,6 +1194,9 @@ msgstr "Reason for deletion:"
 
 msgid "Reason for disabling notes:"
 msgstr "Reason for disabling notes:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1509,6 +1512,9 @@ msgstr "When should this record disappear?"
 
 msgid "Where did this information come from?"
 msgstr "Where did this information come from?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/es/LC_MESSAGES/django.po
+++ b/app/locale/es/LC_MESSAGES/django.po
@@ -561,9 +561,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -580,9 +577,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -892,6 +886,9 @@ msgstr "Estoy buscando información"
 msgid "I am this person"
 msgstr "Yo soy esta persona"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "No deseo recibir más novedades sobre este registro."
 
@@ -918,6 +915,9 @@ msgstr "He recibido spam."
 
 msgid "I prefer not to specify."
 msgstr "Prefiero no proporcionar información específica."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Estoy buscando a alguien"
@@ -1243,6 +1243,9 @@ msgstr "Motivo de la eliminación:"
 
 msgid "Reason for disabling notes:"
 msgstr "Motivo para inhabilitar la publicación de notas:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1571,6 +1574,9 @@ msgstr "¿Cuándo debería desaparecer este registro?"
 
 msgid "Where did this information come from?"
 msgstr "¿De dónde procede esta información?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/es_419/LC_MESSAGES/django.po
+++ b/app/locale/es_419/LC_MESSAGES/django.po
@@ -541,9 +541,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -560,9 +557,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -871,6 +865,9 @@ msgstr "Estoy buscando información."
 msgid "I am this person"
 msgstr "Soy esta persona."
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Quiero dejar de recibir actualizaciones de este registro."
 
@@ -897,6 +894,9 @@ msgstr "Recibí spam."
 
 msgid "I prefer not to specify."
 msgstr "Prefiero no especificar."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Estoy buscando a alguien."
@@ -1216,6 +1216,9 @@ msgstr "Motivo de la eliminación:"
 
 msgid "Reason for disabling notes:"
 msgstr "Motivo de la inhabilitación de las notas:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1537,6 +1540,9 @@ msgstr "¿Cuándo debería desaparecer este registro?"
 
 msgid "Where did this information come from?"
 msgstr "¿De dónde proviene esta información?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/et/LC_MESSAGES/django.po
+++ b/app/locale/et/LC_MESSAGES/django.po
@@ -537,9 +537,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -556,9 +553,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -863,6 +857,9 @@ msgstr "Otsin teavet"
 msgid "I am this person"
 msgstr "Mina olen see isik"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Ma ei soovi saada rohkem selle kirje värskendusi."
 
@@ -889,6 +886,9 @@ msgstr "Olen saanud rämpsposti."
 
 msgid "I prefer not to specify."
 msgstr "Ma ei soovi täpsustada."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Otsin kedagi"
@@ -1198,6 +1198,9 @@ msgstr "Kustutamise põhjus:"
 
 msgid "Reason for disabling notes:"
 msgstr "Märkmete keelamise põhjus:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1512,6 +1515,9 @@ msgstr "Millal peaks see kirje kaduma?"
 
 msgid "Where did this information come from?"
 msgstr "Kust see info tuli?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/eu/LC_MESSAGES/django.po
+++ b/app/locale/eu/LC_MESSAGES/django.po
@@ -544,9 +544,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -563,9 +560,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -870,6 +864,9 @@ msgstr "Informazio bila nabil"
 msgid "I am this person"
 msgstr "Pertsona hori naiz"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Ez dut erregistro honen eguneratze gehiagorik jaso nahi."
 
@@ -896,6 +893,9 @@ msgstr "Spama jaso dut."
 
 msgid "I prefer not to specify."
 msgstr "Nahiago dut ez zehaztu."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Norbaiten bila nabil"
@@ -1207,6 +1207,9 @@ msgstr "Ezabatzearen arrazoia:"
 
 msgid "Reason for disabling notes:"
 msgstr "Oharrak desgaitzearen arrazoia:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1521,6 +1524,9 @@ msgstr "Noiz desagertu beharko luke erregistro horrek?"
 
 msgid "Where did this information come from?"
 msgstr "Nondik jaso da informazioa?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/fa/LC_MESSAGES/django.po
+++ b/app/locale/fa/LC_MESSAGES/django.po
@@ -522,9 +522,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -541,9 +538,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -844,6 +838,9 @@ msgstr "به دنبال کسب اطلاعات هستم"
 msgid "I am this person"
 msgstr "من همین شخص هستم"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "نمی‌خواهم به‌روزرسانی‌های دیگری برای این سابقه داشته باشم."
 
@@ -870,6 +867,9 @@ msgstr "هرزنامه دریافت کرده‌ام."
 
 msgid "I prefer not to specify."
 msgstr "ترجیح می‌دهم مشخص نکنم."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "من به دنبال شخصی هستم"
@@ -1181,6 +1181,9 @@ msgstr "دلیل حذف:"
 
 msgid "Reason for disabling notes:"
 msgstr "دلیل غیرفعال کردن یادداشت‌ها:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1498,6 +1501,9 @@ msgstr "این سابقه چه زمانی دیگر نشان داده نشود؟"
 
 msgid "Where did this information come from?"
 msgstr "این اطلاعات از کجا آمده است؟"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/fi/LC_MESSAGES/django.po
+++ b/app/locale/fi/LC_MESSAGES/django.po
@@ -548,9 +548,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -567,9 +564,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -872,6 +866,9 @@ msgstr "Etsin tietoja"
 msgid "I am this person"
 msgstr "Olen kyseinen henkilö"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "En halua enää saada näitä tietoja koskevia päivityksiä."
 
@@ -898,6 +895,9 @@ msgstr "Olen saanut roskapostia."
 
 msgid "I prefer not to specify."
 msgstr "En halua kertoa."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Etsin jotakuta henkilöä"
@@ -1211,6 +1211,9 @@ msgstr "Poiston syy:"
 
 msgid "Reason for disabling notes:"
 msgstr "Syy muistiinpanojen käytöstä poistamiseen:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1527,6 +1530,9 @@ msgstr "Milloin nämä tiedot tulee poistaa näkyvistä?"
 
 msgid "Where did this information come from?"
 msgstr "Mistä nämä tiedot ovat peräisin?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/fil/LC_MESSAGES/django.po
+++ b/app/locale/fil/LC_MESSAGES/django.po
@@ -543,9 +543,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -562,9 +559,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -876,6 +870,9 @@ msgstr "Naghahanap ako ng impormasyon"
 msgid "I am this person"
 msgstr "Ako ang taong ito"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr ""
 "Hindi ko gustong makatanggap ng higit pang mga update tungkol sa talaang "
@@ -904,6 +901,9 @@ msgstr "Nakatanggap ako ng spam."
 
 msgid "I prefer not to specify."
 msgstr "Mas gusto kong huwag tukuyin."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "May hinahanap akong isang tao"
@@ -1219,6 +1219,9 @@ msgstr "Dahilan ng pagtatanggal:"
 
 msgid "Reason for disabling notes:"
 msgstr "Dahilan para sa pag-disable sa mga tala:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1543,6 +1546,9 @@ msgstr "Kailan dapat mawala ang talaang ito?"
 
 msgid "Where did this information come from?"
 msgstr "Saan nagmula ang impormasyong ito?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/fr/LC_MESSAGES/django.po
+++ b/app/locale/fr/LC_MESSAGES/django.po
@@ -552,9 +552,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -571,9 +568,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -885,6 +879,9 @@ msgstr "Je recherche des informations."
 msgid "I am this person"
 msgstr "Je confirme être cette personne."
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Je ne veux pas que cet avis de recherche soit mis à jour."
 
@@ -911,6 +908,9 @@ msgstr "J'ai reçu du spam."
 
 msgid "I prefer not to specify."
 msgstr "Je préfère ne pas donner plus de précisions."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Je recherche une personne"
@@ -1234,6 +1234,9 @@ msgstr "Motif de la suppression :"
 
 msgid "Reason for disabling notes:"
 msgstr "Motif de la désactivation des commentaires :"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1571,6 +1574,9 @@ msgstr "Quand cet avis de recherche doit-il être supprimé ?"
 
 msgid "Where did this information come from?"
 msgstr "Quelle est la source de ces informations ?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/fr_CA/LC_MESSAGES/django.po
+++ b/app/locale/fr_CA/LC_MESSAGES/django.po
@@ -556,9 +556,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -575,9 +572,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -888,6 +882,9 @@ msgstr "Je cherche de l'information"
 msgid "I am this person"
 msgstr "Je suis cette personne"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Je ne veux plus que cet avis de recherche soit mis à jour."
 
@@ -914,6 +911,9 @@ msgstr "J'ai reçu du pourriel."
 
 msgid "I prefer not to specify."
 msgstr "Je préfère ne pas donner plus de précisions."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Je cherche quelqu'un"
@@ -1243,6 +1243,9 @@ msgstr "Raison de la suppression :"
 
 msgid "Reason for disabling notes:"
 msgstr "Raison pour la désactivation des commentaires :"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1574,6 +1577,9 @@ msgstr "Quand cet avis de recherche doit-il être supprimé?"
 
 msgid "Where did this information come from?"
 msgstr "D'où ces données proviennent-elles?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/gl/LC_MESSAGES/django.po
+++ b/app/locale/gl/LC_MESSAGES/django.po
@@ -556,9 +556,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -575,9 +572,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -882,6 +876,9 @@ msgstr "Busco información"
 msgid "I am this person"
 msgstr "Son esta persoa"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Non desexo máis actualizacións neste rexistro."
 
@@ -908,6 +905,9 @@ msgstr "Recibín spam."
 
 msgid "I prefer not to specify."
 msgstr "Prefiro non dar máis detalles."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Busco alguén"
@@ -1221,6 +1221,9 @@ msgstr "Motivo para a eliminación:"
 
 msgid "Reason for disabling notes:"
 msgstr "Motivo polo que queres deshabilitar as notas:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1538,6 +1541,9 @@ msgstr "Cando debe desaparecer este rexistro?"
 
 msgid "Where did this information come from?"
 msgstr "Cal é a procedencia da información?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/gu/LC_MESSAGES/django.po
+++ b/app/locale/gu/LC_MESSAGES/django.po
@@ -546,9 +546,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -565,9 +562,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -872,6 +866,9 @@ msgstr "હું માહિતી શોધું છું"
 msgid "I am this person"
 msgstr "હું આ વ્યક્તિ છું"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "મને આ રેકોર્ડ પર કોઈ વધુ અપડેટ્સ જોઈતા નથી."
 
@@ -898,6 +895,9 @@ msgstr "મને સ્પામ પ્રાપ્ત થઈ છે."
 
 msgid "I prefer not to specify."
 msgstr "હું ઉલ્લેખ ન કરવાનું પસંદ કરું છું."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "હું કોઈ વ્યક્તિને શોઘી રહ્યો/રહી છું"
@@ -1214,6 +1214,9 @@ msgstr "કાઢી નાંખવાનું માટેનું કાર
 msgid "Reason for disabling notes:"
 msgstr "નોટ્સને અક્ષમ કરવા માટેનું કારણ:"
 
+msgid "Record information"
+msgstr ""
+
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
 msgstr "\"%(query)s\" થી મેળ ખાતા નામો અને સરનામાંઓ ધરાવતા રેકોર્ડ્સ"
@@ -1528,6 +1531,9 @@ msgstr "આ રેકોર્ડ ક્યારે અદ્રશ્ય થ�
 
 msgid "Where did this information come from?"
 msgstr "આ માહિતી ક્યાંથી આવી હતી?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/he/LC_MESSAGES/django.po
+++ b/app/locale/he/LC_MESSAGES/django.po
@@ -530,9 +530,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -549,9 +546,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -845,6 +839,9 @@ msgstr "אני מחפש מידע"
 msgid "I am this person"
 msgstr "אני האדם הזה"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "אני לא מעוניין בעדכונים נוספים לרשומה הזו."
 
@@ -871,6 +868,9 @@ msgstr "קיבלתי דואר זבל."
 
 msgid "I prefer not to specify."
 msgstr "אני מעדיף שלא לציין."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "אני מחפש מישהו"
@@ -1168,6 +1168,9 @@ msgstr "הסיבה למחיקה:"
 
 msgid "Reason for disabling notes:"
 msgstr "הסיבה להשבתת ההערות:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1479,6 +1482,9 @@ msgstr "מתי הרשומה הזו אמורה להיעלם?"
 
 msgid "Where did this information come from?"
 msgstr "מאיפה המידע הזה הגיע?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/hi/LC_MESSAGES/django.po
+++ b/app/locale/hi/LC_MESSAGES/django.po
@@ -552,9 +552,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -571,9 +568,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -878,6 +872,9 @@ msgstr "मैं जानकारी ढूंढ रहा/रही हू�
 msgid "I am this person"
 msgstr "मैं यह व्यक्ति हूं"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "मैं इस रिकॉर्ड पर और अधिक अपडेट नहीं चाहता/चाहती."
 
@@ -904,6 +901,9 @@ msgstr "मुझे अनचाहा प्राप्त हुआ."
 
 msgid "I prefer not to specify."
 msgstr "मैं न बताना पसंद करूंगा/करूंगी."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "मैं किसी को ढूंढ रहा/रही हूं"
@@ -1217,6 +1217,9 @@ msgstr "हटाने का कारण:"
 
 msgid "Reason for disabling notes:"
 msgstr "नोट अक्षम करने का कारण:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1532,6 +1535,9 @@ msgstr "यह रिकॉर्ड कब गायब होना चाह�
 
 msgid "Where did this information come from?"
 msgstr "यह जानकारी कहां से मिली थी?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/hr/LC_MESSAGES/django.po
+++ b/app/locale/hr/LC_MESSAGES/django.po
@@ -541,9 +541,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -560,9 +557,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -865,6 +859,9 @@ msgstr "Tražim informacije"
 msgid "I am this person"
 msgstr "Ja sam ta osoba"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Ne želim više primati ažuriranja o tim zapisima."
 
@@ -891,6 +888,9 @@ msgstr "Primam neželjenu poštu."
 
 msgid "I prefer not to specify."
 msgstr "Ne želim navesti."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Tražim nekog"
@@ -1198,6 +1198,9 @@ msgstr "Razlog brisanja:"
 
 msgid "Reason for disabling notes:"
 msgstr "Razlog onemogućavanja bilježaka:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1512,6 +1515,9 @@ msgstr "Kad bi trebao nestati ovaj zapis?"
 
 msgid "Where did this information come from?"
 msgstr "Odakle je ta informacija?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/ht/LC_MESSAGES/django.po
+++ b/app/locale/ht/LC_MESSAGES/django.po
@@ -498,9 +498,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -517,9 +514,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -819,6 +813,9 @@ msgstr "Map chèche enfòmasyon"
 msgid "I am this person"
 msgstr "Mwen se moun sa a"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Mwen pa vle resevwa nouvèl sou dosye sa a ankò."
 
@@ -845,6 +842,9 @@ msgstr "Mwen te resevwa espam"
 
 msgid "I prefer not to specify."
 msgstr "Mwen prefere pa presize."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Mwen ap chèche yon moun"
@@ -1148,6 +1148,9 @@ msgstr "Rezon pou efase:"
 
 msgid "Reason for disabling notes:"
 msgstr "Rezon pou dezaktive nòt:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1462,6 +1465,9 @@ msgstr "Kilè dozye sa a ta dwe disparèt?"
 
 msgid "Where did this information come from?"
 msgstr "Kote enfòmasyon sa a sòti?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/hu/LC_MESSAGES/django.po
+++ b/app/locale/hu/LC_MESSAGES/django.po
@@ -550,9 +550,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -569,9 +566,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -877,6 +871,9 @@ msgstr "Információt keresek"
 msgid "I am this person"
 msgstr "Én vagyok ez a személy"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Nem kérek több frissítést ezzel a bejegyzéssel kapcsolatban."
 
@@ -903,6 +900,9 @@ msgstr "Spamet kaptam."
 
 msgid "I prefer not to specify."
 msgstr "Nem szeretném megadni."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Keresek valakit"
@@ -1218,6 +1218,9 @@ msgstr "A törlés oka:"
 
 msgid "Reason for disabling notes:"
 msgstr "A megjegyzések letiltásának oka:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1543,6 +1546,9 @@ msgstr "Meddig maradjon meg ez a bejegyzés?"
 
 msgid "Where did this information come from?"
 msgstr "Honnan származik ez az információ?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/hy/LC_MESSAGES/django.po
+++ b/app/locale/hy/LC_MESSAGES/django.po
@@ -535,9 +535,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -554,9 +551,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -857,6 +851,9 @@ msgstr "Ես տեղեկություն եմ որոնում"
 msgid "I am this person"
 msgstr "Ես եմ այդ մարդը"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Ես այլևս չեմ ցանկանում տեղեկանալ այս գրառման մասին:"
 
@@ -883,6 +880,9 @@ msgstr "Ես ստացել եմ լցոն:"
 
 msgid "I prefer not to specify."
 msgstr "Ես նախընտրում եմ չմանրամասնել:"
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Ես փնտրում եմ ինչ-որ մեկին"
@@ -1194,6 +1194,9 @@ msgstr "Հեռացման պատճառը`"
 
 msgid "Reason for disabling notes:"
 msgstr "Նշումների անջատման պատճառը`"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1508,6 +1511,9 @@ msgstr "Ե՞րբ պետք է այս գրառումը հեռացվի:"
 
 msgid "Where did this information come from?"
 msgstr "Որտեղի՞ց է ստացվել այս տեղեկությունը:"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/id/LC_MESSAGES/django.po
+++ b/app/locale/id/LC_MESSAGES/django.po
@@ -552,9 +552,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -571,9 +568,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -880,6 +874,9 @@ msgstr "Saya mencari informasi"
 msgid "I am this person"
 msgstr "Saya adalah orang ini"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Saya tidak menginginkan pembaruan lainnya untuk rekaman ini."
 
@@ -906,6 +903,9 @@ msgstr "Saya telah menerima spam."
 
 msgid "I prefer not to specify."
 msgstr "Saya tidak ingin menyebutkannya."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Saya mencari seseorang"
@@ -1211,6 +1211,9 @@ msgstr "Alasan penghapusan:"
 
 msgid "Reason for disabling notes:"
 msgstr "Alasan menonaktifkan catatan:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1524,6 +1527,9 @@ msgstr "Kapan sebaiknya rekaman ini dihilangkan?"
 
 msgid "Where did this information come from?"
 msgstr "Dari manakah informasi ini berasal?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/is/LC_MESSAGES/django.po
+++ b/app/locale/is/LC_MESSAGES/django.po
@@ -556,9 +556,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -575,9 +572,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -882,6 +876,9 @@ msgstr "Ég er að leita eftir upplýsingum"
 msgid "I am this person"
 msgstr "Ég er þessi manneskja"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Ég vil ekki fleiri fréttir af þessari færslu."
 
@@ -908,6 +905,9 @@ msgstr "Ég hef fengið ruslpóst."
 
 msgid "I prefer not to specify."
 msgstr "Ég kýs að tilgreina ekki nánar."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Ég er að leita að einhverjum"
@@ -1221,6 +1221,9 @@ msgstr "Ástæða fyrir eyðingu:"
 
 msgid "Reason for disabling notes:"
 msgstr "Ástæða fyrir því að gera athugasemdir óvirkar:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1540,6 +1543,9 @@ msgstr "Hvenær ætti þessi færsla að hverfa?"
 
 msgid "Where did this information come from?"
 msgstr "Hvaðan koma þessar upplýsingar?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/it/LC_MESSAGES/django.po
+++ b/app/locale/it/LC_MESSAGES/django.po
@@ -559,9 +559,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -578,9 +575,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -887,6 +881,9 @@ msgstr "Sto cercando informazioni"
 msgid "I am this person"
 msgstr "Sono questa persona"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Non desidero più ricevere aggiornamenti su questo record."
 
@@ -913,6 +910,9 @@ msgstr "Ho ricevuto spam."
 
 msgid "I prefer not to specify."
 msgstr "Preferisco non specificare."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Sto cercando qualcuno"
@@ -1226,6 +1226,9 @@ msgstr "Motivo dell'eliminazione:"
 
 msgid "Reason for disabling notes:"
 msgstr "Motivi della disattivazione delle note:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1543,6 +1546,9 @@ msgstr "Quando dovrebbe scomparire questo record?"
 
 msgid "Where did this information come from?"
 msgstr "Da dove provengono queste informazioni?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/ja/LC_MESSAGES/django.po
+++ b/app/locale/ja/LC_MESSAGES/django.po
@@ -529,9 +529,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -548,9 +545,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -841,6 +835,9 @@ msgstr "情報を探している"
 msgid "I am this person"
 msgstr "私が本人である"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "この記録に関する新着情報は不要"
 
@@ -867,6 +864,9 @@ msgstr "この記録が原因でスパムを受信したから"
 
 msgid "I prefer not to specify."
 msgstr "指定しない"
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "人を探している"
@@ -1148,6 +1148,9 @@ msgstr "削除する理由:"
 
 msgid "Reason for disabling notes:"
 msgstr "メモを無効にする理由:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1449,6 +1452,9 @@ msgstr "この記録をいつ削除するか指定してください。"
 
 msgid "Where did this information come from?"
 msgstr "この記録の情報源を指定してください。"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/jv/LC_MESSAGES/django.po
+++ b/app/locale/jv/LC_MESSAGES/django.po
@@ -531,9 +531,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -550,9 +547,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -859,6 +853,9 @@ msgstr "Aku lagi nggoleki informasi"
 msgid "I am this person"
 msgstr "Aku wong iki"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Aku ora gelem nganyari apa wae ing laporan iki."
 
@@ -885,6 +882,9 @@ msgstr "Aku nampa spam."
 
 msgid "I prefer not to specify."
 msgstr "Aku milih ora nulis."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Aku lagi nggoleki sawijining wong"
@@ -1194,6 +1194,9 @@ msgstr "Alesan pambusakan:"
 
 msgid "Reason for disabling notes:"
 msgstr "Alesan kanggo mateni cathetan:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1510,6 +1513,9 @@ msgstr "Kapan laporan iki bakal ilang?"
 
 msgid "Where did this information come from?"
 msgstr "Saka endi informasi iki?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/ka/LC_MESSAGES/django.po
+++ b/app/locale/ka/LC_MESSAGES/django.po
@@ -559,9 +559,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -578,9 +575,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -885,6 +879,9 @@ msgstr "მე ვეძებ ინფორმაციას"
 msgid "I am this person"
 msgstr "ეს პიროვნება მე ვარ"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "აღარ მსურს ამ ჩანაწერთან დაკავშირებული განახლებების მიღება"
 
@@ -911,6 +908,9 @@ msgstr "მივიღე სპამი."
 
 msgid "I prefer not to specify."
 msgstr "მირჩევნია, არ დავაკონკრეტო."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "ვეძებ დაკარგულ ადამიანს"
@@ -1223,6 +1223,9 @@ msgstr "წაშლის მიზეზი:"
 
 msgid "Reason for disabling notes:"
 msgstr "შენიშვნების გამორთვის მიზეზი:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1543,6 +1546,9 @@ msgstr "როდის გაქრეს ეს ჩანაწერი?"
 
 msgid "Where did this information come from?"
 msgstr "საიდან მოვიდა ეს ინფორმაცია?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/kk/LC_MESSAGES/django.po
+++ b/app/locale/kk/LC_MESSAGES/django.po
@@ -543,9 +543,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -562,9 +559,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -871,6 +865,9 @@ msgstr "Мен ақпарат іздеудемін"
 msgid "I am this person"
 msgstr "Мен сол адаммын"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Мен осыдан былай бұл дерекке қатысты жаңартуларды қаламаймын."
 
@@ -897,6 +894,9 @@ msgstr "Мен спам алдым."
 
 msgid "I prefer not to specify."
 msgstr "Мен толық ақпарат беруді қаламаймын."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Мен біреуді іздеп жүрмін"
@@ -1204,6 +1204,9 @@ msgstr "Жою себебі:"
 
 msgid "Reason for disabling notes:"
 msgstr "Жазбаларды өшіру себебі:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1522,6 +1525,9 @@ msgstr "Бұл дерек қашан жойылуы қажет?"
 
 msgid "Where did this information come from?"
 msgstr "Бұл ақпарат қайдан алынды?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/km/LC_MESSAGES/django.po
+++ b/app/locale/km/LC_MESSAGES/django.po
@@ -557,9 +557,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -576,9 +573,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -887,6 +881,9 @@ msgstr "ខ្ញុំ​កំពុង​ស្វែង​រក​ព័ត
 msgid "I am this person"
 msgstr "ខ្ញុំ​ជា​បុគ្គល​នេះ"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "ខ្ញុំ​មិន​ចង់​បាន​បច្ចុប្បន្ន​ភាព​ណា​មួយ​បន្ថែម​ទៀត​នៅ​លើ​កំណត់​ត្រា​នេះឡើយ។"
 
@@ -913,6 +910,9 @@ msgstr "ខ្ញុំ​បាន​ទទួល​សារ​ឥត​បា
 
 msgid "I prefer not to specify."
 msgstr "ខ្ញុំ​ពេញ​ចិត្ត​​មិន​បញ្ជាក់​។"
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "ខ្ញុំ​កំពុង​តែ​ស្វែង​រក​នរណា​ម្នាក់"
@@ -1227,6 +1227,9 @@ msgstr "មូលហេតុ​សម្រាប់​ការ​លុប​
 
 msgid "Reason for disabling notes:"
 msgstr "មូលហេតុ​សម្រាប់​ការ​បិទ​កំណត់​ចំណាំ​:៖"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1556,6 +1559,9 @@ msgstr "ពេល​ណា​ដែល​កំណត់​ត្រា​នេ
 
 msgid "Where did this information come from?"
 msgstr "តើ​ព័ត៌​មាន​នេះ​បាន​មក​ពី​ណា​?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/kn/LC_MESSAGES/django.po
+++ b/app/locale/kn/LC_MESSAGES/django.po
@@ -551,9 +551,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -570,9 +567,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -879,6 +873,9 @@ msgstr "ಮಾಹಿತಿಯ ಹುಡುಕಾಟದಲ್ಲಿದ್ದೇ�
 msgid "I am this person"
 msgstr "ಈ ವ್ಯಕ್ತಿ ನಾನೇ"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "ಈ ರೆಕಾರ್ಡ್‌ನಲ್ಲಿ ಯಾವುದೇ ಹೆಚ್ಚಿನ ನವೀಕರಣಗಳನ್ನು ನಾನು ಬಯಸುವುದಿಲ್ಲ."
 
@@ -905,6 +902,9 @@ msgstr "ನನಗೆ ಸ್ಪ್ಯಾಮ್ ಬಂದಿದೆ."
 
 msgid "I prefer not to specify."
 msgstr "ನಾನು ಸೂಚಿಸಲು ಆದ್ಯತೆ ವಹಿಸುವುದಿಲ್ಲ."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "ನಾನು ಒಬ್ಬರನ್ನು ಹುಡುಕುತ್ತಿದ್ದೇನೆ"
@@ -1220,6 +1220,9 @@ msgstr "ಅಳಿಸುವಿಕೆಗೆ ಕಾರಣ:"
 
 msgid "Reason for disabling notes:"
 msgstr "ಟಿಪ್ಪಣಿಗಳನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸುತ್ತಿರುವುದಕ್ಕೆ ಕಾರಣ:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1539,6 +1542,9 @@ msgstr "ಈ ರೆಕಾರ್ಡ್ ಯಾವಾಗ ಅಳಿಸಿ ಹೋಗ�
 
 msgid "Where did this information come from?"
 msgstr "ಈ ಮಾಹಿತಿ ಎಲ್ಲಿಂದ ಸಿಕ್ಕಿದೆ?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/ko/LC_MESSAGES/django.po
+++ b/app/locale/ko/LC_MESSAGES/django.po
@@ -522,9 +522,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -541,9 +538,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -836,6 +830,9 @@ msgstr "정보를 찾고 있습니다."
 msgid "I am this person"
 msgstr "내가 이 사람입니다."
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "이 신상기록에 대한 업데이트를 더 이상 받지 않겠습니다."
 
@@ -862,6 +859,9 @@ msgstr "스팸을 받았습니다."
 
 msgid "I prefer not to specify."
 msgstr "명시하고 싶지 않습니다."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "사람 찾기"
@@ -1149,6 +1149,9 @@ msgstr "삭제 사유:"
 
 msgid "Reason for disabling notes:"
 msgstr "메모 사용 중지 이유:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1452,6 +1455,9 @@ msgstr "이 신상기록의 만료일을 언제로 지정하시겠습니까?"
 
 msgid "Where did this information come from?"
 msgstr "이 신상기록의 출처에 대해 알려주세요."
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/ky/LC_MESSAGES/django.po
+++ b/app/locale/ky/LC_MESSAGES/django.po
@@ -542,9 +542,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -561,9 +558,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -862,6 +856,9 @@ msgstr "Мен маалымат издеймин"
 msgid "I am this person"
 msgstr "Мен ушул кишимин"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Мен мындан ары бул жазуунун жаңыртууларын алууну каалабайм."
 
@@ -888,6 +885,9 @@ msgstr "Мен спам алдым."
 
 msgid "I prefer not to specify."
 msgstr "Мен тактоону каалабаймын."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Мен бирөөнү издеймин"
@@ -1197,6 +1197,9 @@ msgstr "Өчүрүүнүн себеби:"
 
 msgid "Reason for disabling notes:"
 msgstr "Билдирүүлөрдү токтотуунун себеби:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1513,6 +1516,9 @@ msgstr "Бул жазуу качан жок кылынышы керек?"
 
 msgid "Where did this information come from?"
 msgstr "Бул маалымат кайдан алынды?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/lo/LC_MESSAGES/django.po
+++ b/app/locale/lo/LC_MESSAGES/django.po
@@ -538,9 +538,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -557,9 +554,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -856,6 +850,9 @@ msgstr "ຂ້ອຍກຳລັງຊອກຫາຂໍ້ມູນ"
 msgid "I am this person"
 msgstr "ຂ້ອຍແມ່ນບຸກຄົນນີ້"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "ຂ້ອຍບໍ່ຕ້ອງການຮັບການອັບເດດສຳລັບບັນທຶກນີ້ອີກຕໍ່ໄປ."
 
@@ -882,6 +879,9 @@ msgstr "ຂ້ອຍໄດ້ຮັບສະແປມ."
 
 msgid "I prefer not to specify."
 msgstr "ຂ້ອຍບໍ່ຂໍລະບຸ."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "ຂ້ອຍກຳລັງຊອກຫາບຸກຄົນນຶ່ງຢູ່"
@@ -1186,6 +1186,9 @@ msgstr "ເຫດຜົນຂອງການລຶບ:"
 
 msgid "Reason for disabling notes:"
 msgstr "ເຫດຜົນເພື່ອປິດການນຳໃຊ້ໂນ໋ດ:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1496,6 +1499,9 @@ msgstr "ທ່ານຕ້ອງການໃຫ້ບັນທຶກຂອງຂ
 
 msgid "Where did this information come from?"
 msgstr "ຂໍ້ມູນນີ້ມາຈາກໃສ?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/lt/LC_MESSAGES/django.po
+++ b/app/locale/lt/LC_MESSAGES/django.po
@@ -548,9 +548,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -567,9 +564,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -872,6 +866,9 @@ msgstr "Ieškau informacijos"
 msgid "I am this person"
 msgstr "Aš esu šis asmuo"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Nebenoriu gauti šio įrašo naujinių."
 
@@ -898,6 +895,9 @@ msgstr "Gavau šlamšto."
 
 msgid "I prefer not to specify."
 msgstr "Nenoriu nurodyti."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Aš ieškau asmens"
@@ -1209,6 +1209,9 @@ msgstr "Ištrynimo priežastis:"
 
 msgid "Reason for disabling notes:"
 msgstr "Priežastys, dėl kurių neleidžiamos pastabos:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1532,6 +1535,9 @@ msgstr "Kada šis įrašas nebebus rodomas?"
 
 msgid "Where did this information come from?"
 msgstr "Iš kur gauta ši informacija?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/lv/LC_MESSAGES/django.po
+++ b/app/locale/lv/LC_MESSAGES/django.po
@@ -554,9 +554,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -573,9 +570,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -880,6 +874,9 @@ msgstr "Es meklēju informāciju"
 msgid "I am this person"
 msgstr "Es esmu šī persona"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Es vairs nevēlos saņemt šī ieraksta atjauninājumus."
 
@@ -906,6 +903,9 @@ msgstr "Es saņēmu mēstuli"
 
 msgid "I prefer not to specify."
 msgstr "Es nevēlos norādīt."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Es meklēju kādu personu"
@@ -1219,6 +1219,9 @@ msgstr "Dzēšanas iemesls:"
 
 msgid "Reason for disabling notes:"
 msgstr "Piezīmju atspējošanas iemesls:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1537,6 +1540,9 @@ msgstr "Pēc cik ilga laika šo ierakstu var dzēst?"
 
 msgid "Where did this information come from?"
 msgstr "No kurienes ir šī informācija?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/mk/LC_MESSAGES/django.po
+++ b/app/locale/mk/LC_MESSAGES/django.po
@@ -555,9 +555,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -574,9 +571,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -881,6 +875,9 @@ msgstr "Барам информации"
 msgid "I am this person"
 msgstr "Јас сум ова лице"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Не сакам повеќе ажурирања за овој запис."
 
@@ -907,6 +904,9 @@ msgstr "Добив спам."
 
 msgid "I prefer not to specify."
 msgstr "Претпочитам да не прецизирам."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Барам некого"
@@ -1218,6 +1218,9 @@ msgstr "Причина за бришење:"
 
 msgid "Reason for disabling notes:"
 msgstr "Причина за оневозможување белешки:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1536,6 +1539,9 @@ msgstr "Кога треба да исчезне овој запис?"
 
 msgid "Where did this information come from?"
 msgstr "Од каде доаѓаат овие информации?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/ml/LC_MESSAGES/django.po
+++ b/app/locale/ml/LC_MESSAGES/django.po
@@ -564,9 +564,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -583,9 +580,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -890,6 +884,9 @@ msgstr "ഞാൻ വിവരങ്ങൾ തേടുന്നു"
 msgid "I am this person"
 msgstr "ഈ വ്യക്തി ഞാനാണ്"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "ഈ റെക്കോർഡിനെക്കുറിച്ച് എനിക്ക് കൂടുതൽ അപ്‌ഡേറ്റുകൾ ആവശ്യമില്ല."
 
@@ -916,6 +913,9 @@ msgstr "എനിക്ക് സ്‌പാം ലഭിച്ചു."
 
 msgid "I prefer not to specify."
 msgstr "വ്യക്തമാക്കാതിരിക്കാൻ ഞാൻ താൽപ്പര്യപ്പെടുന്നു."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "ഞാൻ ഒരാളെ തിരയുകയാണ്"
@@ -1237,6 +1237,9 @@ msgstr "ഇല്ലാതാക്കുന്നതിനുള്ള കാ�
 
 msgid "Reason for disabling notes:"
 msgstr "കുറിപ്പുകൾ പ്രവർത്തനരഹിതമാക്കുന്നതിനുള്ള കാരണം:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1561,6 +1564,9 @@ msgstr "ഈ റെക്കോർഡ് എപ്പോൾ അപ്രത്യ
 
 msgid "Where did this information come from?"
 msgstr "ഈ വിവരം ലഭിച്ചത് എവിടെ നിന്നാണ്?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/mn/LC_MESSAGES/django.po
+++ b/app/locale/mn/LC_MESSAGES/django.po
@@ -541,9 +541,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -560,9 +557,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -861,6 +855,9 @@ msgstr "Би мэдээлэл хайж байна"
 msgid "I am this person"
 msgstr "Би энэ хүн байна"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Би энэ бичлэгийн талаар шинэ мэдээлэл авахгүй."
 
@@ -887,6 +884,9 @@ msgstr "Би спам хүлээж авсан."
 
 msgid "I prefer not to specify."
 msgstr "Би тодорхойлохыг хүсэхгүй байна."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Би хэн нэгнийг хайж байна"
@@ -1199,6 +1199,9 @@ msgstr "Устгах шалтгаан:"
 
 msgid "Reason for disabling notes:"
 msgstr "Тэмдэглэлийг идэвхгүйжүүлэх шалтгаан:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1513,6 +1516,9 @@ msgstr "Энэ бичлэг хэзээ арилах ёстой вэ?"
 
 msgid "Where did this information come from?"
 msgstr "Энэ мэдээлэл хаанаас ирсэн бэ?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/mr/LC_MESSAGES/django.po
+++ b/app/locale/mr/LC_MESSAGES/django.po
@@ -554,9 +554,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -573,9 +570,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -878,6 +872,9 @@ msgstr "मी माहिती शोधत आहे"
 msgid "I am this person"
 msgstr "मी ही व्यक्ती आहे"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "मला या रेकॉर्डवरील कोणतीही अधिक अद्यतने नको आहेत."
 
@@ -904,6 +901,9 @@ msgstr "मला स्पॅम प्राप्त झाला."
 
 msgid "I prefer not to specify."
 msgstr "मी निर्दिष्ट न करण्यास प्राधान्य देतो."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "मी कोणालातरी शोधत आहे"
@@ -1217,6 +1217,9 @@ msgstr "हटविण्याचे कारण:"
 
 msgid "Reason for disabling notes:"
 msgstr "टिपा अक्षम करण्याचे कारण:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1534,6 +1537,9 @@ msgstr "हे रेकॉर्ड अदृश्य केव्हा व�
 
 msgid "Where did this information come from?"
 msgstr "ही माहिती कुठून आली?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/ms/LC_MESSAGES/django.po
+++ b/app/locale/ms/LC_MESSAGES/django.po
@@ -552,9 +552,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -571,9 +568,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -881,6 +875,9 @@ msgstr "Saya sedang mencari maklumat"
 msgid "I am this person"
 msgstr "Sayalah orang ini"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Saya tidak mahu sebarang kemas kini lagi pada rekod ini."
 
@@ -907,6 +904,9 @@ msgstr "Saya telah menerima spam."
 
 msgid "I prefer not to specify."
 msgstr "Saya memilih untuk tidak nyatakan."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Saya sedang mencari seseorang"
@@ -1221,6 +1221,9 @@ msgstr "Alasan untuk pemadaman:"
 msgid "Reason for disabling notes:"
 msgstr "Sebab untuk melumpuhkan nota:"
 
+msgid "Record information"
+msgstr ""
+
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
 msgstr "Rekod dengan nama dan alamat yang sepadan \"%(query)s\""
@@ -1533,6 +1536,9 @@ msgstr "Bila rekod ini harus luput?"
 
 msgid "Where did this information come from?"
 msgstr "Dari manakah asalnya maklumat ini?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/my/LC_MESSAGES/django.po
+++ b/app/locale/my/LC_MESSAGES/django.po
@@ -560,9 +560,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -579,9 +576,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -904,6 +898,9 @@ msgstr "ကၽြန္ေတာ္(ကၽြန္မ) သတင္းအခ်
 msgid "I am this person"
 msgstr "ကၽြန္ေတာ္(ကၽြန္မ)က အဲဒီသူပါ။"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "ဒီမွတ္တမ္းႏွင့္ပတ္သတ္သည့္ အပ္ဒိတ္ updates မ်ားကို မလိုခ်င္ေတာ့ပါ။"
 
@@ -934,6 +931,9 @@ msgstr "ကၽြန္ေတာ္(ကၽြန္မ) spam ရပါတယ္�
 
 msgid "I prefer not to specify."
 msgstr "ကၽြန္ေတာ္(ကၽြန္မ) အေသးစိတ္ မေျပာလိုဘူး။"
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "ကၽြန္ေတာ္(ကၽြန္မ) လူတစ္ေယာက္ကို ရွာေနတယ္။"
@@ -1267,6 +1267,9 @@ msgstr "ဖ်က္ျပစ္ရတဲ ့အေႀကာင္းအရာ�
 
 msgid "Reason for disabling notes:"
 msgstr "မွတ္စုမ်ားကို disable လုပ္ရတဲ့ အေႀကာင္းအရာ။"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1624,6 +1627,9 @@ msgstr "ဒီမွတ္တမ္းက ဘယ္အခ်ိန္မွာ �
 
 msgid "Where did this information come from?"
 msgstr "ဒီသတင္းအခ်က္အလက္က ဘယ္ကေနရတာလဲ။"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/ne/LC_MESSAGES/django.po
+++ b/app/locale/ne/LC_MESSAGES/django.po
@@ -507,9 +507,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -526,9 +523,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -837,6 +831,9 @@ msgstr "म जानकारी खोजिरहेको छु"
 msgid "I am this person"
 msgstr "म यो व्यक्ति हुँ"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "यस रेकर्डमा अरू थप अद्यावधिकहरू म चाहन्न।"
 
@@ -863,6 +860,9 @@ msgstr "मैले स्प्याम प्राप्त गरेको
 
 msgid "I prefer not to specify."
 msgstr "म तोक्न रूचाउँदिन।"
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "म कसैलाई खोजिरहेको छु"
@@ -1183,6 +1183,9 @@ msgstr "मेट्नका लागि कारण:"
 msgid "Reason for disabling notes:"
 msgstr "टिप्पणी असक्षम पार्नका लागि कारण:"
 
+msgid "Record information"
+msgstr ""
+
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
 msgstr "\"%(query)s\" सँग मिल्दो नाम ठेगानासहितको रेकर्डहरू"
@@ -1499,6 +1502,9 @@ msgstr "यस रेकर्ड कहिले हट्नुपर्छ?"
 
 msgid "Where did this information come from?"
 msgstr "यो जानकारी कहाँबाट आयो?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/nl/LC_MESSAGES/django.po
+++ b/app/locale/nl/LC_MESSAGES/django.po
@@ -555,9 +555,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -574,9 +571,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -889,6 +883,9 @@ msgstr "Ik ben op zoek naar informatie"
 msgid "I am this person"
 msgstr "Ik ben deze persoon"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Ik wil niet dat er updates voor deze vermelding worden weergegeven."
 
@@ -915,6 +912,9 @@ msgstr "Ik heb spam ontvangen."
 
 msgid "I prefer not to specify."
 msgstr "Ik geef liever niet meer details."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Ik ben op zoek naar iemand"
@@ -1228,6 +1228,9 @@ msgstr "Reden voor verwijdering:"
 
 msgid "Reason for disabling notes:"
 msgstr "Reden voor het uitschakelen van opmerkingen:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1547,6 +1550,9 @@ msgstr "Wanneer moet deze vermelding worden opgeheven?"
 
 msgid "Where did this information come from?"
 msgstr "Waar komt deze informatie vandaan?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/no/LC_MESSAGES/django.po
+++ b/app/locale/no/LC_MESSAGES/django.po
@@ -546,9 +546,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -565,9 +562,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -874,6 +868,9 @@ msgstr "Jeg er på jakt etter informasjon"
 msgid "I am this person"
 msgstr "Jeg er denne personen"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Jeg vil ikke lenger motta oppdateringer for denne oppføringen."
 
@@ -900,6 +897,9 @@ msgstr "Jeg har mottatt nettsøppel."
 
 msgid "I prefer not to specify."
 msgstr "Jeg foretrekker å ikke oppgi ytterligere opplysninger."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Jeg leter etter noen"
@@ -1207,6 +1207,9 @@ msgstr "Årsak til sletting:"
 
 msgid "Reason for disabling notes:"
 msgstr "Årsak til deaktivering av notater:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1527,6 +1530,9 @@ msgstr "Når skal oppføringen forsvinne?"
 
 msgid "Where did this information come from?"
 msgstr "Hvor kommer denne informasjonen fra?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/pa/LC_MESSAGES/django.po
+++ b/app/locale/pa/LC_MESSAGES/django.po
@@ -530,9 +530,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -549,9 +546,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -856,6 +850,9 @@ msgstr "ਮੈਂ ਜਾਣਕਾਰੀ ਲੈ ਰਿਹਾ ਹਾਂ"
 msgid "I am this person"
 msgstr "ਮੈਂ ਇਹ ਵਿਅਕਤੀ ਹਾਂ"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "ਮੈਂ ਇਸ ਰਿਕਾਰਡ ਉੱਤੇ ਹੋਰ ਕੋਈ ਵੀ ਅਦਿਅਤਨ ਨਹੀਂ ਕਰਨਾ ਚਾਹੁੰਦਾ."
 
@@ -882,6 +879,9 @@ msgstr "ਮੈਨੂੰ ਸਪੈਮ ਪ੍ਰਾਪਤ ਹੋਇਆ ਹੈ."
 
 msgid "I prefer not to specify."
 msgstr " ਮੈਂ ਨਿਰਦਿਸ਼ਟ ਕਰਨਾ ਪਸੰਦ ਨਹੀਂ ਕਰਦਾ."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "ਮੈਂ ਕਿਸੇ ਲਈ ਵੇਖ ਰਿਹਾ ਹਾਂ"
@@ -1192,6 +1192,9 @@ msgstr "ਹਟਾਏ ਜਾਣ ਦੇ ਕਾਰਨ:"
 
 msgid "Reason for disabling notes:"
 msgstr "ਨੋਟਸ ਨੂੰ ਅਕਰਮਕ ਕਰਨ ਦੇ ਕਾਰਨ: :"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1507,6 +1510,9 @@ msgstr "ਇਹ ਰਿਕਾਰਡ ਕਦੋਂ ਗਾਇਬ ਹੋ ਜਾਣਾ 
 
 msgid "Where did this information come from?"
 msgstr "ਇਹ ਜਾਣਕਾਰੀ ਕਿੱਥੋ ਆਈ?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/pl/LC_MESSAGES/django.po
+++ b/app/locale/pl/LC_MESSAGES/django.po
@@ -554,9 +554,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -573,9 +570,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -882,6 +876,9 @@ msgstr "Szukam informacji"
 msgid "I am this person"
 msgstr "Jestem tą osobą"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Nie chcę już otrzymywać nowych informacji o tym wpisie."
 
@@ -908,6 +905,9 @@ msgstr "Wysłano mi spam"
 
 msgid "I prefer not to specify."
 msgstr "Wolę nie podawać"
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Szukam kogoś"
@@ -1217,6 +1217,9 @@ msgstr "Przyczyna usunięcia:"
 
 msgid "Reason for disabling notes:"
 msgstr "Przyczyna wyłączenia dodawania notatek:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1529,6 +1532,9 @@ msgstr "Kiedy ten wpis powinien zniknąć?"
 
 msgid "Where did this information come from?"
 msgstr "Skąd pochodzą te informacje?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/prs/LC_MESSAGES/django.po
+++ b/app/locale/prs/LC_MESSAGES/django.po
@@ -359,9 +359,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -378,9 +375,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -670,6 +664,9 @@ msgstr "من در جستجو معلومات هستم"
 msgid "I am this person"
 msgstr "من این شخص هستم"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr ""
 
@@ -695,6 +692,9 @@ msgid "I have received spam."
 msgstr ""
 
 msgid "I prefer not to specify."
+msgstr ""
+
+msgid "I want to input information about this person."
 msgstr ""
 
 msgid "I'm looking for someone"
@@ -978,6 +978,9 @@ msgid "Reason for deletion:"
 msgstr ""
 
 msgid "Reason for disabling notes:"
+msgstr ""
+
+msgid "Record information"
 msgstr ""
 
 #, python-format
@@ -1280,6 +1283,9 @@ msgstr ""
 
 msgid "Where did this information come from?"
 msgstr "این معلومات از کجا بدست امده ؟"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/ps/LC_MESSAGES/django.po
+++ b/app/locale/ps/LC_MESSAGES/django.po
@@ -359,9 +359,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -378,9 +375,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -669,6 +663,9 @@ msgstr "زه معلومات غواړم/ لټوم"
 msgid "I am this person"
 msgstr "زه همدا شخص يم"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr ""
 
@@ -694,6 +691,9 @@ msgid "I have received spam."
 msgstr ""
 
 msgid "I prefer not to specify."
+msgstr ""
+
+msgid "I want to input information about this person."
 msgstr ""
 
 msgid "I'm looking for someone"
@@ -978,6 +978,9 @@ msgid "Reason for deletion:"
 msgstr ""
 
 msgid "Reason for disabling notes:"
+msgstr ""
+
+msgid "Record information"
 msgstr ""
 
 #, python-format
@@ -1280,6 +1283,9 @@ msgstr ""
 
 msgid "Where did this information come from?"
 msgstr "دا معلومات له کوم ځايه راغلي"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/ps1/LC_MESSAGES/django.po
+++ b/app/locale/ps1/LC_MESSAGES/django.po
@@ -552,9 +552,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -571,9 +568,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -874,6 +868,9 @@ msgstr "Î åm šééķîñĝ îñƒörmåţîöñ"
 msgid "I am this person"
 msgstr "Î åm ţĥîš þéršöñ"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Î ðö ñöţ ŵåñţ åñý möré ûþðåţéš öñ ţĥîš réçörð."
 
@@ -900,6 +897,9 @@ msgstr "Î ĥåvé réçéîvéð šþåm."
 
 msgid "I prefer not to specify."
 msgstr "Î þréƒér ñöţ ţö šþéçîƒý."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Î'm ļööķîñĝ ƒör šöméöñé"
@@ -1205,6 +1205,9 @@ msgstr "®éåšöñ ƒör ðéļéţîöñ:"
 
 msgid "Reason for disabling notes:"
 msgstr "®éåšöñ ƒör ðîšåbļîñĝ ñöţéš:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1520,6 +1523,9 @@ msgstr "Ŵĥéñ šĥöûļð ţĥîš réçörð ðîšåþþéår¿"
 
 msgid "Where did this information come from?"
 msgstr "Ŵĥéré ðîð ţĥîš îñƒörmåţîöñ çömé ƒröm¿"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/pt_BR/LC_MESSAGES/django.po
+++ b/app/locale/pt_BR/LC_MESSAGES/django.po
@@ -536,9 +536,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -555,9 +552,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -862,6 +856,9 @@ msgstr "Estou buscando informações"
 msgid "I am this person"
 msgstr "Sou esta pessoa"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Não desejo receber mais atualizações neste registro."
 
@@ -888,6 +885,9 @@ msgstr "Recebi spam."
 
 msgid "I prefer not to specify."
 msgstr "Prefiro não especificar."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Estou procurando alguém"
@@ -1202,6 +1202,9 @@ msgstr "Motivo da exclusão:"
 msgid "Reason for disabling notes:"
 msgstr "Motivo para desativar as notas:"
 
+msgid "Record information"
+msgstr ""
+
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
 msgstr "Registros com nomes e endereços que correspondem a \"%(query)s\""
@@ -1515,6 +1518,9 @@ msgstr "Quando este registro deverá ser descontinuado?"
 
 msgid "Where did this information come from?"
 msgstr "De onde vieram estas informações?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/pt_PT/LC_MESSAGES/django.po
+++ b/app/locale/pt_PT/LC_MESSAGES/django.po
@@ -546,9 +546,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -565,9 +562,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -872,6 +866,9 @@ msgstr "Procuro informações"
 msgid "I am this person"
 msgstr "Sou esta pessoa"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Não pretendo mais atualizações neste registo."
 
@@ -898,6 +895,9 @@ msgstr "Recebi spam."
 
 msgid "I prefer not to specify."
 msgstr "Prefiro não especificar."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Procuro alguém"
@@ -1207,6 +1207,9 @@ msgstr "Motivo da eliminação:"
 
 msgid "Reason for disabling notes:"
 msgstr "Motivo para a desativação das notas:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1527,6 +1530,9 @@ msgstr "Quando deverá desaparecer este registo?"
 
 msgid "Where did this information come from?"
 msgstr "De onde veio esta informação?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/ro/LC_MESSAGES/django.po
+++ b/app/locale/ro/LC_MESSAGES/django.po
@@ -561,9 +561,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -580,9 +577,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -893,6 +887,9 @@ msgstr "Caut informații"
 msgid "I am this person"
 msgstr "Eu sunt această persoană"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Nu mai doresc actualizări pentru această înregistrare."
 
@@ -919,6 +916,9 @@ msgstr "Am primit spam."
 
 msgid "I prefer not to specify."
 msgstr "Prefer să nu specific."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Caut pe cineva"
@@ -1236,6 +1236,9 @@ msgstr "Motiv de ștergere:"
 
 msgid "Reason for disabling notes:"
 msgstr "Motivul dezactivării notelor:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1561,6 +1564,9 @@ msgstr "Când ar trebui să dispară această înregistrare?"
 
 msgid "Where did this information come from?"
 msgstr "De unde provin aceste informații?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/ru/LC_MESSAGES/django.po
+++ b/app/locale/ru/LC_MESSAGES/django.po
@@ -530,9 +530,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -549,9 +546,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -857,6 +851,9 @@ msgstr "Я ищу информацию"
 msgid "I am this person"
 msgstr "Я этот человек"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Больше не получать сведения об обновлениях этой записи."
 
@@ -883,6 +880,9 @@ msgstr "Мне прислали спам"
 
 msgid "I prefer not to specify."
 msgstr "Предпочитаю не указывать"
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Я ищу человека"
@@ -1196,6 +1196,9 @@ msgstr "Причина:"
 msgid "Reason for disabling notes:"
 msgstr "Причина отключения заметок:"
 
+msgid "Record information"
+msgstr ""
+
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
 msgstr "Записи, содержащие имена и адреса, по запросу \"%(query)s\""
@@ -1508,6 +1511,9 @@ msgstr "Время, через которое запись можно будет
 
 msgid "Where did this information come from?"
 msgstr "Об этом уже сообщалось ранее?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/si/LC_MESSAGES/django.po
+++ b/app/locale/si/LC_MESSAGES/django.po
@@ -538,9 +538,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -557,9 +554,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -860,6 +854,9 @@ msgstr "මම තොරතුරු ඉල්ලමින් සිටිමි
 msgid "I am this person"
 msgstr "මම මෙම පුද්ගලයාය"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "මට මෙම වාර්තාව මත තවදුරටත් යාවත්කාලීන අවශ්‍ය නැත."
 
@@ -886,6 +883,9 @@ msgstr "මට ආයාචිත තැපැල් ලැබී ඇත."
 
 msgid "I prefer not to specify."
 msgstr "විශේෂයෙන් සඳහන් නොකිරීමට මම ප්‍රිය කරමි."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "මම යමෙකු සොයමින් සිටිමි"
@@ -1195,6 +1195,9 @@ msgstr "මැකීම සඳහා හේතුව:"
 
 msgid "Reason for disabling notes:"
 msgstr "සටහන් අබල කිරීමට හේතුව:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1513,6 +1516,9 @@ msgstr "මෙම වාර්තාව නොපෙනී යන්නේ ක�
 
 msgid "Where did this information come from?"
 msgstr "මෙම තොරතුරු පැමිණියේ කොහින්ද?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/sk/LC_MESSAGES/django.po
+++ b/app/locale/sk/LC_MESSAGES/django.po
@@ -543,9 +543,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -562,9 +559,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -869,6 +863,9 @@ msgstr "Hľadám informácie"
 msgid "I am this person"
 msgstr "Som táto osoba"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Nechcem žiadne ďalšie aktualizácie o tomto zázname."
 
@@ -895,6 +892,9 @@ msgstr "Dostal(-a) som spam."
 
 msgid "I prefer not to specify."
 msgstr "Neželám si uviesť."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Niekoho hľadám"
@@ -1210,6 +1210,9 @@ msgstr "Dôvod odstránenia:"
 
 msgid "Reason for disabling notes:"
 msgstr "Dôvod zakázania poznámok:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1527,6 +1530,9 @@ msgstr "Kedy by mal tento záznam zmiznúť?"
 
 msgid "Where did this information come from?"
 msgstr "Odkiaľ tieto informácie pochádzajú?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/sl/LC_MESSAGES/django.po
+++ b/app/locale/sl/LC_MESSAGES/django.po
@@ -544,9 +544,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -563,9 +560,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -870,6 +864,9 @@ msgstr "Iščem informacije"
 msgid "I am this person"
 msgstr "Ta oseba sem jaz"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Za ta zapis ne želim novih posodobitev."
 
@@ -896,6 +893,9 @@ msgstr "Prejel sem vsiljeno pošto."
 
 msgid "I prefer not to specify."
 msgstr "Ne želim navesti."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Iščem nekoga"
@@ -1205,6 +1205,9 @@ msgstr "Razlog za izbris:"
 
 msgid "Reason for disabling notes:"
 msgstr "Razlog, zaradi katerega ste onemogočili opombe:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1521,6 +1524,9 @@ msgstr "Kdaj mora ta zapis izginiti?"
 
 msgid "Where did this information come from?"
 msgstr "Od kod so te informacije?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/sq/LC_MESSAGES/django.po
+++ b/app/locale/sq/LC_MESSAGES/django.po
@@ -514,9 +514,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -533,9 +530,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -848,6 +842,9 @@ msgstr "Po kërkoj informacione"
 msgid "I am this person"
 msgstr "Unë jam ky person"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Nuk dua më njoftime mbi këtë raport."
 
@@ -874,6 +871,9 @@ msgstr "Kam marrë mesazhe të padëshirueshme (spam)."
 
 msgid "I prefer not to specify."
 msgstr "Preferoj të mos specifikoj."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Po kërkoj dikë"
@@ -1196,6 +1196,9 @@ msgstr "Arsyeja e fshirjes:"
 
 msgid "Reason for disabling notes:"
 msgstr "Arsyeja për çaktivizimin e shënimeve:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1524,6 +1527,9 @@ msgstr "Kur mund të hiqet ky raport?"
 
 msgid "Where did this information come from?"
 msgstr "Prej nga erdhi ky informacion?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/sr/LC_MESSAGES/django.po
+++ b/app/locale/sr/LC_MESSAGES/django.po
@@ -543,9 +543,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -562,9 +559,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -865,6 +859,9 @@ msgstr "Тражим информације"
 msgid "I am this person"
 msgstr "Ја сам та особа"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Не желим више да добијам новости о овом запису."
 
@@ -891,6 +888,9 @@ msgstr "Примио/ла сам непожељан садржај."
 
 msgid "I prefer not to specify."
 msgstr "Не желим да наведем."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Тражим некога"
@@ -1198,6 +1198,9 @@ msgstr "Разлог за брисање:"
 
 msgid "Reason for disabling notes:"
 msgstr "Разлог за онемогућавање бележака:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1514,6 +1517,9 @@ msgstr "Када би овај запис требало да нестане?"
 
 msgid "Where did this information come from?"
 msgstr "Одакле потичу ове информације?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/su/LC_MESSAGES/django.po
+++ b/app/locale/su/LC_MESSAGES/django.po
@@ -544,9 +544,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -563,9 +560,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -868,6 +862,9 @@ msgstr "Abdi milarian béja"
 msgid "I am this person"
 msgstr "Abdi jalma ieu"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Abdi henteu hoyong pangénggalan deui tina rékaman ieu."
 
@@ -894,6 +891,9 @@ msgstr "Kuring kantos nampi spam."
 
 msgid "I prefer not to specify."
 msgstr "Kuring mendingan henteu ngawartosan."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Kuring milari salah saurang jalma"
@@ -1210,6 +1210,9 @@ msgstr "Alesa ngahapus:"
 
 msgid "Reason for disabling notes:"
 msgstr "Alesan pikeun mareuman catetan:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1529,6 +1532,9 @@ msgstr "Iraha rékaman ieu kedah dihapus?"
 
 msgid "Where did this information come from?"
 msgstr "Timana béja ieu datangna?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/sv/LC_MESSAGES/django.po
+++ b/app/locale/sv/LC_MESSAGES/django.po
@@ -557,9 +557,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -576,9 +573,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -883,6 +877,9 @@ msgstr "Jag söker information"
 msgid "I am this person"
 msgstr "Jag är den här personen"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Jag vill inte få fler uppdateringar för den här posten."
 
@@ -909,6 +906,9 @@ msgstr "Jag har fått skräppost."
 
 msgid "I prefer not to specify."
 msgstr "Jag vill helst inte specificera."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Jag letar efter någon"
@@ -1216,6 +1216,9 @@ msgstr "Orsak till borttagning:"
 
 msgid "Reason for disabling notes:"
 msgstr "Anledning till att inaktivera meddelanden:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1535,6 +1538,9 @@ msgstr "När ska posten tas bort?"
 
 msgid "Where did this information come from?"
 msgstr "Varifrån fick du informationen?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/sw/LC_MESSAGES/django.po
+++ b/app/locale/sw/LC_MESSAGES/django.po
@@ -538,9 +538,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -557,9 +554,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -866,6 +860,9 @@ msgstr "Natafuta maelezo"
 msgid "I am this person"
 msgstr "Mimi ndiye mtu huyu"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Sitaki taarifa zaidi kwenye rekodi hii."
 
@@ -892,6 +889,9 @@ msgstr "Nimepokea barua taka."
 
 msgid "I prefer not to specify."
 msgstr "Sitaki kubainisha."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Namtafuta mtu fulani"
@@ -1207,6 +1207,9 @@ msgstr "Sababu ya kufuta:"
 
 msgid "Reason for disabling notes:"
 msgstr "Sababu ya kuficha ujumbe ulioachwa:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1526,6 +1529,9 @@ msgstr "Je, rekodi hii inafaa iwache kuonyeshwa lini?"
 
 msgid "Where did this information come from?"
 msgstr "Je, habari hii ilitoka wapi?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/ta/LC_MESSAGES/django.po
+++ b/app/locale/ta/LC_MESSAGES/django.po
@@ -556,9 +556,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -575,9 +572,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -884,6 +878,9 @@ msgstr "நான் தகவலைத் தேடுகிறேன்"
 msgid "I am this person"
 msgstr "இது நான்தான்"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "இந்தப் பதிவைப் பற்றிய மேலும் புதுப்பிப்புகள் எதுவும் எனக்கு வேண்டாம்."
 
@@ -910,6 +907,9 @@ msgstr "ஸ்பேமைப் பெற்றுள்ளேன்."
 
 msgid "I prefer not to specify."
 msgstr "நான் எதையும் குறிப்பிட விரும்பவில்லை."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "ஒருவரைத் தேடிக்கொண்டிருக்கிறேன்"
@@ -1227,6 +1227,9 @@ msgstr "நீக்கத்திற்கான காரணம்:"
 
 msgid "Reason for disabling notes:"
 msgstr "குறிப்புகளை முடக்குவதற்கான காரணம்:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1552,6 +1555,9 @@ msgstr "இந்த விவரத்தை எத்தனை நாள் �
 
 msgid "Where did this information come from?"
 msgstr "இந்தத் தகவல் எங்கிருந்து வந்தது?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/te/LC_MESSAGES/django.po
+++ b/app/locale/te/LC_MESSAGES/django.po
@@ -545,9 +545,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -564,9 +561,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -875,6 +869,9 @@ msgstr "నేను సమాచారాన్ని శోధిస్తు�
 msgid "I am this person"
 msgstr "ఈ వ్యక్తిని నేనే"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "నేను ఇకపై ఈ రికార్డ్‌లో నవీకరణలను స్వీకరించాలనుకోవడం లేదు."
 
@@ -901,6 +898,9 @@ msgstr "నేను స్పామ్‌ను స్వీకరించా�
 
 msgid "I prefer not to specify."
 msgstr "నేను పేర్కొనకూడదనుకుంటున్నాను."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "నేను ఒకరి కోసం వెతుకుతున్నాను"
@@ -1216,6 +1216,9 @@ msgstr "తొలగింపుకి కారణం:"
 
 msgid "Reason for disabling notes:"
 msgstr "గమనికల నిలిపివేతకు కారణం:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1537,6 +1540,9 @@ msgstr "ఈ రికార్డ్ ఎప్పుడు కనిపించ
 
 msgid "Where did this information come from?"
 msgstr "ఈ సమాచారం ఎక్కడి నుండి వచ్చింది?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/th/LC_MESSAGES/django.po
+++ b/app/locale/th/LC_MESSAGES/django.po
@@ -542,9 +542,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -561,9 +558,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -862,6 +856,9 @@ msgstr "ฉันกำลังหาข้อมูล"
 msgid "I am this person"
 msgstr "ฉันคือบุคคลนี้"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "ฉันไม่ต้องการรับการอัปเดตเพิ่มเติมของบันทึกนี้"
 
@@ -888,6 +885,9 @@ msgstr "ฉันได้รับสแปม"
 
 msgid "I prefer not to specify."
 msgstr "ฉันไม่ต้องการระบุชัดเจน"
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "ฉันกำลังตามหาคน"
@@ -1191,6 +1191,9 @@ msgstr "เหตุผลสำหรับการนำออก:"
 
 msgid "Reason for disabling notes:"
 msgstr "สาเหตุที่ปิดใช้งานข้อความ:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1501,6 +1504,9 @@ msgstr "บันทึกนี้ควรจะหายไปเมื่อ
 
 msgid "Where did this information come from?"
 msgstr "ข้อมูลนี้มาจากไหน"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/tr/LC_MESSAGES/django.po
+++ b/app/locale/tr/LC_MESSAGES/django.po
@@ -557,9 +557,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -576,9 +573,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -881,6 +875,9 @@ msgstr "Bilgi arıyorum"
 msgid "I am this person"
 msgstr "Bu kişiyim"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Bu kayıtla ilgili başka güncelleme almak istemiyorum."
 
@@ -907,6 +904,9 @@ msgstr "Spam aldım."
 
 msgid "I prefer not to specify."
 msgstr "Belirtmemeyi tercih ediyorum."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Birisini arıyorum"
@@ -1216,6 +1216,9 @@ msgstr "Silme nedeni:"
 
 msgid "Reason for disabling notes:"
 msgstr "Notları devre dışı bırakma nedeni:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1530,6 +1533,9 @@ msgstr "Bu kayıt ne zaman kaldırılmalı?"
 
 msgid "Where did this information come from?"
 msgstr "Bu bilgiler nereden geldi?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/uk/LC_MESSAGES/django.po
+++ b/app/locale/uk/LC_MESSAGES/django.po
@@ -542,9 +542,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -561,9 +558,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -871,6 +865,9 @@ msgstr "Я шукаю інформацію"
 msgid "I am this person"
 msgstr "Я є цією особою"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Я більше не хочу отримувати оновлення щодо цього запису."
 
@@ -897,6 +894,9 @@ msgstr "Мені надійшов спам."
 
 msgid "I prefer not to specify."
 msgstr "Не хочу уточнювати."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Я шукаю особу"
@@ -1208,6 +1208,9 @@ msgstr "Причина видалення:"
 
 msgid "Reason for disabling notes:"
 msgstr "Причина вимкнення нотаток:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1528,6 +1531,9 @@ msgstr "Коли має зникнути цей запис?"
 
 msgid "Where did this information come from?"
 msgstr "Звідки ця інформація?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/ur/LC_MESSAGES/django.po
+++ b/app/locale/ur/LC_MESSAGES/django.po
@@ -543,9 +543,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -562,9 +559,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -864,6 +858,9 @@ msgstr "میں معلومات حاصل کر رہا ہوں"
 msgid "I am this person"
 msgstr "میں یہ شخص ہوں"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "میں اس ریکارڈ پر کسی مزید اپ ڈیٹس کا خواہاں نہیں ہوں۔"
 
@@ -890,6 +887,9 @@ msgstr "مجھے سپام موصول ہوا ہے۔"
 
 msgid "I prefer not to specify."
 msgstr "میں نہیں بتانا پسند کرتا ہوں۔"
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "میں کسی کو تلاش کر رہا ہوں"
@@ -1202,6 +1202,9 @@ msgstr "حذف کی وجہ:"
 
 msgid "Reason for disabling notes:"
 msgstr "نوٹس غیر فعال کرنے کی وجہ:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1521,6 +1524,9 @@ msgstr "یہ ریکارڈ کب غائب ہو جانا چاہیے؟"
 
 msgid "Where did this information come from?"
 msgstr "یہ اطلاع کہاں سے آئی؟"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/uz/LC_MESSAGES/django.po
+++ b/app/locale/uz/LC_MESSAGES/django.po
@@ -545,9 +545,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -564,9 +561,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -876,6 +870,9 @@ msgstr "Men ma'lumot izlayapman"
 msgid "I am this person"
 msgstr "Bu inson menman"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Men bu yozuv yangilanishlarini olishni xohlamayman."
 
@@ -902,6 +899,9 @@ msgstr "Men spam qabul qildim."
 
 msgid "I prefer not to specify."
 msgstr "Sababini ko‘rsatishni xohlamayman."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Men bir odamni izlayapman"
@@ -1212,6 +1212,9 @@ msgstr "O‘chirilish sababi:"
 
 msgid "Reason for disabling notes:"
 msgstr "Eslatmalarning o‘chirilib qo‘yilishi sababi:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1535,6 +1538,9 @@ msgstr "Ushbu yozuv qachon olib tashlansin?"
 
 msgid "Where did this information come from?"
 msgstr "Bu ma'lumot qayerdan olingan?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/vi/LC_MESSAGES/django.po
+++ b/app/locale/vi/LC_MESSAGES/django.po
@@ -540,9 +540,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -559,9 +556,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -862,6 +856,9 @@ msgstr "Tôi đang tìm kiếm thông tin"
 msgid "I am this person"
 msgstr "Tôi là người này"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Tôi không muốn bất kỳ cập nhật nào trên hồ sơ này nữa."
 
@@ -888,6 +885,9 @@ msgstr "Tôi đã nhận được spam."
 
 msgid "I prefer not to specify."
 msgstr "Tôi không muốn chỉ rõ."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Tôi đang tìm kiếm một người"
@@ -1199,6 +1199,9 @@ msgstr "Lý do xóa:"
 
 msgid "Reason for disabling notes:"
 msgstr "Lý do tắt ghi chú:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1514,6 +1517,9 @@ msgstr "Khi nào hồ sơ này sẽ biến mất?"
 
 msgid "Where did this information come from?"
 msgstr "Thông tin này lấy từ đâu?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/zh_CN/LC_MESSAGES/django.po
+++ b/app/locale/zh_CN/LC_MESSAGES/django.po
@@ -507,9 +507,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -526,9 +523,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -819,6 +813,9 @@ msgstr "我正在寻找这个人的消息"
 msgid "I am this person"
 msgstr "正是我本人"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "我不想再对此记录进行任何更新了。"
 
@@ -845,6 +842,9 @@ msgstr "我收到了垃圾内容。"
 
 msgid "I prefer not to specify."
 msgstr "我不想指明。"
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "我正在寻人"
@@ -1128,6 +1128,9 @@ msgstr "删除的原因："
 
 msgid "Reason for disabling notes:"
 msgstr "停用注释功能的原因："
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1429,6 +1432,9 @@ msgstr "此记录可在何时删除？"
 
 msgid "Where did this information come from?"
 msgstr "此信息的出处为何？"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/zh_TW/LC_MESSAGES/django.po
+++ b/app/locale/zh_TW/LC_MESSAGES/django.po
@@ -532,9 +532,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -551,9 +548,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -844,6 +838,9 @@ msgstr "我正在找尋這個人的消息"
 msgid "I am this person"
 msgstr "我就是這個人"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "我不想再收到這筆紀錄的最新動態。"
 
@@ -870,6 +867,9 @@ msgstr "我收到垃圾資訊。"
 
 msgid "I prefer not to specify."
 msgstr "保留。"
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "我正在尋找某人"
@@ -1153,6 +1153,9 @@ msgstr "刪除原因："
 
 msgid "Reason for disabling notes:"
 msgstr "停用註記功能的原因："
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1454,6 +1457,9 @@ msgstr "移除這筆紀錄的時間"
 
 msgid "Where did this information come from?"
 msgstr "這個消息的出處為何？"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/zhhk/LC_MESSAGES/django.po
+++ b/app/locale/zhhk/LC_MESSAGES/django.po
@@ -532,9 +532,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -551,9 +548,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -844,6 +838,9 @@ msgstr "我正在找尋這個人的消息"
 msgid "I am this person"
 msgstr "我就是這個人"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "我不想再收到這項記錄的最新動態。"
 
@@ -870,6 +867,9 @@ msgstr "我收到垃圾資訊。"
 
 msgid "I prefer not to specify."
 msgstr "我不想指定。"
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "我正在尋找某人"
@@ -1153,6 +1153,9 @@ msgstr "刪除原因："
 
 msgid "Reason for disabling notes:"
 msgstr "停用註解功能的原因："
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1454,6 +1457,9 @@ msgstr "這項記錄應在何時移除？"
 
 msgid "Where did this information come from?"
 msgstr "此消息的出處何在？"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/locale/zu/LC_MESSAGES/django.po
+++ b/app/locale/zu/LC_MESSAGES/django.po
@@ -554,9 +554,6 @@ msgstr ""
 msgid "(Last known location / other photos)"
 msgstr ""
 
-msgid "(Last known location/ other photos)"
-msgstr ""
-
 msgid "(Your phone number / Expiry)"
 msgstr ""
 
@@ -573,9 +570,6 @@ msgid "+ More information about status of the person"
 msgstr ""
 
 msgid "+ More information to identify the person"
-msgstr ""
-
-msgid "+ Other source of record detail"
 msgstr ""
 
 msgid "A message for this person or others seeking this person"
@@ -882,6 +876,9 @@ msgstr "Ngifuna ulwazi"
 msgid "I am this person"
 msgstr "Ngiwulo muntu"
 
+msgid "I am this person. (input my own information)"
+msgstr ""
+
 msgid "I do not want any more updates on this record."
 msgstr "Angisafuni ezinye izibuyekezo kuleli rekhodi."
 
@@ -908,6 +905,9 @@ msgstr "Ngithole ugaxekile."
 
 msgid "I prefer not to specify."
 msgstr "Ngincamela ukungacacisi."
+
+msgid "I want to input information about this person."
+msgstr ""
 
 msgid "I'm looking for someone"
 msgstr "Ngifuna umuntu othile"
@@ -1221,6 +1221,9 @@ msgstr "Isizathu sokususa:"
 
 msgid "Reason for disabling notes:"
 msgstr "Isizathu sokukhubaza amanothi:"
+
+msgid "Record information"
+msgstr ""
 
 #, python-format
 msgid "Records with names and addresses matching \"%(query)s\""
@@ -1542,6 +1545,9 @@ msgstr "Kufanele leli rekhodi linyamalale nini?"
 
 msgid "Where did this information come from?"
 msgstr "Luvele kuphi lolu lwazi?"
+
+msgid "Where did this record come from?"
+msgstr ""
 
 msgid ""
 "While test mode is in effect, records that are over 24 hours old are "

--- a/app/resources/add_note_base.html.template
+++ b/app/resources/add_note_base.html.template
@@ -20,7 +20,7 @@
 <div class="status section">
   {% if not markdup %}
     <h2>Status</h2>
-    <div class="status subsection">
+    <div class="status subsection" id="status_info">
       <h3>
         {% trans "Status of this person:" %}
       </h3>
@@ -60,7 +60,7 @@
 
   {% if not markdup %}
 
-    <div class="author_made_contact subsection">
+    <div class="author_made_contact subsection" id="made_contact_info">
       <h3 class="mandatory">
         {% trans "Have you personally talked with this person AFTER the disaster? (required)" %}
       </h3>

--- a/app/resources/create.html.template
+++ b/app/resources/create.html.template
@@ -55,8 +55,10 @@
                 <div class="instructions">
                   <div>
                     <input type="radio" name="own_info" value="no"
-                        id="own_info_yes"
-                        checked="checked"
+                        id="own_info_no"
+                        {% ifnotequal params.own_info "yes" %}
+                          checked="checked"
+                        {% endifnotequal %}
                         onclick="update_form()"
                         onchange="update_form()">
                     <label class="option" for="own_info_no">
@@ -65,7 +67,10 @@
                   </div>
                   <div>
                     <input type="radio" name="own_info" value="yes"
-                        id="own_info_no"
+                        id="own_info_yes"
+                        {% ifequal params.own_info "yes" %}
+                          checked="checked"
+                        {% endifequal %}
                         onchange="update_form()"
                         onclick="update_form()">
                     <label class="option" for="own_info_yes">

--- a/app/resources/create.html.template
+++ b/app/resources/create.html.template
@@ -49,9 +49,40 @@
             <h2>
               {% trans "Identifying information" %}
             </h2>
+
+            {% if env.enable_javascript %}            
+              <div class="subsection">
+                <div class="instructions">
+                  <div>
+                    <input type="radio" name="own_info" value="no"
+                        id="own_info_yes"
+                        checked="checked"
+                        onclick="update_form()"
+                        onchange="update_form()">
+                    <label class="option" for="own_info_no">
+                      {% trans "I want to input information about this person." %}
+                    </label>
+                  </div>
+                  <div>
+                    <input type="radio" name="own_info" value="yes"
+                        id="own_info_no"
+                        onchange="update_form()"
+                        onclick="update_form()">
+                    <label class="option" for="own_info_yes">
+                      {% trans "I am this person. (input my own information)" %}                      
+                    </label>
+                  </div>
+                </div>
+              </div>
+            {% else %}
+              {# Only own-info=no is supported when JavaScript is disabled. #}
+              <input type="hidden" name="own-info" value="no">
+            {% endif %}           
+
             <div class="hint">
               {% trans "What is this person's name?" %}
-            </div>
+            </div>            
+
             {% if config.use_family_name and config.family_name_first %}
               <div class="field">
                 <div class="label">
@@ -100,6 +131,7 @@
                 </span>
               </div>
             {% endif %}
+
 
             <a href="#" class="expand-button">
               {% trans "+ More information to identify the person" %} <br>
@@ -395,7 +427,7 @@
             </div>
           </div>
 
-          <div class="source section">
+          <div class="source section" id="source_record">
             <h2>
               {% trans "Source of Record" %}
             </h2>
@@ -472,7 +504,58 @@
                     class="medium-text-input"
                     value="{{params.author_email}}" />
               </span>
-            </div>          
+            </div>  
+
+            {% if env.enable_javascript %}
+              <div class="subsection" id="source_title_row" style="display: none">
+                <h3>
+                  {% trans "Record information" %}
+                </h3>
+                <span class="hint">
+                  {% trans "Where did this record come from?" %}
+                </span>                        
+                <div class="field" id="source_url_row" style="display: none">
+                  <span class="label">
+                    <label for="source_url">
+                      {% trans "URL of original record" %}:
+                    </label>
+                  </span>
+                  <span class="value">
+                    <input name="source_url" id="source_url"
+                        class="medium-text-input"
+                        value="{{params.source_url}}" />
+                  </span>
+                </div>
+                <div class="field" id="source_date_row" style="display: none">
+                  <span class="label">
+                    <label for="source_date">
+                      {% trans "Original posting date" %}:
+                    </label>
+                  </span>
+                  <span class="value">
+                    <input name="source_date" id="source_date"
+                        class="medium-text-input"
+                        value="{{params.source_date}}" />
+                  </span>
+                </div>
+                <div class="field" id="source_date_hint_row"
+                    style="display: none">
+                  <div class="value hint">{% trans "Enter as YYYY-MM-DD" %}</div>
+                </div>
+                <div class="field" id="source_name_row" style="display: none">
+                  <span class="label">
+                    <label for="source_name">
+                      {% trans "Original site name" %}:
+                    </label>
+                  </span>
+                  <span class="value">
+                    <input name="source_name" id="source_name"
+                        class="medium-text-input"
+                        value="{{params.source_name}}" />
+                  </span>
+                </div>
+              </div>
+            {% endif %}
 
             <a href="#" class="expand-button">
               {% trans "+ More information about source of record" %} <br>
@@ -529,54 +612,10 @@
                   </select>
                 </div>
                 <div class="end-multi-columns"></div>
-              </div>
-            </div>            
+              </div>          
+            </div>
+          </div>  
 
-            {% if env.enable_javascript %}
-              <div class="field" id="source_url_row" style="display: none">
-                <span class="label">
-                  <label for="source_url">
-                    {% trans "URL of original record" %}:
-                  </label>
-                </span>
-                <span class="value">
-                  <input name="source_url" id="source_url"
-                      class="medium-text-input"
-                      value="{{params.source_url}}" />
-                </span>
-              </div>
-              <div class="field" id="source_date_row" style="display: none">
-                <span class="label">
-                  <label for="source_date">
-                    {% trans "Original posting date" %}:
-                  </label>
-                </span>
-                <span class="value">
-                  <input name="source_date" id="source_date"
-                      class="medium-text-input"
-                      value="{{params.source_date}}" />
-                </span>
-              </div>
-              <div class="field" id="source_date_hint_row"
-                  style="display: none">
-                <div class="value hint">{% trans "Enter as YYYY-MM-DD" %}</div>
-              </div>
-              <div class="field" id="source_name_row" style="display: none">
-                <span class="label">
-                  <label for="source_name">
-                    {% trans "Original site name" %}:
-                  </label>
-                </span>
-                <span class="value">
-                  <input name="source_name" id="source_name"
-                      class="medium-text-input"
-                      value="{{params.source_name}}" />
-                </span>
-              </div>
-            {% endif %}
-            <div class="end-multi-columns"></div>
-          </div>
-          
           {% ifequal params.role "provide" %}
             {% include "add_note_base.html.template" %}
           {% endifequal %}     

--- a/app/resources/forms.js
+++ b/app/resources/forms.js
@@ -46,10 +46,10 @@ function hide(element) {
 
 // Dynamic behavior for the whole form.
 function update_form() {
-  var hide_contact = $('own_info_yes').checked ? '' : 'none';
-  $('source_record').style.display = hide_contact;
-  $('status_info').style.display = hide_contact;
-  $('made_contact_info').style.display = hide_contact;
+  var display_contact = $('own_info_no').checked ? '' : 'none';
+  $('source_record').style.display = display_contact;
+  $('status_info').style.display = display_contact;
+  $('made_contact_info').style.display = display_contact;
 }
 
 // Dynamic behavior for the Person entry form.
@@ -283,8 +283,12 @@ function mark_dup() {
 // Returns true if the contents of the form are okay to submit.
 function validate_fields() {
   // Check that mandatory fields are filled in.
-  // TODO(ryok): maybe just check full_name instead of given_name and family_name.
-  var mandatory_fields = ['given_name', 'family_name', 'text', 'author_name'];
+  // TODO(ryok): maybe just check full_name instead of given_name and family_name. 
+  if ($('own_info_yes').checked)
+    var mandatory_fields = ['given_name', 'family_name', 'text'];
+  else
+    var mandatory_fields = ['given_name', 'family_name', 'text', 'author_name'];
+
   for (var i = 0; i < mandatory_fields.length; i++) {
     field = $(mandatory_fields[i]);
     if (field != null && field.value.match(/^\s*$/)) {

--- a/app/resources/forms.js
+++ b/app/resources/forms.js
@@ -44,6 +44,14 @@ function hide(element) {
   }
 }
 
+// Dynamic behavior for the whole form.
+function update_form() {
+  var hide_contact = $('own_info_yes').checked ? '' : 'none';
+  $('source_record').style.display = hide_contact;
+  $('status_info').style.display = hide_contact;
+  $('made_contact_info').style.display = hide_contact;
+}
+
 // Dynamic behavior for the Person entry form.
 function update_clone() {
   var display_original = $('clone_no').checked ? 'inline' : 'none';
@@ -56,6 +64,7 @@ function update_clone() {
   $('author_name_clone').style.display = display_clone;
   $('author_phone_clone').style.display = display_clone;
   $('author_email_clone').style.display = display_clone;
+  $('source_title_row').style.display = display_source;  
   $('source_url_row').style.display = display_source;
   $('source_date_row').style.display = display_source;
   $('source_date_hint_row').style.display = display_source;

--- a/app/resources/view.html.template
+++ b/app/resources/view.html.template
@@ -196,17 +196,10 @@
 
           <div class="source section">
             <h2>{% trans "Source of this record" %}</h2>
-            {% if person.author_name %}
-              <div class="field">
-                <span class="label">{% trans "Author's name" %}:</span>
-                <span class="value">{{person.author_name}}</span>                
-              </div>            
-            {% else %}
-              <div class="field">
-                <span class="label">{% trans "Author's name" %}:</span>
-                <span class="value">{{person.full_name}}</span>
-              </div>                          
-            {% endif %}  
+            <div class="field">
+              <span class="label">{% trans "Author's name" %}:</span>
+              <span class="value">{{person.author_name}}</span>                
+            </div>            
             {% if env.enable_captcha %}
               {% if person.author_phone %}
                 <div class="field">

--- a/app/resources/view.html.template
+++ b/app/resources/view.html.template
@@ -196,10 +196,17 @@
 
           <div class="source section">
             <h2>{% trans "Source of this record" %}</h2>
-            <div class="field">
-              <span class="label">{% trans "Author's name" %}:</span>
-              <span class="value">{{person.author_name}}</span>
-            </div>
+            {% if person.author_name %}
+              <div class="field">
+                <span class="label">{% trans "Author's name" %}:</span>
+                <span class="value">{{person.author_name}}</span>                
+              </div>            
+            {% else %}
+              <div class="field">
+                <span class="label">{% trans "Author's name" %}:</span>
+                <span class="value">{{person.full_name}}</span>
+              </div>                          
+            {% endif %}  
             {% if env.enable_captcha %}
               {% if person.author_phone %}
                 <div class="field">

--- a/app/utils.py
+++ b/app/utils.py
@@ -690,6 +690,7 @@ class BaseHandler(webapp.RequestHandler):
         'ui': strip_and_lower,
         'utcnow': validate_timestamp,
         'version': validate_version,
+        'own_info': validate_yes,
     }
 
     def redirect(self, path, repo=None, permanent=False, **params):


### PR DESCRIPTION
**The goal is to Hide some part of the form if the person is inputing his/her own information**

So inside the form user can choose 

+ I want to input information about this person
![form](https://cloud.githubusercontent.com/assets/15961861/17765077/898f7f98-655e-11e6-932a-89d65ff9d261.png)

+ I am this person. (input my own information) **(Some not necessary part of the form is hidden)**
![form2](https://cloud.githubusercontent.com/assets/15961861/17765164/1bcace8a-655f-11e6-8ee3-a5e3341259a4.png)

also edit the place if user select 
+ This record is copied from another source
![source](https://cloud.githubusercontent.com/assets/15961861/17765195/486180b0-655f-11e6-9210-30118e6224ab.png)


One remaining unsolved problem is that when you hide some part of the code,
it will appear a warning message to ask the user to fill all the required part (because the required part in the source section is hidden) :(

I have two idea to solve this problem:
1. define params.own_info to add {% if params.own_info %} to set the author_name automatically to the person's full_name.
2. edit the requred field to set the author name to not required. 

Do you have any better idea?