### PR TITLE
Avoid horizontal stretch of images on results page.

### DIFF
--- a/app/resources/css-default.template
+++ b/app/resources/css-default.template
@@ -900,7 +900,7 @@ label.option {
 }
 
 img.resultImage {
-  width: 80px;
+  width: auto;
   height: auto;
   max-width: 80px;
   max-height: 80px;


### PR DESCRIPTION
height was set to auto but not width, which let tall images get
stretched out.