### PR TITLE
Fix server test failure

### DIFF
--- a/app/delete.py
+++ b/app/delete.py
@@ -57,11 +57,11 @@ def get_restore_url(handler, person, ttl=3*24*3600):
     """Returns a URL to be used for restoring a deleted person record.
     The default TTL for a restoration URL is 3 days."""
     key_name = person.key().name()
-    data = 'restore:%s' % key_name 
+    data = 'restore:%s' % key_name
     token = reveal.sign(data, ttl)
     if person.is_original():
         return handler.get_url('/restore', token=token, id=key_name)
-    else: 
+    else:
         return None
 
 def delete_person(handler, person, send_notices=True):
@@ -125,7 +125,7 @@ class Handler(utils.BaseHandler):
             return self.error(400, 'No person with ID: %r' % self.params.id)
 
         captcha_response = self.get_captcha_response()
-        if self.env.test_mode or captcha_response.is_valid:
+        if captcha_response.is_valid:
             # Log the user action.
             model.UserActionLog.put_new(
                 'delete', person, self.request.get('reason_for_deletion'))

--- a/app/disable_notes.py
+++ b/app/disable_notes.py
@@ -60,7 +60,7 @@ class Handler(utils.BaseHandler):
             return self.error(400, 'No person with ID: %r' % self.params.id)
 
         captcha_response = self.get_captcha_response()
-        if self.env.test_mode or captcha_response.is_valid:
+        if captcha_response.is_valid:
             disable_notes_url = get_disable_notes_url(self, person)
             # To make debug with local dev_appserver easier.
             logging.info('Disable notes URL: %s' % disable_notes_url)

--- a/app/enable_notes.py
+++ b/app/enable_notes.py
@@ -52,7 +52,7 @@ class Handler(utils.BaseHandler):
             return self.error(400, 'No person with ID: %r' % self.params.id)
 
         captcha_response = self.get_captcha_response()
-        if self.env.test_mode or captcha_response.is_valid:
+        if captcha_response.is_valid:
             enable_notes_url = get_enable_notes_url(self, person)
             utils.send_confirmation_email_to_record_author(self,
                                                            person,

--- a/app/extend.py
+++ b/app/extend.py
@@ -27,17 +27,17 @@ EXPIRED_EXTENSION_DAYS = 60
 
 def get_extension_days(handler):
     return handler.config.default_extension_days or EXPIRED_EXTENSION_DAYS
-    
+
 
 class Handler(utils.BaseHandler):
     """Handles a user request to extend expiration of a person record."""
 
-    def show_page(self, person, error_code=None): 
+    def show_page(self, person, error_code=None):
         self.render('extend.html',
                     person=person,
                     view_url=self.get_url('/view', id=self.params.id),
                     captcha_html=self.get_captcha_html(error_code=error_code))
-        
+
     def get(self):
         """Prompts the user with a Turing test before carrying out extension."""
         person = model.Person.get(self.repo, self.params.id)
@@ -52,7 +52,7 @@ class Handler(utils.BaseHandler):
             return self.error(400, 'No person with ID: %r' % self.params.id)
 
         captcha_response = self.get_captcha_response()
-        if self.env.test_mode or captcha_response.is_valid:
+        if captcha_response.is_valid:
             # Log the user action.
             if person.is_original():
                 model.UserActionLog.put_new('extend', person)
@@ -68,7 +68,7 @@ class Handler(utils.BaseHandler):
                     expiry_datetime_local_string = self.to_formatted_local_datetime(
                         person.expiry_date),
                     view_url=self.get_url('/view', id=person.record_id))
-            else: 
+            else:
                 # this shouldn't happen in normal work flow.
                 return self.info(200, _('The record cannot be extended.',))
         else:

--- a/app/flag_note.py
+++ b/app/flag_note.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from google.appengine.ext import db
-from recaptcha.client import captcha 
+from recaptcha.client import captcha
 
 import model
 import reveal
@@ -49,7 +49,7 @@ class Handler(utils.BaseHandler):
             return self.error(400, 'No note with ID: %r' % self.params.id)
 
         captcha_response = note.hidden and self.get_captcha_response()
-        if not note.hidden or captcha_response.is_valid or self.env.test_mode:
+        if not note.hidden or captcha_response.is_valid:
             note.hidden = not note.hidden
             # When "hidden" changes, update source_date and entry_date (melwitt)
             # http://code.google.com/p/googlepersonfinder/issues/detail?id=58

