### PR TITLE
Add and fix a comment for translators.

### DIFF
--- a/app/locale/af/LC_MESSAGES/django.po
+++ b/app/locale/af/LC_MESSAGES/django.po
@@ -812,6 +812,12 @@ msgid ""
 "NTT."
 msgstr "Vir fone benewens selfone, gebruik die 171-diens van NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Vanaf: %(home_location)s"

--- a/app/locale/am/LC_MESSAGES/django.po
+++ b/app/locale/am/LC_MESSAGES/django.po
@@ -791,6 +791,12 @@ msgid ""
 "NTT."
 msgstr "ከተንቀሳቃሽ ስልክ ውጪ ለሆኑ ስልኮች እባክዎ በNTT የቀረበውን የ171 አገልግሎት ይጠቀሙ።"
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "ከ፦ %(home_location)s"

--- a/app/locale/ar/LC_MESSAGES/django.po
+++ b/app/locale/ar/LC_MESSAGES/django.po
@@ -809,6 +809,12 @@ msgstr ""
 "‏بالنسبة إلى الأرقام بخلاف الهواتف الجوالة، يرجى استخدام خدمة 171 التي "
 "تقدمها NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "من: %(home_location)s"

--- a/app/locale/az/LC_MESSAGES/django.po
+++ b/app/locale/az/LC_MESSAGES/django.po
@@ -819,6 +819,12 @@ msgstr ""
 "Mobil olmayan telefonlar üçün lütfən, NTT tərəfindən təmin edilən 171 "
 "xidmətindən istifadə edin."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Buradan: %(home_location)s"

--- a/app/locale/bg/LC_MESSAGES/django.po
+++ b/app/locale/bg/LC_MESSAGES/django.po
@@ -818,6 +818,12 @@ msgstr ""
 "За телефони, които не са мобилни, моля, използвайте предоставената от NTT"
 " услуга 171."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "От: %(home_location)s"

--- a/app/locale/bn/LC_MESSAGES/django.po
+++ b/app/locale/bn/LC_MESSAGES/django.po
@@ -820,6 +820,12 @@ msgstr ""
 "মোবাইল ফোন ছাড়া অন্য ফোনের জন্য, দয়া করে NTT কর্তৃক প্রদত্ত ১৭১ পরিষেবা "
 "ব্যবহার করুন৷"
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "এর থেকে: %(home_location)s"

--- a/app/locale/ca/LC_MESSAGES/django.po
+++ b/app/locale/ca/LC_MESSAGES/django.po
@@ -823,6 +823,12 @@ msgstr ""
 "Per a telèfons que no siguin mòbils, feu servir el servei 171 "
 "subministrat per NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Des de: %(home_location)s"

--- a/app/locale/cs/LC_MESSAGES/django.po
+++ b/app/locale/cs/LC_MESSAGES/django.po
@@ -808,6 +808,12 @@ msgstr ""
 "V případě jiných než mobilních telefonů prosím použijte službu "
 "společnosti NTT dostupnou na telefonním čísle 171."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Místo pobytu: %(home_location)s"

--- a/app/locale/da/LC_MESSAGES/django.po
+++ b/app/locale/da/LC_MESSAGES/django.po
@@ -818,6 +818,12 @@ msgstr ""
 "Brug 171-tjenesten, der leveres af NTT, hvis du ikke bruger en "
 "mobiltelefon."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Fra: %(home_location)s"

--- a/app/locale/de/LC_MESSAGES/django.po
+++ b/app/locale/de/LC_MESSAGES/django.po
@@ -822,6 +822,12 @@ msgstr ""
 "Wenn es sich um kein Mobiltelefon handelt, nutzen Sie bitte den "
 "171-Dienst von NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Aus: %(home_location)s"

--- a/app/locale/el/LC_MESSAGES/django.po
+++ b/app/locale/el/LC_MESSAGES/django.po
@@ -853,6 +853,12 @@ msgstr ""
 "Για αριθμούς τηλεφώνου εκτός από κινητά, χρησιμοποιήστε την υπηρεσία 171 "
 "που προσφέρεται από την NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Από: %(home_location)s"

