### PR TITLE
Clean up some pytest warnings.

### DIFF
--- a/tests/test_pfif.py
+++ b/tests/test_pfif.py
@@ -56,7 +56,7 @@ def dict_to_entity(dict):
     return entity
 
 
-class _TestCase:
+class PFIFTestCase:
     """A container for test data and expected results."""
     def __init__(self, pfif_version, xml, person_records=[], note_records=[],
                  do_parse_test=True, do_write_test=True, is_expired=False):
@@ -75,8 +75,8 @@ class _TestCase:
         self.is_expired = is_expired
 
 
-# The tests iterate over this list of _TestCases and check each one.  Testing
-# changes to PFIF should just require appending new _TestCases to this list.
+# The tests iterate over this list of PFIFTestCases and check each one.  Testing
+# changes to PFIF should just require appending new PFIFTestCases to this list.
 TEST_CASES = []
 
 # The records corresponding to the PFIF 1.4 XML documents below.
@@ -135,7 +135,7 @@ NOTE_RECORD_1_4 = {
 
 TEST_CASES.append((
     'PFIF 1.4 with tag prefixes',
-    _TestCase('1.4', '''\
+    PFIFTestCase('1.4', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.4">
   <pfif:person>
@@ -192,7 +192,7 @@ _test_profile_url2</pfif:profile_urls>
 
 TEST_CASES.append((
     'PFIF 1.4 with tag prefixes, with the person_record_id after the note',
-    _TestCase('1.4', '''\
+    PFIFTestCase('1.4', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.4">
   <pfif:person>
@@ -249,7 +249,7 @@ _test_profile_url2</pfif:profile_urls>
 
 TEST_CASES.append((
     'PFIF 1.4 with notes only',
-    _TestCase('1.4', '''\
+    PFIFTestCase('1.4', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif xmlns="http://zesty.ca/pfif/1.4">
   <note>
@@ -276,7 +276,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.4 for an expired record with data that should be hidden',
-    _TestCase('1.4', '''\
+    PFIFTestCase('1.4', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.4">
   <pfif:person>
@@ -291,7 +291,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.4 for an expired record with data that has been wiped',
-    _TestCase('1.4', '''\
+    PFIFTestCase('1.4', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.4">
   <pfif:person>
@@ -358,7 +358,7 @@ NOTE_RECORD_1_3 = {
 
 TEST_CASES.append((
     'PFIF 1.3 with tag prefixes',
-    _TestCase('1.3', '''\
+    PFIFTestCase('1.3', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.3">
   <pfif:person>
@@ -411,7 +411,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.3 with tag prefixes, with the person_record_id after the note',
-    _TestCase('1.3', '''\
+    PFIFTestCase('1.3', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.3">
   <pfif:person>
@@ -464,7 +464,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.3 with notes only',
-    _TestCase('1.3', '''\
+    PFIFTestCase('1.3', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif xmlns="http://zesty.ca/pfif/1.3">
   <note>
@@ -490,7 +490,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.3 for an expired record with data that should be hidden',
-    _TestCase('1.3', '''\
+    PFIFTestCase('1.3', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.3">
   <pfif:person>
@@ -505,7 +505,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.3 for an expired record with data that has been wiped',
-    _TestCase('1.3', '''\
+    PFIFTestCase('1.3', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.3">
   <pfif:person>
@@ -564,7 +564,7 @@ NOTE_RECORD_1_2 = {
 
 TEST_CASES.append((
     'PFIF 1.2 XML document with tag prefixes',
-    _TestCase('1.2', '''\
+    PFIFTestCase('1.2', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.2">
   <pfif:person>
@@ -615,7 +615,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.2 XML document without tag prefixes',
-    _TestCase('1.2', '''\
+    PFIFTestCase('1.2', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif xmlns="http://zesty.ca/pfif/1.2">
   <person>
@@ -666,7 +666,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.2 with tag prefixes, with the person_record_id after the note',
-    _TestCase('1.2', '''\
+    PFIFTestCase('1.2', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.2">
   <pfif:person>
@@ -717,7 +717,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.2 XML document with notes only',
-    _TestCase('1.2', '''\
+    PFIFTestCase('1.2', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif xmlns="http://zesty.ca/pfif/1.2">
   <note>
@@ -780,7 +780,7 @@ NOTE_RECORD_1_1 = {
 
 TEST_CASES.append((
     'PFIF 1.1 XML document with tag prefixes',
-    _TestCase('1.1', '''\
+    PFIFTestCase('1.1', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.1">
   <pfif:person>
@@ -835,7 +835,7 @@ PERSON_RECORD_WITH_NON_ASCII = {
 # A PFIF document containing some non-ASCII characters in UTF-8 encoding.
 TEST_CASES.append((
     'PFIF 1.2 with non-ASCII characters',
-    _TestCase('1.2', '''\
+    PFIFTestCase('1.2', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.2">
   <pfif:person>

--- a/tests/test_pfif.py
+++ b/tests/test_pfif.py
@@ -56,7 +56,7 @@ def dict_to_entity(dict):
     return entity
 
 
-class TestCase:
+class _TestCase:
     """A container for test data and expected results."""
     def __init__(self, pfif_version, xml, person_records=[], note_records=[],
                  do_parse_test=True, do_write_test=True, is_expired=False):
@@ -75,8 +75,8 @@ class TestCase:
         self.is_expired = is_expired
 
 
-# The tests iterate over this list of TestCases and check each one.  Testing
-# changes to PFIF should just require appending new TestCases to this list.
+# The tests iterate over this list of _TestCases and check each one.  Testing
+# changes to PFIF should just require appending new _TestCases to this list.
 TEST_CASES = []
 
 # The records corresponding to the PFIF 1.4 XML documents below.
@@ -135,7 +135,7 @@ NOTE_RECORD_1_4 = {
 
 TEST_CASES.append((
     'PFIF 1.4 with tag prefixes',
-    TestCase('1.4', '''\
+    _TestCase('1.4', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.4">
   <pfif:person>
@@ -192,7 +192,7 @@ _test_profile_url2</pfif:profile_urls>
 
 TEST_CASES.append((
     'PFIF 1.4 with tag prefixes, with the person_record_id after the note',
-    TestCase('1.4', '''\
+    _TestCase('1.4', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.4">
   <pfif:person>
@@ -249,7 +249,7 @@ _test_profile_url2</pfif:profile_urls>
 
 TEST_CASES.append((
     'PFIF 1.4 with notes only',
-    TestCase('1.4', '''\
+    _TestCase('1.4', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif xmlns="http://zesty.ca/pfif/1.4">
   <note>
@@ -276,7 +276,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.4 for an expired record with data that should be hidden',
-    TestCase('1.4', '''\
+    _TestCase('1.4', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.4">
   <pfif:person>
@@ -291,7 +291,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.4 for an expired record with data that has been wiped',
-    TestCase('1.4', '''\
+    _TestCase('1.4', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.4">
   <pfif:person>
@@ -358,7 +358,7 @@ NOTE_RECORD_1_3 = {
 
 TEST_CASES.append((
     'PFIF 1.3 with tag prefixes',
-    TestCase('1.3', '''\
+    _TestCase('1.3', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.3">
   <pfif:person>
@@ -411,7 +411,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.3 with tag prefixes, with the person_record_id after the note',
-    TestCase('1.3', '''\
+    _TestCase('1.3', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.3">
   <pfif:person>
@@ -464,7 +464,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.3 with notes only',
-    TestCase('1.3', '''\
+    _TestCase('1.3', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif xmlns="http://zesty.ca/pfif/1.3">
   <note>
@@ -490,7 +490,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.3 for an expired record with data that should be hidden',
-    TestCase('1.3', '''\
+    _TestCase('1.3', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.3">
   <pfif:person>
@@ -505,7 +505,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.3 for an expired record with data that has been wiped',
-    TestCase('1.3', '''\
+    _TestCase('1.3', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.3">
   <pfif:person>
@@ -564,7 +564,7 @@ NOTE_RECORD_1_2 = {
 
 TEST_CASES.append((
     'PFIF 1.2 XML document with tag prefixes',
-    TestCase('1.2', '''\
+    _TestCase('1.2', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.2">
   <pfif:person>
@@ -615,7 +615,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.2 XML document without tag prefixes',
-    TestCase('1.2', '''\
+    _TestCase('1.2', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif xmlns="http://zesty.ca/pfif/1.2">
   <person>
@@ -666,7 +666,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.2 with tag prefixes, with the person_record_id after the note',
-    TestCase('1.2', '''\
+    _TestCase('1.2', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.2">
   <pfif:person>
@@ -717,7 +717,7 @@ TEST_CASES.append((
 
 TEST_CASES.append((
     'PFIF 1.2 XML document with notes only',
-    TestCase('1.2', '''\
+    _TestCase('1.2', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif xmlns="http://zesty.ca/pfif/1.2">
   <note>
@@ -780,7 +780,7 @@ NOTE_RECORD_1_1 = {
 
 TEST_CASES.append((
     'PFIF 1.1 XML document with tag prefixes',
-    TestCase('1.1', '''\
+    _TestCase('1.1', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.1">
   <pfif:person>
@@ -835,7 +835,7 @@ PERSON_RECORD_WITH_NON_ASCII = {
 # A PFIF document containing some non-ASCII characters in UTF-8 encoding.
 TEST_CASES.append((
     'PFIF 1.2 with non-ASCII characters',
-    TestCase('1.2', '''\
+    _TestCase('1.2', '''\
 <?xml version="1.0" encoding="UTF-8"?>
 <pfif:pfif xmlns:pfif="http://zesty.ca/pfif/1.2">
   <pfif:person>

--- a/tests/test_prefix.py
+++ b/tests/test_prefix.py
@@ -19,7 +19,7 @@ import prefix
 import unittest
 
 
-class _TestPerson(db.Model):
+class PersonForTest(db.Model):
     name = db.StringProperty()
 
 
@@ -35,18 +35,18 @@ class PrefixTests(unittest.TestCase):
         prefix_properties = ['name']
         prefix_types = ['_n_', '_n1_', '_n2_']
         all_properties = ['name', 'name_n1_', 'name_n2_', 'name_n_']
-        prefix.add_prefix_properties(_TestPerson, 'name')
+        prefix.add_prefix_properties(PersonForTest, 'name')
         # Test the list of prefix properties was recorded
-        assert _TestPerson._prefix_properties == prefix_properties
+        assert PersonForTest._prefix_properties == prefix_properties
         # Test all prefix properties have been added
         for prefix_type in prefix_types:
-            assert hasattr(_TestPerson, 'name' + prefix_type)
+            assert hasattr(PersonForTest, 'name' + prefix_type)
         # Test that the model class was updated
-        assert sorted(_TestPerson.properties()) == all_properties
+        assert sorted(PersonForTest.properties()) == all_properties
 
     def test_update_prefix_properties(self):
-        prefix.add_prefix_properties(_TestPerson, 'name')
-        test_person = _TestPerson(name='John')
+        prefix.add_prefix_properties(PersonForTest, 'name')
+        test_person = PersonForTest(name='John')
         prefix.update_prefix_properties(test_person)
         assert test_person.name_n_ == 'JOHN'
         assert test_person.name_n1_ == 'J'
@@ -54,22 +54,22 @@ class PrefixTests(unittest.TestCase):
 
     def test_filter_prefix(self):
         # Test 1-char prefix filter
-        test_query = _TestPerson.all()
+        test_query = PersonForTest.all()
         test_criteria = {'name': 'b'}
         prefix.filter_prefix(test_query, **test_criteria)
         assert test_query._get_query() == {'name_n1_ =': u'B'}
         # Test 2-char prefix filter
-        test_query = _TestPerson.all()
+        test_query = PersonForTest.all()
         test_criteria = {'name': 'bryan'}
         prefix.filter_prefix(test_query, **test_criteria)
         assert test_query._get_query() == {'name_n2_ =': u'BR'}
 
     def test_get_prefix_matches(self):
-        db.put(_TestPerson(name='Bryan'))
-        db.put(_TestPerson(name='Bruce'))
-        db.put(_TestPerson(name='Benny'))
-        db.put(_TestPerson(name='Lenny'))
-        test_query = _TestPerson.all().order('name')
+        db.put(PersonForTest(name='Bryan'))
+        db.put(PersonForTest(name='Bruce'))
+        db.put(PersonForTest(name='Benny'))
+        db.put(PersonForTest(name='Lenny'))
+        test_query = PersonForTest.all().order('name')
         # Test full string match
         test_criteria = {'name': 'bryan'}
         test_people = list(person.name for person in prefix.get_prefix_matches(

--- a/tests/test_prefix.py
+++ b/tests/test_prefix.py
@@ -19,7 +19,7 @@ import prefix
 import unittest
 
 
-class TestPerson(db.Model):
+class _TestPerson(db.Model):
     name = db.StringProperty()
 
 
@@ -35,18 +35,18 @@ class PrefixTests(unittest.TestCase):
         prefix_properties = ['name']
         prefix_types = ['_n_', '_n1_', '_n2_']
         all_properties = ['name', 'name_n1_', 'name_n2_', 'name_n_']
-        prefix.add_prefix_properties(TestPerson, 'name')
+        prefix.add_prefix_properties(_TestPerson, 'name')
         # Test the list of prefix properties was recorded
-        assert TestPerson._prefix_properties == prefix_properties
+        assert _TestPerson._prefix_properties == prefix_properties
         # Test all prefix properties have been added
         for prefix_type in prefix_types:
-            assert hasattr(TestPerson, 'name' + prefix_type)
+            assert hasattr(_TestPerson, 'name' + prefix_type)
         # Test that the model class was updated
-        assert sorted(TestPerson.properties()) == all_properties
+        assert sorted(_TestPerson.properties()) == all_properties
 
     def test_update_prefix_properties(self):
-        prefix.add_prefix_properties(TestPerson, 'name')
-        test_person = TestPerson(name='John')
+        prefix.add_prefix_properties(_TestPerson, 'name')
+        test_person = _TestPerson(name='John')
         prefix.update_prefix_properties(test_person)
         assert test_person.name_n_ == 'JOHN'
         assert test_person.name_n1_ == 'J'
@@ -54,22 +54,22 @@ class PrefixTests(unittest.TestCase):
 
     def test_filter_prefix(self):
         # Test 1-char prefix filter
-        test_query = TestPerson.all()
+        test_query = _TestPerson.all()
         test_criteria = {'name': 'b'}
         prefix.filter_prefix(test_query, **test_criteria)
         assert test_query._get_query() == {'name_n1_ =': u'B'}
         # Test 2-char prefix filter
-        test_query = TestPerson.all()
+        test_query = _TestPerson.all()
         test_criteria = {'name': 'bryan'}
         prefix.filter_prefix(test_query, **test_criteria)
         assert test_query._get_query() == {'name_n2_ =': u'BR'}
 
     def test_get_prefix_matches(self):
-        db.put(TestPerson(name='Bryan'))
-        db.put(TestPerson(name='Bruce'))
-        db.put(TestPerson(name='Benny'))
-        db.put(TestPerson(name='Lenny'))
-        test_query = TestPerson.all().order('name')
+        db.put(_TestPerson(name='Bryan'))
+        db.put(_TestPerson(name='Bruce'))
+        db.put(_TestPerson(name='Benny'))
+        db.put(_TestPerson(name='Lenny'))
+        test_query = _TestPerson.all().order('name')
         # Test full string match
         test_criteria = {'name': 'bryan'}
         test_people = list(person.name for person in prefix.get_prefix_matches(


### PR DESCRIPTION
pytest tries to collect tests from TestCase and TestPerson because of their names, and then raises warnings because that doesn't work out. This PR prefixes their names with underscores to clean up the warnings.