### PR TITLE
Use latest pytest version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && /usr/bin/python2.7 get-pip.py
-RUN pip install pytest==3.6.0 lxml cssselect pillow==4.1.0
+RUN pip install pytest==3.7.4 lxml cssselect pillow==4.1.0
 
 # Install app engine
 WORKDIR   /opt/

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -37,11 +37,11 @@ os.environ['APPLICATION_ID'] = 'personfinder-unittest'
 os.chdir(os.environ['APP_DIR'])
 
 # ...but we want pytest to default to finding tests in TESTS_DIR, not the cwd.
-# So, when no arguments are given, we make the option parser return TESTS_DIR.
-import _pytest.config
-original_parse_setoption = _pytest.config.Parser.parse_setoption
-_pytest.config.Parser.parse_setoption = (lambda *args, **kwargs: 
-    original_parse_setoption(*args, **kwargs) or [os.environ['TESTS_DIR']])
+# So, when no arguments besides options are given, we add TESTS_DIR to the list
+# of options passed to pytest.
+args = sys.argv[1:]
+if all([arg.startswith('-') for arg in args]):
+  args += [os.environ['TESTS_DIR']]
 
 # Run the tests, using sys.exit to set exit status (nonzero for failure).
-sys.exit(pytest.main())
+sys.exit(pytest.main(args))

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -37,11 +37,11 @@ os.environ['APPLICATION_ID'] = 'personfinder-unittest'
 os.chdir(os.environ['APP_DIR'])
 
 # ...but we want pytest to default to finding tests in TESTS_DIR, not the cwd.
-# So, when no arguments besides options are given, we add TESTS_DIR to the list
-# of options passed to pytest.
-args = sys.argv[1:]
-if all([arg.startswith('-') for arg in args]):
-  args += [os.environ['TESTS_DIR']]
+# So, when no arguments are given, we make the option parser return TESTS_DIR.
+import _pytest.config.argparsing
+original_parse_setoption = _pytest.config.argparsing.Parser.parse_setoption
+_pytest.config.argparsing.Parser.parse_setoption = (lambda *args, **kwargs: 
+    original_parse_setoption(*args, **kwargs) or [os.environ['TESTS_DIR']])
 
 # Run the tests, using sys.exit to set exit status (nonzero for failure).
-sys.exit(pytest.main(args))
+sys.exit(pytest.main())


### PR DESCRIPTION
Docker tests started failing last week and it doesn't seem to be because of any code changes (based on pull request #422 failing too). The error message is:
```
/usr/local/lib/python2.7/dist-packages/py/_path/local.py:668: in pyimport
    __import__(modname)
/usr/local/lib/python2.7/dist-packages/_pytest/assertion/rewrite.py:145: in find_module
    _write_pyc(state, co, source_stat, pyc)
/usr/local/lib/python2.7/dist-packages/_pytest/assertion/rewrite.py:269: in _write_pyc
    marshal.dump(co, fp.file)
E   AttributeError: '_io.BufferedWriter' object has no attribute 'file'
```

pytest's assertion/rewrite.py has since been changed to not access fp.file, so I suspect the version of one of our dependencies got ahead of the other. Using the latest version of pytest seemed to solve the problem locally; hopefully it works on Travis too.

This PR also includes the code from #417 (to handle the new version of pytest).