### PR TITLE
Fix layout of the map section.

### DIFF
--- a/app/resources/add_note_base.html.template
+++ b/app/resources/add_note_base.html.template
@@ -169,14 +169,13 @@
           {% endif %}
         </div>
         <div class="field">
-            <textarea name="last_known_location"
-                id="clickable_map_location_field"
-                class="long-text-input"
-                rows=2>{{params.last_known_location}}</textarea>
+          <textarea name="last_known_location"
+              id="clickable_map_location_field"
+              class="long-text-input"
+              rows=2>{{params.last_known_location}}</textarea>
         </div>
-        <div class="end-multi-columns"></div>
         {% if env.enable_javascript and env.maps_api_key %}
-          <div class="field map-container">
+          <div class="map-container">
             <div>
               <span id="clickable_map_show_link">
                 <a href='#' onclick="toggleClickableMap('clickable_map'); return false;">
@@ -199,8 +198,8 @@
             </div>
             <div id="clickable_map" class="map" style="display: none"></div>
           </div>
-          <div class="end-multi-columns"></div>
         {% endif %}
+        <div class="end-multi-columns"></div>
       </div>
 
       {# Hide the photo upload fields for the note record in create form #}


### PR DESCRIPTION
#363

Remove "field" class from the map-container so that "display: flex" (applied for "field" class, which layouts its children horizontally) is not applied to the map-container.

Also applied minor HTML clean up.

Before: https://goo.gl/photos/ChASwkn3Mfq6mNvq7
After: 
![lfr6ml5ubb9](https://user-images.githubusercontent.com/15363/29405770-df6e5ee0-8379-11e7-9003-24e9a4ad3d18.png)