--- a/app/locale/en/LC_MESSAGES/django.po
+++ b/app/locale/en/LC_MESSAGES/django.po
@@ -607,6 +607,14 @@ msgid ""
 "NTT."
 msgstr ""
 
+#. Translators: The title of a page for people who respond to disasters.
+msgid "For responders"
+msgstr ""
+
+#. Translators: The title of a page of frequently asked questions.
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr ""
@@ -1298,6 +1306,8 @@ msgstr ""
 msgid "Use current location"
 msgstr ""
 
+#. Translators: The title of the page which explains how to use
+#. Person Finder.
 msgid "User's Guide"
 msgstr ""
 

--- a/app/locale/en_GB/LC_MESSAGES/django.po
+++ b/app/locale/en_GB/LC_MESSAGES/django.po
@@ -816,6 +816,12 @@ msgstr ""
 "For phones other than mobile phones, please use 171 service provided by "
 "NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "From: %(home_location)s"

--- a/app/locale/es/LC_MESSAGES/django.po
+++ b/app/locale/es/LC_MESSAGES/django.po
@@ -835,6 +835,12 @@ msgstr ""
 "Si el número no corresponde a un teléfono móvil, utiliza el servicio que "
 "proporciona NTT a través del número 171."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "De: %(home_location)s"

--- a/app/locale/es_419/LC_MESSAGES/django.po
+++ b/app/locale/es_419/LC_MESSAGES/django.po
@@ -819,6 +819,12 @@ msgstr ""
 "En el caso de los teléfonos que no son celulares, usa el servicio que NTT"
 " ofrece a través del número 171."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "De: %(home_location)s"

--- a/app/locale/et/LC_MESSAGES/django.po
+++ b/app/locale/et/LC_MESSAGES/django.po
@@ -810,6 +810,12 @@ msgid ""
 "NTT."
 msgstr "Tavatelefonide puhul kasutage NTT pakutavat teenust 171."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Asukohast: %(home_location)s"

--- a/app/locale/eu/LC_MESSAGES/django.po
+++ b/app/locale/eu/LC_MESSAGES/django.po
@@ -816,6 +816,12 @@ msgstr ""
 "Mugikorretakoak ez diren telefono-zenbakien kasuan, erabili NTTk "
 "eskainitako 171 zerbitzua."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Kokapena: %(home_location)s"

--- a/app/locale/fa/LC_MESSAGES/django.po
+++ b/app/locale/fa/LC_MESSAGES/django.po
@@ -794,6 +794,12 @@ msgstr ""
 "‏‫برای شماره تلفن‌های غیر از تلفن‌ همراه لطفاً از سرویس ۱۷۱ ارائه شده "
 "توسط NTT استفاده کنید."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "از: %(home_location)s"

--- a/app/locale/fi/LC_MESSAGES/django.po
+++ b/app/locale/fi/LC_MESSAGES/django.po
@@ -820,6 +820,12 @@ msgid ""
 "NTT."
 msgstr "Käytä lankapuhelinnumerojen tapauksessa NTT:n 171-palvelua."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Kotipaikkakunta: %(home_location)s"

--- a/app/locale/fil/LC_MESSAGES/django.po
+++ b/app/locale/fil/LC_MESSAGES/django.po
@@ -823,6 +823,12 @@ msgstr ""
 "Para sa mga teleponong hindi mobile phone, mangyaring gamitin ang "
 "serbisyong 171 na ibinibigay ng NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Mula sa: %(home_location)s"

--- a/app/locale/fr/LC_MESSAGES/django.po
+++ b/app/locale/fr/LC_MESSAGES/django.po
@@ -831,6 +831,12 @@ msgstr ""
 "Pour les numéros de téléphone ne correspondant pas à un mobile, veuillez "
 "composer le 171 pour accéder au service de la NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "De : %(home_location)s"

