### PR TITLE
Scrollbars for code snippets.

### DIFF
--- a/app/resources/css-default.template
+++ b/app/resources/css-default.template
@@ -101,6 +101,7 @@ pre {  /* code samples */
   border: 1px solid #dadada;
   margin: 0 2em;
   padding: 1em;
+  overflow: auto;
   font-size: 12px;
 }
 


### PR DESCRIPTION
To address issue #357 by putting scrollbars on code snippet elements when it
would overflow. Tested with the global/responders.html page in Chrome (via the
mobile emulator in Developer Tools).