### PR TITLE
Add temporary Japanese translations.

### DIFF
--- a/app/locale/ja/LC_MESSAGES/django.po
+++ b/app/locale/ja/LC_MESSAGES/django.po
@@ -789,10 +789,10 @@ msgid ""
 msgstr "携帯電話以外の電話の場合は、NTT の 171 サービスをご利用ください。"
 
 msgid "For responders"
-msgstr ""
+msgstr "災害対応者向け情報"
 
 msgid "Frequently asked questions"
-msgstr ""
+msgstr "よくある質問"
 
 #, python-format
 msgid "From: %(home_location)s"
@@ -1486,7 +1486,7 @@ msgid "Use current location"
 msgstr "現在位置を使う"
 
 msgid "User's Guide"
-msgstr ""
+msgstr "活用ガイド"
 
 msgid "View the record"
 msgstr "記録を見る"


### PR DESCRIPTION
Because we want the site to look good in Japanese in the preparedness week in Japan (from Aug 28), and I'm not confident if we can get translation by translators by then.