--- a/app/locale/fr_CA/LC_MESSAGES/django.po
+++ b/app/locale/fr_CA/LC_MESSAGES/django.po
@@ -836,6 +836,12 @@ msgstr ""
 "Pour les numéros ne correspondant pas à un téléphone cellulaire, veuillez"
 " composer le 171 pour accéder au service de la NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "De : %(home_location)s"

--- a/app/locale/gl/LC_MESSAGES/django.po
+++ b/app/locale/gl/LC_MESSAGES/django.po
@@ -829,6 +829,12 @@ msgstr ""
 "Nos teléfonos que non sexan móbiles, utiliza o servizo 171 proporcionado "
 "por NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Desde: %(home_location)s"

--- a/app/locale/gu/LC_MESSAGES/django.po
+++ b/app/locale/gu/LC_MESSAGES/django.po
@@ -819,6 +819,12 @@ msgstr ""
 "મોબાઇલ ફોન્સ સિવાયના અન્ય ફોન્સ માટે, કૃપા કરીને NTT દ્વારા પૂરી પાડવામાં"
 " આવેલ 171 સેવાનો ઉપયોગ કરો."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "અહીંથી: %(home_location)s"

--- a/app/locale/he/LC_MESSAGES/django.po
+++ b/app/locale/he/LC_MESSAGES/django.po
@@ -795,6 +795,12 @@ msgid ""
 "NTT."
 msgstr "‏עבור טלפונים שאינם טלפונים ניידים, השתמש בשירות 171 מטעם NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "מ: %(home_location)s"

--- a/app/locale/hi/LC_MESSAGES/django.po
+++ b/app/locale/hi/LC_MESSAGES/django.po
@@ -825,6 +825,12 @@ msgstr ""
 "मोबाइल फ़ोन के अलावा अन्य फ़ोन के लिए, कृपया NTT द्वारा प्रदान की जाने "
 "वाली 171 सेवा का उपयोग करें."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "प्रेषक: %(home_location)s"

--- a/app/locale/hr/LC_MESSAGES/django.po
+++ b/app/locale/hr/LC_MESSAGES/django.po
@@ -814,6 +814,12 @@ msgid ""
 "NTT."
 msgstr "Za telefone koji nisu mobilni upotrijebite uslugu 171 tvrtke NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Prebivalište: %(home_location)s"

--- a/app/locale/ht/LC_MESSAGES/django.po
+++ b/app/locale/ht/LC_MESSAGES/django.po
@@ -768,6 +768,12 @@ msgstr ""
 "Pou telefòn ki pa telefòn mobil yo, tanpri itilize sèvis 171 ki ofri pa "
 "NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Soti nan: %(home_location)s"

--- a/app/locale/hu/LC_MESSAGES/django.po
+++ b/app/locale/hu/LC_MESSAGES/django.po
@@ -826,6 +826,12 @@ msgstr ""
 "Nem mobiltelefonok esetében, kérjük, használja az NTT által biztosított "
 "171-szolgáltatást."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "A következő helyről: %(home_location)s"

--- a/app/locale/hy/LC_MESSAGES/django.po
+++ b/app/locale/hy/LC_MESSAGES/django.po
@@ -809,6 +809,12 @@ msgstr ""
 "Հեռախոսների կամ շարժական սարքերի համար օգտագործեք NTT-ի կողմից տրամադրվող"
 " 171 ծառայությունը:"
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Ումից՝ %(home_location)s"

--- a/app/locale/id/LC_MESSAGES/django.po
+++ b/app/locale/id/LC_MESSAGES/django.po
@@ -823,6 +823,12 @@ msgid ""
 "NTT."
 msgstr "Untuk telepon selain ponsel, gunakan layanan 171 yang disediakan oleh NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Dari: %(home_location)s"

--- a/app/locale/is/LC_MESSAGES/django.po
+++ b/app/locale/is/LC_MESSAGES/django.po
@@ -829,6 +829,12 @@ msgstr ""
 "Fyrir síma sem ekki eru farsímar skaltu nota 171-þjónustuna sem NTT býður"
 " upp á."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Frá: %(home_location)s"