--- a/app/main.py
+++ b/app/main.py
@@ -350,10 +350,6 @@ def setup_env(request):
     env = utils.Struct()
     env.repo, env.action = get_repo_and_action(request)
     env.config = config.Configuration(env.repo or '*')
-    # TODO(ryok): Rename to local_test_mode or something alike to disambiguate
-    # better from repository's test_mode.
-    env.test_mode = (request.remote_addr == '127.0.0.1' and
-                     request.get('test_mode'))
 
     env.analytics_id = config.get('analytics_id')
     env.maps_api_key = config.get('maps_api_key')

--- a/app/restore.py
+++ b/app/restore.py
@@ -29,7 +29,7 @@ from django.utils.translation import ugettext as _
 RESTORED_RECORD_TTL = datetime.timedelta(60, 0, 0)
 
 
-class RestoreError(Exception): 
+class RestoreError(Exception):
     """Container for user-facing error messages about the restore operation."""
     pass
 
@@ -49,19 +49,19 @@ class Handler(utils.BaseHandler):
 
         self.render('restore.html',
                     captcha_html=self.get_captcha_html(),
-                    token=token, 
+                    token=token,
                     id=self.params.id)
 
     def post(self):
         """If the Turing test response is valid, restores the record by setting
         its expiry date into the future.  Otherwise, offer another test."""
-        try: 
+        try:
             person, token = self.get_person_and_verify_params()
         except RestoreError, err:
             return self.error(400, unicode(err))
 
         captcha_response = self.get_captcha_response()
-        if not captcha_response.is_valid and not self.env.test_mode:
+        if not captcha_response.is_valid:
             captcha_html = self.get_captcha_html(captcha_response.error_code)
             self.render('restore.html',
                         captcha_html=captcha_html,
@@ -92,13 +92,13 @@ class Handler(utils.BaseHandler):
             )
 
         self.redirect(record_url)
-        
+
     def get_person_and_verify_params(self):
         """Checks the request for a valid person id and valid crypto token.
 
         Returns a tuple containing: (person, token)
-            
-        If there is an error we raise a RestoreError, instead of pretending 
+
+        If there is an error we raise a RestoreError, instead of pretending
         we're using C."""
         person = model.Person.get_by_key_name(self.params.id)
         if not person:

--- a/app/reveal.py
+++ b/app/reveal.py
@@ -107,7 +107,7 @@ class Handler(BaseHandler):
 
     def post(self):
         captcha_response = self.get_captcha_response()
-        if captcha_response.is_valid or self.env.test_mode:
+        if captcha_response.is_valid:
             signature = sign(self.params.content_id)
             # self.params.target contains only the path part of the URL e.g.,
             # "/test/view?...".

--- a/app/subscribe.py
+++ b/app/subscribe.py
@@ -172,7 +172,7 @@ class Handler(BaseHandler):
 
         # Check the captcha
         captcha_response = self.get_captcha_response()
-        if not captcha_response.is_valid and not self.env.test_mode:
+        if not captcha_response.is_valid:
             # Captcha is incorrect
             captcha_html = self.get_captcha_html(captcha_response.error_code)
             site_key = config.get('captcha_site_key')

--- a/app/utils.py
+++ b/app/utils.py
@@ -834,6 +834,13 @@ class BaseHandler(webapp.RequestHandler):
     def get_captcha_response(self):
         """Returns an object containing the CAPTCHA response information for the
         given request's CAPTCHA field information."""
+        # Allows faking the CAPTCHA response by an HTTP request parameter, but
+        # only locally, for testing purpose.
+        faked_captcha_response = self.request.get('faked_captcha_response')
+        if faked_captcha_response and self.request.remote_addr == '127.0.0.1':
+            return captcha.RecaptchaResponse(
+                is_valid=faked_captcha_response == 'success')
+
         captcha_response = self.request.get('g-recaptcha-response')
         return captcha.submit(captcha_response)
 


### PR DESCRIPTION
#362

I believe the recent failure was because reCAPTCHA server slightly changed its behavior. Looks like it returned failure on the dummy API key + empty request before, but now it returns success.

But anyway we shouldn't rely on the real server's response because we want to fake the response.

So I replaced "test_mode" parameter with "faked_captcha_response" parameter, which allows faking a failure response as well as success.

Also, the faking is now done in utils.BaseHandler.get_captcha_response(). So it's no longer necessary for each handler to check env.test_mode.