### PR TITLE
Making changes for ifconfig/easy_install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,9 +24,9 @@ RUN tar xvfz Imaging-1.1.7.tar.gz && cd Imaging-1.1.7 && python2.7 setup.py inst
 
 WORKDIR   /opt/
 RUN wget  https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.25.zip
-RUN unzip google_appengine_1.9.25.zip 
+RUN unzip google_appengine_1.9.25.zip
 
-RUN easy_install-2.7 pytest
+RUN easy_install pytest
 RUN apt-get install -y gettext
 
 ADD gae-run-app.sh      /usr/bin/

--- a/docker/gae-run-app.sh
+++ b/docker/gae-run-app.sh
@@ -4,7 +4,7 @@ PORT=8000
 HOST_PORT=8001
 API_PORT=49532
 
-IP_ADDR=`ifconfig eth0 | grep -o "addr:[0-9][0-9][0-9]\.[0-9]*\.[0-9]*\.[0-9]*" | awk -F ":" '{print $2}'`
+IP_ADDR=`ip addr list eth0 | grep 'inet ' | cut -d' ' -f6 | cut -d'/' -f1`
 
 cd ${PERSONFINDER_DIR}
 echo "Starting Person Finder server"

--- a/docker/setup_datastore.sh
+++ b/docker/setup_datastore.sh
@@ -2,7 +2,7 @@
 # Initialize the Person Finder's datastore the first time it is run on this machine.
 
 PORT=8000
-IP_ADDR=`ifconfig eth0 | grep -o "addr:[0-9][0-9][0-9]\.[0-9]*\.[0-9]*\.[0-9]*" | awk -F ":" '{print $2}'`
+IP_ADDR=`ip addr list eth0 | grep 'inet ' | cut -d' ' -f6 | cut -d'/' -f1`
 
 if [ 0 = ${INIT_DATASTORE} ]; then
     echo "Setting datastore for server at ${IP_ADDR}:${PORT}"


### PR DESCRIPTION
The original Dockerfile would not build correctly on the latest version of Docker.

In the phusion/baseimage ifconfig is not available for use.  However the ip command is available so I migrated the IP addressing command to use ip over ifconfig inside of the docker/gae-run-app.sh and docker/setup_datastore.sh scripts.

In addition, there was a build error when trying to run easy_install to get the pytest module.  I corrected the command and the image builds successfully.