--- a/app/locale/it/LC_MESSAGES/django.po
+++ b/app/locale/it/LC_MESSAGES/django.po
@@ -835,6 +835,12 @@ msgstr ""
 "Per numeri diversi da quelli dei cellulari, utilizza il servizio 171 "
 "fornito da NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Da: %(home_location)s"

--- a/app/locale/ja/LC_MESSAGES/django.po
+++ b/app/locale/ja/LC_MESSAGES/django.po
@@ -788,6 +788,12 @@ msgid ""
 "NTT."
 msgstr "携帯電話以外の電話の場合は、NTT の 171 サービスをご利用ください。"
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "「%(home_location)s」から"

--- a/app/locale/jv/LC_MESSAGES/django.po
+++ b/app/locale/jv/LC_MESSAGES/django.po
@@ -806,6 +806,12 @@ msgstr ""
 "Kanggo telpon saliyane HP, gunakake layanan 171 sing disedhiyani dening "
 "NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Saka: %(home_location)s"

--- a/app/locale/ka/LC_MESSAGES/django.po
+++ b/app/locale/ka/LC_MESSAGES/django.po
@@ -833,6 +833,12 @@ msgstr ""
 "ტელეფონებისთვის, მობილური ტელეფონების გარდა, გთხოვთ, გამოიყენოთ NTT-ის "
 "მიერ უზრუნველყოფილი სერვისი 171."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "საიდან: %(home_location)s"

--- a/app/locale/kk/LC_MESSAGES/django.po
+++ b/app/locale/kk/LC_MESSAGES/django.po
@@ -821,6 +821,12 @@ msgstr ""
 "Ұялы телефоннан басқа телефондар үшін NTT компаниясы қамтамасыз еткен 171"
 " қызметін қолданыңыз."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Қайдан: %(home_location)s"

--- a/app/locale/km/LC_MESSAGES/django.po
+++ b/app/locale/km/LC_MESSAGES/django.po
@@ -835,6 +835,12 @@ msgstr ""
 "សំរាប់​ទូរស័ព្ទ​ផ្សេង​ទៀត​ជាង​ទូរស័ព្ទ​ដៃ​សូម​ប្រើ 171 សេវា​ដែល​ផ្ដល់​ដោយ"
 " NTT ។"
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "ពី៖ %(home_location)s"

--- a/app/locale/kn/LC_MESSAGES/django.po
+++ b/app/locale/kn/LC_MESSAGES/django.po
@@ -826,6 +826,12 @@ msgstr ""
 "ಮೊಬೈಲ್ ಫೋನ್‌ಗಳನ್ನು ಹೊರತುಪಡಿಸಿ ಫೋನ್‌ಗಳಿಗಾಗಿ, ದಯವಿಟ್ಟು NTT ಒದಗಿಸಿರುವ 171 "
 "ಸೇವೆಯನ್ನು ಬಳಸಿ."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "ಇಲ್ಲಿಂದ: %(home_location)s"

--- a/app/locale/ko/LC_MESSAGES/django.po
+++ b/app/locale/ko/LC_MESSAGES/django.po
@@ -783,6 +783,12 @@ msgid ""
 "NTT."
 msgstr "휴대전화가 아닌 일반 전화의 경우 NTT가 제공하는 171 서비스를 사용하세요."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "거주지: %(home_location)s"

--- a/app/locale/ky/LC_MESSAGES/django.po
+++ b/app/locale/ky/LC_MESSAGES/django.po
@@ -809,6 +809,12 @@ msgid ""
 "NTT."
 msgstr "Мобилдик эмес телефондор үчүн NTT камсыздаган 171 кызматын колдонуңуз."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Бул жерден: %(home_location)s"

--- a/app/locale/lo/LC_MESSAGES/django.po
+++ b/app/locale/lo/LC_MESSAGES/django.po
@@ -807,6 +807,12 @@ msgid ""
 "NTT."
 msgstr "ສຳລັບໂທລະສັບອື່ນໆນອກເໜືອຈາກມືຖື, ກະລຸນາໃຊ້ການບໍລິການ 171 ໂດຍ NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "ຈາກ: %(home_location)s"

