### PR TITLE
AMP Variable for Google Analytics ID implementation

### DIFF
--- a/app/resources/base.html.template
+++ b/app/resources/base.html.template
@@ -110,6 +110,7 @@
     {% if env.amp and env.enable_analytics %}
       <amp-analytics config="https://www.googletagmanager.com/amp.json?id={{config.amp_analytics_id}}"
                      data-credentials="include">
+        //AMP variable for dynamic GA property setting
         <script type="application/json">
         {
           "vars": {

--- a/app/resources/base.html.template
+++ b/app/resources/base.html.template
@@ -109,7 +109,15 @@
   {% block body %}
     {% if env.amp and env.enable_analytics %}
       <amp-analytics config="https://www.googletagmanager.com/amp.json?id={{config.amp_analytics_id}}"
-                     data-credentials="include"></amp-analytics>
+                     data-credentials="include">
+        <script type="application/json">
+        {
+          "vars": {
+          "gaProperty": "{{env.analytics_id}}"
+          }
+        }
+  </script> 
+      </amp-analytics>
     {% endif %}
     <div class="header title-bar" role="banner">
       {% block header %}


### PR DESCRIPTION
Right now AMP GTM variable is not implemented to capture Google Analytics ID.
We should implement it to allow dynamic GA property ID implementation.