### PR TITLE
Fix #331: App Engine SDK from Dockerfile is out-dated

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,8 +26,8 @@ RUN pip install --upgrade pip && pip install pytest lxml
 
 # Install app engine
 WORKDIR   /opt/
-ADD https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.25.zip /opt/
-RUN unzip -qq google_appengine_1.9.25.zip && rm google_appengine_1.9.25.zip
+ADD https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.50.zip /opt/
+RUN unzip -qq google_appengine_1.9.50.zip && rm google_appengine_1.9.50.zip
 
 ADD gae-run-app.sh      /usr/bin/
 ADD setup_datastore.sh  /usr/bin/


### PR DESCRIPTION
Update Google App Engine in Dockerfile image from `1.9.25` to `1.9.50`

#331 