--- a/app/locale/lt/LC_MESSAGES/django.po
+++ b/app/locale/lt/LC_MESSAGES/django.po
@@ -822,6 +822,12 @@ msgid ""
 "NTT."
 msgstr "Jei naudojate ne mobilųjį telefoną, naudokite 171 paslaugą, pateiktą NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Iš: %(home_location)s"

--- a/app/locale/lv/LC_MESSAGES/django.po
+++ b/app/locale/lv/LC_MESSAGES/django.po
@@ -827,6 +827,12 @@ msgstr ""
 "Tālruņiem, kas nav mobilie tālruņi, lūdzu, izmantojiet pakalpojumu 171, "
 "ko nodrošina NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "No: %(home_location)s"

--- a/app/locale/mk/LC_MESSAGES/django.po
+++ b/app/locale/mk/LC_MESSAGES/django.po
@@ -830,6 +830,12 @@ msgstr ""
 "За телефони различни од мобилни телефони, ве молиме користете ја услугата"
 " 171 што ја обезбедува NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Од: %(home_location)s"

--- a/app/locale/ml/LC_MESSAGES/django.po
+++ b/app/locale/ml/LC_MESSAGES/django.po
@@ -838,6 +838,12 @@ msgid ""
 "NTT."
 msgstr "മൊബൈൽ ഫോൺ ഒഴികെയുള്ള ഫോണുകൾക്കായി, NTT നൽകുന്ന 171 സേവനം ഉപയോഗിക്കുക."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "ഇവിടെ നിന്ന്: %(home_location)s"

--- a/app/locale/mn/LC_MESSAGES/django.po
+++ b/app/locale/mn/LC_MESSAGES/django.po
@@ -811,6 +811,12 @@ msgid ""
 "NTT."
 msgstr "Гар утаснаас бусад утасны хувьд NTT-н 171 үйлчилгээг ашиглана уу."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Хаанаас: %(home_location)s"

--- a/app/locale/mr/LC_MESSAGES/django.po
+++ b/app/locale/mr/LC_MESSAGES/django.po
@@ -828,6 +828,12 @@ msgstr ""
 "मोबाईल फोन व्यतिरिक्त फोनसाठी, कृपया NTT द्वारे प्रदान केलेली 171 सेवा "
 "वापरा."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "यापासून: %(home_location)s"

--- a/app/locale/ms/LC_MESSAGES/django.po
+++ b/app/locale/ms/LC_MESSAGES/django.po
@@ -826,6 +826,12 @@ msgstr ""
 "Untuk telefon selain telefon mudah alih, sila gunakan perkhidmatan 171 "
 "yang disediakan oleh NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Dari: %(home_location)s"

--- a/app/locale/my/LC_MESSAGES/django.po
+++ b/app/locale/my/LC_MESSAGES/django.po
@@ -842,6 +842,12 @@ msgstr ""
 "မိုဘိုင္းမဟုတ္ေသာဖုန္းမ်ားအတြက္၊ ေက်းဇူၿပဳ၍ NTT မွ၀န္ေဆာင္မႈေပးေသာ 171 \n"
 "ဆားဗစ္အား သံုးပါ။"
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "မှ − %(home_location)s"

--- a/app/locale/ne/LC_MESSAGES/django.po
+++ b/app/locale/ne/LC_MESSAGES/django.po
@@ -784,6 +784,12 @@ msgstr ""
 "मोबाइल फोन बाहेकका फोनहरूका लागि कृपया NTT ले प्रदान गरेको १७१ सेवा "
 "प्रयोग गर्नुहोस्।"
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "निम्न स्थानबाट: %(home_location)s"

--- a/app/locale/nl/LC_MESSAGES/django.po
+++ b/app/locale/nl/LC_MESSAGES/django.po
@@ -834,6 +834,12 @@ msgstr ""
 "Voor andere telefoons dan mobiele telefoons moet u de 171-service "
 "gebruiken die wordt geleverd door NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Van: %(home_location)s"

