### PR TITLE
Fix a bug that an extra whitespace is inserted to the display query.

### DIFF
--- a/app/results.py
+++ b/app/results.py
@@ -258,8 +258,9 @@ class Handler(BaseHandler):
                         # search result not based on the user input
                         results_based_on_input = False
 
-            concatenated_query = ('%s %s' % (self.params.query_name,
-                                 self.params.query_location))
+            concatenated_query = (
+                ('%s %s' % (self.params.query_name, self.params.query_location))
+                    .strip())
 
             # Show the (possibly empty) matches.
             return self.render('results.html',


### PR DESCRIPTION
Before: Search results for: "ichikawa "
After: Search results for: "ichikawa"