### PR TITLE
Add name or mobile phone message when disable fulltext_search

### DIFF
--- a/app/resources/query_form.html.template
+++ b/app/resources/query_form.html.template
@@ -112,15 +112,13 @@
               class="short-text-input"
               value="{{params.query_name}}">
         {% else %}
-          {% if config.enable_fulltext_search %}
-            <span class="mandatory label">
-              {% if config.jp_mobile_carrier_redirect %}
-                {% trans "Name or mobile phone number (required)" %}:
-              {% else %}
-                {% trans "Name (required)" %}:
-              {% endif %}
-            </span>
-          {% endif %}
+          <span class="mandatory label">
+            {% if config.jp_mobile_carrier_redirect %}
+              {% trans "Name or mobile phone number (required)" %}:
+            {% else %}
+              {% trans "Name (required)" %}:
+            {% endif %}
+          </span>
           <input id="query_name" name="query_name"
               class="long-text-input"
               value="{{params.query_name}}" placeholder="{% trans 'e.g., Will Smith, Will or Smith' %}">


### PR DESCRIPTION
Fixed #311 
Show name or mobile phone message when disable fulltext_search. 

![disable fulltext search](https://cloud.githubusercontent.com/assets/15961861/19588598/c92653f0-97a1-11e6-9928-1c9507d361c5.png)
