### PR TITLE
Center action buttons on repo homepage.

### DIFF
--- a/app/resources/css-default.template
+++ b/app/resources/css-default.template
@@ -612,12 +612,15 @@ td.submit {
   line-height: 10px;
 }
 
+/* We want to display the "I have info"/"I'm seeking info" buttons side-by-side
+   on desktop, but stacked on top of each other on mobile, so we have an extra
+   couple CSS rules for larger screens. */
 @media (min-width: 700px) {
   .main .action-wrapper {
     display: inline-block;
   }
   .main .action-outer {
-    float: left;
+    display: inline-block;
     margin: 10px;
   }
 }

--- a/app/resources/css-default.template
+++ b/app/resources/css-default.template
@@ -552,10 +552,6 @@ td.submit {
   text-align: center;
 }
 
-.action-wrapper {
-  text-align: center;
-}
-
 .main .action-outer {
   border: none;
   font-size: 20px;
@@ -616,9 +612,6 @@ td.submit {
    on desktop, but stacked on top of each other on mobile, so we have an extra
    couple CSS rules for larger screens. */
 @media (min-width: 700px) {
-  .main .action-wrapper {
-    display: inline-block;
-  }
   .main .action-outer {
     display: inline-block;
     margin: 10px;

--- a/app/resources/css-default.template
+++ b/app/resources/css-default.template
@@ -544,6 +544,7 @@ td.submit {
 
 .main .row {
   margin: 24px;
+  text-align: center;
 }
 
 .main .stats {
@@ -551,11 +552,14 @@ td.submit {
   text-align: center;
 }
 
+.action-wrapper {
+  text-align: center;
+}
+
 .main .action-outer {
   border: none;
   font-size: 20px;
   margin-bottom: 1em;
-  margin-{{start}}: 40px;
   max-width: 240px;
   min-height: 70px;
   padding: 16px;
@@ -569,15 +573,16 @@ td.submit {
   text-decoration: none;
 }
 
+.main .action-outer {
+  margin: 0 auto 10px;
+}
+
 .main .action-outer.start {
   background: #4285f4;
-  float: {{start}};
-  margin-{{end}}: 18px;
 }
 
 .main .action-outer.end {
   background: #15a04a;
-  float: {{start}};
 }
 
 .main .action-inner {
@@ -605,6 +610,16 @@ td.submit {
   /* A trick to align all social share buttons vertically.
      https://stackoverflow.com/a/21919504/4339963 */
   line-height: 10px;
+}
+
+@media (min-width: 700px) {
+  .main .action-wrapper {
+    display: inline-block;
+  }
+  .main .action-outer {
+    float: left;
+    margin: 10px;
+  }
 }
 
 /* Query page */

--- a/app/resources/start.html.template
+++ b/app/resources/start.html.template
@@ -29,31 +29,33 @@
 
     <div class="main">
       <div class="row">
-        {# Following onclick is to make the whole button clickable. #}
-        <div class="action-outer start"
-          {% if not env.amp %}
-            onclick="location.href = '{{seek_url}}';" style="cursor: pointer;"
-          {% endif %}
-        >
-          <div class="action-inner">
-            <a href="{{seek_url}}" tabindex="1">
-              {% trans "I'm looking for someone" %}
-            </a>
+        <div class="action-wrapper">
+          {# Following onclick is to make the whole button clickable. #}
+          <div class="action-outer start"
+            {% if not env.amp %}
+              onclick="location.href = '{{seek_url}}';" style="cursor: pointer;"
+            {% endif %}
+          >
+            <div class="action-inner">
+              <a href="{{seek_url}}" tabindex="1">
+                {% trans "I'm looking for someone" %}
+              </a>
+            </div>
           </div>
-        </div>
-        {# Following onclick is to make the whole button clickable. #}
-        <div class="action-outer end"
-          {% if not env.amp %}
-            onclick="location.href = '{{provide_url}}';" style="cursor: pointer;"
-          {% endif %}
-        >
-          <div class="action-inner">
-            <a href="{{provide_url}}" tabindex="2">
-              {% trans "I have information about someone" %}
-            </a>
+          {# Following onclick is to make the whole button clickable. #}
+          <div class="action-outer end"
+            {% if not env.amp %}
+              onclick="location.href = '{{provide_url}}';" style="cursor: pointer;"
+            {% endif %}
+          >
+            <div class="action-inner">
+              <a href="{{provide_url}}" tabindex="2">
+                {% trans "I have information about someone" %}
+              </a>
+            </div>
           </div>
-        </div>
-        <div class="end-multi-columns"></div>
+          <div class="end-multi-columns"></div>
+	</div>
       </div>
       <div class="row stats">
         {% if num_people %}

--- a/app/resources/start.html.template
+++ b/app/resources/start.html.template
@@ -29,33 +29,31 @@
 
     <div class="main">
       <div class="row">
-        <div class="action-wrapper">
-          {# Following onclick is to make the whole button clickable. #}
-          <div class="action-outer start"
-            {% if not env.amp %}
-              onclick="location.href = '{{seek_url}}';" style="cursor: pointer;"
-            {% endif %}
-          >
-            <div class="action-inner">
-              <a href="{{seek_url}}" tabindex="1">
-                {% trans "I'm looking for someone" %}
-              </a>
-            </div>
+        {# Following onclick is to make the whole button clickable. #}
+        <div class="action-outer start"
+          {% if not env.amp %}
+            onclick="location.href = '{{seek_url}}';" style="cursor: pointer;"
+          {% endif %}
+        >
+          <div class="action-inner">
+            <a href="{{seek_url}}" tabindex="1">
+              {% trans "I'm looking for someone" %}
+            </a>
           </div>
-          {# Following onclick is to make the whole button clickable. #}
-          <div class="action-outer end"
-            {% if not env.amp %}
-              onclick="location.href = '{{provide_url}}';" style="cursor: pointer;"
-            {% endif %}
-          >
-            <div class="action-inner">
-              <a href="{{provide_url}}" tabindex="2">
-                {% trans "I have information about someone" %}
-              </a>
-            </div>
-          </div>
-          <div class="end-multi-columns"></div>
         </div>
+        {# Following onclick is to make the whole button clickable. #}
+        <div class="action-outer end"
+          {% if not env.amp %}
+            onclick="location.href = '{{provide_url}}';" style="cursor: pointer;"
+          {% endif %}
+        >
+          <div class="action-inner">
+            <a href="{{provide_url}}" tabindex="2">
+              {% trans "I have information about someone" %}
+            </a>
+          </div>
+        </div>
+        <div class="end-multi-columns"></div>
       </div>
       <div class="row stats">
         {% if num_people %}

--- a/app/resources/start.html.template
+++ b/app/resources/start.html.template
@@ -55,7 +55,7 @@
             </div>
           </div>
           <div class="end-multi-columns"></div>
-	</div>
+        </div>
       </div>
       <div class="row stats">
         {% if num_people %}


### PR DESCRIPTION
I couldn't find a way to get it right on both mobile and desktop without
using @media to add desktop-specific rules, but that's been around for a
while (IE9 supports them) so it seems OK. What do you think?