### PR TITLE
gtm.html.template includes event type by default

### DIFF
--- a/app/resources/gtm.html.template
+++ b/app/resources/gtm.html.template
@@ -19,8 +19,7 @@
       var num_results = '{{num_results}}';
       if (num_results != '') {
 	dataLayer.push({
-	  'num_results': num_results,
-	  'event': 'search'
+	  'num_results': num_results
         });
       }
     } catch(err) {


### PR DESCRIPTION
gtm.html.template is including "event" parameter by default so the "search" event tag fires automatically regardless the event action. So removing the event type from the template required.