### PR TITLE
Hide the photo area for note record for the create page

### DIFF
--- a/app/resources/add_note_base.html.template
+++ b/app/resources/add_note_base.html.template
@@ -195,6 +195,8 @@
           <div class="end-multi-columns"></div>
         {% endif %}
       </div>
+
+      {# Hide the photo upload fields for the note record in create form because two photo upload fields show at the same time are a bit confusing. #}
       {% if not params.create_mode %}
         {% if env.enable_photo_upload %}
           <div class="photo subsection">

--- a/app/resources/add_note_base.html.template
+++ b/app/resources/add_note_base.html.template
@@ -195,45 +195,46 @@
           <div class="end-multi-columns"></div>
         {% endif %}
       </div>
-
-      {% if env.enable_photo_upload %}
-        <div class="photo subsection">
-          <h3>Photo</h3>
-          <div class="hint">
-            {% trans "To attach a photo to this note, upload it or enter its URL." %}
+      {% if not params.create_mode %}
+        {% if env.enable_photo_upload %}
+          <div class="photo subsection">
+            <h3>Photo</h3>
+            <div class="hint">
+              {% trans "To attach a photo to this note, upload it or enter its URL." %}
+            </div>
+            <div class="field" onclick="$('note_photo_url_radio').checked=true; update_image_input(true);">
+              <span class="radio">
+                  <input id="note_photo_url_radio" type="radio"
+                      checked="checked" name="note_photo_input">
+              </span>
+              <span class="label">
+                {% trans "URL" %}:
+              </span>
+              <span class="value">
+                <input name="note_photo_url" id="note_photo_url"
+                    class="medium-text-input"
+                    value="{{params.photo_url}}" />
+              </span>
+            </div>
+            <div class="field" onclick="$('note_photo_upload_radio').checked=true; update_image_input(true);">
+              {% comment %} This td can be removed if uploading needs to be disabled {% endcomment %}
+              <span class="radio">
+                <input id="note_photo_upload_radio" type="radio"
+                    name="note_photo_input">
+              </span>
+              <span class="label">
+                {% trans "Upload" %}:
+              </span>
+              <span class="value">
+                <input class="photo-upload-input" id="note_photo_upload" type="file"
+                    name="note_photo" disabled="disabled" onchange="show_photo_remove_icon('note_photo_upload')">
+                <a href="javascript:remove_photo_upload('note_photo_upload')" id="remove_note_photo_upload" style="display: none"><img class="photo-upload-cancel" src="{{env.global_url}}/cancel.png" alt="Cancel"></a>
+              </span>
+              {% comment %} see above comment {% endcomment %}
+            </div>
+            <div class="end-multi-columns"></div>
           </div>
-          <div class="field" onclick="$('note_photo_url_radio').checked=true; update_image_input(true);">
-            <span class="radio">
-                <input id="note_photo_url_radio" type="radio"
-                    checked="checked" name="note_photo_input">
-            </span>
-            <span class="label">
-              {% trans "URL" %}:
-            </span>
-            <span class="value">
-              <input name="note_photo_url" id="note_photo_url"
-                  class="medium-text-input"
-                  value="{{params.photo_url}}" />
-            </span>
-          </div>
-          <div class="field" onclick="$('note_photo_upload_radio').checked=true; update_image_input(true);">
-            {% comment %} This td can be removed if uploading needs to be disabled {% endcomment %}
-            <span class="radio">
-              <input id="note_photo_upload_radio" type="radio"
-                  name="note_photo_input">
-            </span>
-            <span class="label">
-              {% trans "Upload" %}:
-            </span>
-            <span class="value">
-              <input class="photo-upload-input" id="note_photo_upload" type="file"
-                  name="note_photo" disabled="disabled" onchange="show_photo_remove_icon('note_photo_upload')">
-              <a href="javascript:remove_photo_upload('note_photo_upload')" id="remove_note_photo_upload" style="display: none"><img class="photo-upload-cancel" src="{{env.global_url}}/cancel.png" alt="Cancel"></a>
-            </span>
-            {% comment %} see above comment {% endcomment %}
-          </div>
-          <div class="end-multi-columns"></div>
-        </div>
+        {% endif %}
       {% endif %}
     </div>
   {% endif %}

--- a/app/resources/add_note_base.html.template
+++ b/app/resources/add_note_base.html.template
@@ -196,47 +196,46 @@
         {% endif %}
       </div>
 
-      {# Hide the photo upload fields for the note record in create form because two photo upload fields show at the same time are a bit confusing. #}
-      {% if not params.create_mode %}
-        {% if env.enable_photo_upload %}
-          <div class="photo subsection">
-            <h3>Photo</h3>
-            <div class="hint">
-              {% trans "To attach a photo to this note, upload it or enter its URL." %}
-            </div>
-            <div class="field" onclick="$('note_photo_url_radio').checked=true; update_image_input(true);">
-              <span class="radio">
-                  <input id="note_photo_url_radio" type="radio"
-                      checked="checked" name="note_photo_input">
-              </span>
-              <span class="label">
-                {% trans "URL" %}:
-              </span>
-              <span class="value">
-                <input name="note_photo_url" id="note_photo_url"
-                    class="medium-text-input"
-                    value="{{params.photo_url}}" />
-              </span>
-            </div>
-            <div class="field" onclick="$('note_photo_upload_radio').checked=true; update_image_input(true);">
-              {% comment %} This td can be removed if uploading needs to be disabled {% endcomment %}
-              <span class="radio">
-                <input id="note_photo_upload_radio" type="radio"
-                    name="note_photo_input">
-              </span>
-              <span class="label">
-                {% trans "Upload" %}:
-              </span>
-              <span class="value">
-                <input class="photo-upload-input" id="note_photo_upload" type="file"
-                    name="note_photo" disabled="disabled" onchange="show_photo_remove_icon('note_photo_upload')">
-                <a href="javascript:remove_photo_upload('note_photo_upload')" id="remove_note_photo_upload" style="display: none"><img class="photo-upload-cancel" src="{{env.global_url}}/cancel.png" alt="Cancel"></a>
-              </span>
-              {% comment %} see above comment {% endcomment %}
-            </div>
-            <div class="end-multi-columns"></div>
+      {# Hide the photo upload fields for the note record in create form #}
+      {# Two photo upload fields show at the same time are a bit confusing. #}
+      {% if not params.create_mode and env.enable_photo_upload %}
+        <div class="photo subsection">
+          <h3>Photo</h3>
+          <div class="hint">
+            {% trans "To attach a photo to this note, upload it or enter its URL." %}
           </div>
-        {% endif %}
+          <div class="field" onclick="$('note_photo_url_radio').checked=true; update_image_input(true);">
+            <span class="radio">
+                <input id="note_photo_url_radio" type="radio"
+                    checked="checked" name="note_photo_input">
+            </span>
+            <span class="label">
+              {% trans "URL" %}:
+            </span>
+            <span class="value">
+              <input name="note_photo_url" id="note_photo_url"
+                  class="medium-text-input"
+                  value="{{params.photo_url}}" />
+            </span>
+          </div>
+          <div class="field" onclick="$('note_photo_upload_radio').checked=true; update_image_input(true);">
+            {% comment %} This td can be removed if uploading needs to be disabled {% endcomment %}
+            <span class="radio">
+              <input id="note_photo_upload_radio" type="radio"
+                  name="note_photo_input">
+            </span>
+            <span class="label">
+              {% trans "Upload" %}:
+            </span>
+            <span class="value">
+              <input class="photo-upload-input" id="note_photo_upload" type="file"
+                  name="note_photo" disabled="disabled" onchange="show_photo_remove_icon('note_photo_upload')">
+              <a href="javascript:remove_photo_upload('note_photo_upload')" id="remove_note_photo_upload" style="display: none"><img class="photo-upload-cancel" src="{{env.global_url}}/cancel.png" alt="Cancel"></a>
+            </span>
+            {% comment %} see above comment {% endcomment %}
+          </div>
+          <div class="end-multi-columns"></div>
+        </div>
       {% endif %}
     </div>
   {% endif %}


### PR DESCRIPTION
Fixed the branch problem for pull request #296
Fixed issue #87 
The second photo area don't show on the initial entry page for "I want to input someone's information".
![create](https://cloud.githubusercontent.com/assets/15961861/18945504/cff4592c-8665-11e6-8885-970f9ccde6af.png)
and only show the the photo area for note record
![note](https://cloud.githubusercontent.com/assets/15961861/18945542/02ac680a-8666-11e6-88f7-b0a1e4370a88.png)
