### PR TITLE
Move the language selector below the header bars.

### DIFF
--- a/app/resources/base.html.template
+++ b/app/resources/base.html.template
@@ -71,9 +71,6 @@
     onload="{{onload_function}}">
   {% block body %}
     <div class="header title-bar" role="banner">
-      {% if env.show_language_menu %}
-        {% include "language-menu.html.template" %}
-      {% endif %}
       {% block header %}
         {% if env.show_logo %}
           {% block logo %}{% endblock %}
@@ -85,6 +82,10 @@
       <div class="subtitle-bar">
         {{env.repo_title}}
       </div>
+    {% endif %}
+
+    {% if env.show_language_menu %}
+      {% include "language-menu.html.template" %}
     {% endif %}
 
     <div class="outer-container">

--- a/app/resources/css-default.template
+++ b/app/resources/css-default.template
@@ -61,7 +61,7 @@ h3 {
   clear: both;
 }
 
-/* outer-container contains everything 
+/* outer-container contains everything
     except for the header and the side bar */
 .outer-container {
   max-width: 900px;
@@ -139,7 +139,7 @@ pre {  /* code samples */
   margin-right: 10px;
 }
 
-/* A line for separating No searching results 
+/* A line for separating No searching results
   and search results without location */
 .under-line {
   border-bottom: 2px solid #e6e6e6
@@ -177,16 +177,17 @@ div.languages {
   text-decoration: none;
   color: black;
   text-align: {{end}};
-  float: {{end}};
-  padding-{{end}}: 20px;
+  margin-top: 5px;
+  margin-{{end}}: 5px;
 }
 
 div.languages img {
-  vertical-align: text-top;
+  vertical-align: middle;
 }
 
 div.languages select {
   background: white;
+  vertical-align: middle;
 }
 
 /* Repository menu */
@@ -302,7 +303,7 @@ a.expand-button {
 
 /* Icon for the expand-button after the form is expanded */
 .expand-button-icon-up {
-  background: url({{env.global_url}}/expand-icon-up.png);  
+  background: url({{env.global_url}}/expand-icon-up.png);
   background-repeat: no-repeat;
   background-position: {{end}};
 }


### PR DESCRIPTION
Follow-up fix for #344.

#350 moved the language selector inside the header bar. But I found that it causes an issue on mobile; It gives too little space for the title. So I decided to move the language selector to just below the header bars.

Before:
![huoxpyupign](https://cloud.githubusercontent.com/assets/15363/24853084/cb92c0fc-1e14-11e7-8ead-d91e30be751f.png)

After:
![z4hosyxhlg1](https://cloud.githubusercontent.com/assets/15363/24853089/cff433a6-1e14-11e7-9966-ab0e0e35dca4.png)
