### PR TITLE
Issue #344: Move the language selector to the top

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 app/locale/*/LC_MESSAGES/django.mo
 tests/server_test_cases/.cache/
 .cache/
+.idea/

--- a/app/resources/base.html.template
+++ b/app/resources/base.html.template
@@ -71,6 +71,9 @@
     onload="{{onload_function}}">
   {% block body %}
     <div class="header title-bar" role="banner">
+      {% if env.show_language_menu %}
+        {% include "language-menu.html.template" %}
+      {% endif %}
       {% block header %}
         {% if env.show_logo %}
           {% block logo %}{% endblock %}
@@ -120,10 +123,6 @@
                 Learn more about Google
                 <a href="{{privacy_policy_url}}" {{target_attr}}>Privacy Policy</a>.
               {% endblocktrans %}
-            {% endif %}
-
-            {% if env.show_language_menu %}
-              {% include "language-menu.html.template" %}
             {% endif %}
 
           {% endblock disclaimer %}

--- a/app/resources/css-default.template
+++ b/app/resources/css-default.template
@@ -177,7 +177,7 @@ div.languages {
   text-decoration: none;
   color: black;
   text-align: {{end}};
-  float: right;
+  float: {{end}};
   padding-{{end}}: 20px;
 }
 
@@ -186,7 +186,7 @@ div.languages img {
 }
 
 div.languages select {
- background: white;
+  background: white;
 }
 
 /* Repository menu */

--- a/app/resources/css-default.template
+++ b/app/resources/css-default.template
@@ -177,10 +177,15 @@ div.languages {
   text-decoration: none;
   color: black;
   text-align: {{end}};
+  float:right;
+  margin-right:5%;
 }
 
 div.languages img {
   vertical-align: text-top;
+}
+div.languages select{
+ background:white;
 }
 
 /* Repository menu */

--- a/app/resources/css-default.template
+++ b/app/resources/css-default.template
@@ -177,15 +177,16 @@ div.languages {
   text-decoration: none;
   color: black;
   text-align: {{end}};
-  float:right;
-  margin-right:5%;
+  float: right;
+  padding-{{end}}: 20px;
 }
 
 div.languages img {
   vertical-align: text-top;
 }
-div.languages select{
- background:white;
+
+div.languages select {
+ background: white;
 }
 
 /* Repository menu */


### PR DESCRIPTION
Moved the language selection section to the top navigation bar according to the comment in the issue page.

Here's the preview of the changes.
![screencapture-localhost-8000-global-home-html-1491372561964](https://cloud.githubusercontent.com/assets/7677962/24692038/cfb4a760-19f8-11e7-9be0-eb78784cfa51.png)
![screencapture-localhost-8000-haiti-1491372577621](https://cloud.githubusercontent.com/assets/7677962/24692039/d097cb12-19f8-11e7-99ca-8315c0522b85.png)
