### PR TITLE
Fix Dockerfile for development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~
 app/locale/*/LC_MESSAGES/django.mo
 tests/server_test_cases/.cache/
+.cache/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN pip install --upgrade pip && pip install pytest lxml
+RUN pip install --upgrade pip && pip install pytest lxml cssselect pillow
 
 # Install app engine
 WORKDIR   /opt/


### PR DESCRIPTION
Add `cssselect` and `pillow` to Docker image. We need them for executing tests.