--- a/app/locale/no/LC_MESSAGES/django.po
+++ b/app/locale/no/LC_MESSAGES/django.po
@@ -819,6 +819,12 @@ msgid ""
 "NTT."
 msgstr "For andre telefoner enn mobiltelefoner kan du bruke 171-tjenesten fra NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Fra: %(home_location)s"

--- a/app/locale/pa/LC_MESSAGES/django.po
+++ b/app/locale/pa/LC_MESSAGES/django.po
@@ -803,6 +803,12 @@ msgstr ""
 "ਕ੍ਰਿਪਾ, ਫੋਨ ਲਈ ਹੋਰ ਮੋਬਾਇਲ ਫੋਨ ਤੋਂ ਇਲਾਵਾ, 171 ਏਨਟੀਟੀ ਦੁਆਰਾ ਪ੍ਰਦਾਨ ਕੀਤੀ "
 "ਸੇਵਾ ਦਾ ਵਰਤੋ ਕਰੋ"
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "ਇਸ ਤੋਂ: %(home_location)s"

--- a/app/locale/pl/LC_MESSAGES/django.po
+++ b/app/locale/pl/LC_MESSAGES/django.po
@@ -829,6 +829,12 @@ msgstr ""
 "W przypadku telefonów innych niż komórkowe skorzystaj z usługi 171 "
 "świadczonej przez firmę NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Z: %(home_location)s"

--- a/app/locale/prs/LC_MESSAGES/django.po
+++ b/app/locale/prs/LC_MESSAGES/django.po
@@ -597,6 +597,12 @@ msgid ""
 "NTT."
 msgstr ""
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr ""

--- a/app/locale/ps/LC_MESSAGES/django.po
+++ b/app/locale/ps/LC_MESSAGES/django.po
@@ -594,6 +594,12 @@ msgid ""
 "NTT."
 msgstr ""
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr ""

--- a/app/locale/ps1/LC_MESSAGES/django.po
+++ b/app/locale/ps1/LC_MESSAGES/django.po
@@ -823,6 +823,12 @@ msgstr ""
 "För þĥöñéš öţĥér ţĥåñ möbîļé þĥöñéš, þļéåšé ûšé 171 šérvîçé þrövîðéð bý "
 "ÑŢŢ."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Fröm: ᐅ%(home_location)sᐊ"

--- a/app/locale/pt_BR/LC_MESSAGES/django.po
+++ b/app/locale/pt_BR/LC_MESSAGES/django.po
@@ -812,6 +812,12 @@ msgstr ""
 "Para outros telefones que não celulares, use o serviço 171 oferecido pela"
 " NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "De: %(home_location)s"

--- a/app/locale/pt_PT/LC_MESSAGES/django.po
+++ b/app/locale/pt_PT/LC_MESSAGES/django.po
@@ -822,6 +822,12 @@ msgstr ""
 "Para telefones que não sejam telemóveis, utilize o serviço 171 fornecido "
 "pela NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "De: %(home_location)s"

--- a/app/locale/ro/LC_MESSAGES/django.po
+++ b/app/locale/ro/LC_MESSAGES/django.po
@@ -838,6 +838,12 @@ msgstr ""
 "Pentru alte telefoane decât cele mobile, utilizați serviciul 171 oferit "
 "de NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Din: %(home_location)s"

--- a/app/locale/ru/LC_MESSAGES/django.po
+++ b/app/locale/ru/LC_MESSAGES/django.po
@@ -803,6 +803,12 @@ msgstr ""
 "Если указанный номер не является номером мобильного телефона, наберите "
 "171 (услуга предоставляется оператором NTT)."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Адрес: %(home_location)s"

--- a/app/locale/si/LC_MESSAGES/django.po
+++ b/app/locale/si/LC_MESSAGES/django.po
@@ -809,6 +809,12 @@ msgstr ""
 "ජංගම දුරකථන හැර වෙනත් දුරකථන සඳහා NTT මගින් සපයන ලද 171 සේවාව භාවිතා "
 "කරන්න."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "සිට: %(home_location)s"

