### PR TITLE
Update unit_tests.py to not change pytest option parsing.

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -37,11 +37,11 @@ os.environ['APPLICATION_ID'] = 'personfinder-unittest'
 os.chdir(os.environ['APP_DIR'])
 
 # ...but we want pytest to default to finding tests in TESTS_DIR, not the cwd.
-# So, when no arguments are given, we make the option parser return TESTS_DIR.
-import _pytest.config
-original_parse_setoption = _pytest.config.Parser.parse_setoption
-_pytest.config.Parser.parse_setoption = (lambda *args, **kwargs: 
-    original_parse_setoption(*args, **kwargs) or [os.environ['TESTS_DIR']])
+# So, when no arguments besides options are given, we add TESTS_DIR to the list
+# of options passed to pytest.
+args = sys.argv[1:]
+if all([arg.startswith('-') for arg in args]):
+  args += [os.environ['TESTS_DIR']]
 
 # Run the tests, using sys.exit to set exit status (nonzero for failure).
-sys.exit(pytest.main())
+sys.exit(pytest.main(args))


### PR DESCRIPTION
unit_tests.py previously changed an internal pytest option parsing
function, as a way of using the TESTS_DIR directory by default. pytest
now has a way to be called programmatically with arguments:
https://docs.pytest.org/en/latest/usage.html#calling-pytest-from-python-code
So the unit tests script can just check if any of the command-line
arguments are a test directory or something else to test (vs. just
options like --tb=short) and, if none of them are, add TESTS_DIR as a
default. Then that list of arguments can be passed to pytest.main.