--- a/app/locale/sk/LC_MESSAGES/django.po
+++ b/app/locale/sk/LC_MESSAGES/django.po
@@ -819,6 +819,12 @@ msgstr ""
 "V prípade iných ako mobilných telefónov použite službu spoločnosti NTT "
 "dostupnú na telefónnom čísle 171."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Pôvod: %(home_location)s"

--- a/app/locale/sl/LC_MESSAGES/django.po
+++ b/app/locale/sl/LC_MESSAGES/django.po
@@ -817,6 +817,12 @@ msgid ""
 "NTT."
 msgstr "Za vse telefone, razen mobilnih, uporabite storitev 171 podjetja NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Iz: %(home_location)s"

--- a/app/locale/sq/LC_MESSAGES/django.po
+++ b/app/locale/sq/LC_MESSAGES/django.po
@@ -794,6 +794,12 @@ msgstr ""
 "Për numra të tjerë telefonikë, ndryshe nga celularët, ju lutemi përdorni "
 "shërbimin 171 të ofruar nga NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Nga: %(home_location)s"

--- a/app/locale/sr/LC_MESSAGES/django.po
+++ b/app/locale/sr/LC_MESSAGES/django.po
@@ -812,6 +812,12 @@ msgid ""
 "NTT."
 msgstr "За телефоне који нису мобилни користите услугу 171 коју пружа NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Из: %(home_location)s"

--- a/app/locale/su/LC_MESSAGES/django.po
+++ b/app/locale/su/LC_MESSAGES/django.po
@@ -815,6 +815,12 @@ msgstr ""
 "Kanggo telepon salain tina handphone, mangga anggo layanan 171 anu "
 "disayogikeun ku NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Ti: %(home_location)s"

--- a/app/locale/sv/LC_MESSAGES/django.po
+++ b/app/locale/sv/LC_MESSAGES/django.po
@@ -832,6 +832,12 @@ msgid ""
 "NTT."
 msgstr "För andra telefoner än mobiltelefoner använder du 171-tjänsten från NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Från: %(home_location)s"

--- a/app/locale/sw/LC_MESSAGES/django.po
+++ b/app/locale/sw/LC_MESSAGES/django.po
@@ -815,6 +815,12 @@ msgstr ""
 "Kwa simu nyingine zisizo simu za mkononi, tafadhali tumia huduma ya 171 "
 "inayotolewa na NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Kutoka: %(home_location)s"

--- a/app/locale/ta/LC_MESSAGES/django.po
+++ b/app/locale/ta/LC_MESSAGES/django.po
@@ -832,6 +832,12 @@ msgid ""
 "NTT."
 msgstr "மொபைல் அல்லாத தொலைபேசிகளுக்கு, NTT வழங்கும் 171 சேவையைப் பயன்படுத்தவும்."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "இருப்பிடம்: %(home_location)s"

--- a/app/locale/te/LC_MESSAGES/django.po
+++ b/app/locale/te/LC_MESSAGES/django.po
@@ -822,6 +822,12 @@ msgstr ""
 "మొబైల్ ఫోన్‌లు కాని ఇతర ఫోన్‌‍ల కోసం, దయచేసి NIT అందిస్తోన్న 171 సేవను "
 "ఉపయోగించండి."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "ఇక్కడి నుండి: %(home_location)s"

--- a/app/locale/th/LC_MESSAGES/django.po
+++ b/app/locale/th/LC_MESSAGES/django.po
@@ -811,6 +811,12 @@ msgstr ""
 "สำหรับโทรศัพท์อื่นๆ นอกเหนือจากโทรศัพท์มือถือ โปรดใช้บริการ 171 "
 "ที่ให้บริการโดย NTT"
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "จาก %(home_location)s"

--- a/app/locale/tr/LC_MESSAGES/django.po
+++ b/app/locale/tr/LC_MESSAGES/django.po
@@ -830,6 +830,12 @@ msgstr ""
 "Cep telefonu dışındaki numaralar için lütfen NTT tarafından sağlanan 171 "
 "hizmetini kullanın."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Yaşadığı yer: %(home_location)s"

--- a/app/locale/uk/LC_MESSAGES/django.po
+++ b/app/locale/uk/LC_MESSAGES/django.po
@@ -816,6 +816,12 @@ msgstr ""
 "Для дзвінків зі стаціонарних телефонів використовуйте службу 171 компанії"
 " NTT."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Місцезнаходження: %(home_location)s"

--- a/app/locale/ur/LC_MESSAGES/django.po
+++ b/app/locale/ur/LC_MESSAGES/django.po
@@ -814,6 +814,12 @@ msgstr ""
 "‏موبائل فونز کے علاوہ فونز کیلئے، براہ کرم NTT کے ذریعہ فراہم کردہ 171 "
 "سروس کا استعمال کریں۔"
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "اس سے: %(home_location)s"

--- a/app/locale/uz/LC_MESSAGES/django.po
+++ b/app/locale/uz/LC_MESSAGES/django.po
@@ -823,6 +823,12 @@ msgstr ""
 "Qo‘l telefonlaridan boshqa telefonlar uchun NTTning 171 xizmatidan "
 "foydalaning."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Manzili: %(home_location)s"

--- a/app/locale/vi/LC_MESSAGES/django.po
+++ b/app/locale/vi/LC_MESSAGES/django.po
@@ -811,6 +811,12 @@ msgstr ""
 "Đối với điện thoại không phải là điện thoại di động, vui lòng sử dụng "
 "dịch vụ 171 do NTT cung cấp."
 
+msgid "For responders"
+msgstr ""
+
+msgid "Frequently asked questions"
+msgstr ""
+
 #, python-format
 msgid "From: %(home_location)s"
 msgstr "Từ: %(home_location)s"

--- a/app/resources/base.html.template
+++ b/app/resources/base.html.template
@@ -155,8 +155,12 @@
               {{env.target_attr|safe}}>{% trans "Developers" %}</a>
           <span class="link-separator"></span>
         {% endif %}
-        <a href="{{env.global_url}}/howto.html"
-            {{env.target_attr|safe}}>{% trans "User's Guide" %}</a>
+        <a href="{{env.global_url}}/howto.html" {{env.target_attr|safe}}
+            {% comment %}
+              Translators: The title of the page which explains how to use
+              Person Finder.
+            {% endcomment %}
+            >{% trans "User's Guide" %}</a>
         <span class="link-separator"></span>
         <a href="{{env.global_url}}/tos" {{env.target_attr|safe}}
             >{% trans "Terms of Service" %}</a>

--- a/app/resources/static-base.html.template
+++ b/app/resources/static-base.html.template
@@ -55,10 +55,10 @@
         {{env.target_attr|safe}}>{% trans "Feedback" %}</a>
     <span class="link-separator"></span>
     {% if env.ui != "light" %}
-      {% comment %}
-        Translators: The title of a page of frequently asked questions.
-      {% endcomment %}
       <a href="http://support.google.com/personfinder/?hl={{env.lang}}"
+          {% comment %}
+            Translators: The title of a page of frequently asked questions.
+          {% endcomment %}
           >{% trans "Frequently asked questions" %}</a>
       <span class="link-separator"></span>
       {% comment %}
@@ -70,8 +70,12 @@
           {{env.target_attr|safe}}>{% trans "Developers" %}</a>
       <span class="link-separator"></span>
     {% endif %}
-    <a href="{{env.global_url}}/howto.html"
-       {{env.target_attr|safe}}>{% trans "User's Guide" %}</a>
+    <a href="{{env.global_url}}/howto.html" {{env.target_attr|safe}}
+        {% comment %}
+          Translators: The title of the page which explains how to use
+          Person Finder.
+        {% endcomment %}
+        >{% trans "User's Guide" %}</a>
     <span class="link-separator"></span>
     <a href="{{env.global_url}}/tos" {{env.target_attr|safe}}
         >{% trans "Terms of Service" %}</a>


### PR DESCRIPTION
The comment for "Frequently asked questions" didn't take effect because it was not on the previous line of {%trans%} tag.