### PR TITLE
Make feedback link configurable

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -137,6 +137,7 @@ class Handler(BaseHandler):
                         'brand',
                         'captcha_secret_key',
                         'captcha_site_key',
+                        'feedback_url',
                         'maps_api_key',
                         'notification_email',
                         'privacy_policy_url',

--- a/app/resources/admin.html.template
+++ b/app/resources/admin.html.template
@@ -1034,6 +1034,13 @@
             value="{{view_config.tos_url}}">
       </div>
     </div>
+    <div class="config">
+      <label for="feedback_url">Feedback URL:</label>
+      <div class="response">
+        <input type="text" name="feedback_url" id="feedback_url" size=60
+            value="{{view_config.feedback_url}}">
+      </div>
+    </div>
   </fieldset>
 
   <fieldset>

--- a/app/resources/base.html.template
+++ b/app/resources/base.html.template
@@ -201,9 +201,11 @@
               >{% trans "About Google Person Finder" %}</a>
           <span class="link-separator"></span>
           {% include "repo-menu.html.template" %}
-          <span class="link-separator"></span>
-          <a href="https://support.google.com/personfinder/contact/pf_feedback"
-              {{env.target_attr|safe}}>{% trans "Feedback" %}</a>
+	  {% if config.feedback_url %}
+            <span class="link-separator"></span>
+            <a href="{{config.feedback_url}}"
+	        {{env.target_attr|safe}}>{% trans "Feedback" %}</a>
+          {% endif %}
           <span class="link-separator"></span>
           {% if env.ui != "light" %}
             <a href="https://github.com/google/personfinder"

--- a/app/resources/static-base.html.template
+++ b/app/resources/static-base.html.template
@@ -50,9 +50,11 @@
         >{% trans "About Google Person Finder" %}</a>
     <span class="link-separator"></span>
     {% include "repo-menu.html.template" %}
-    <span class="link-separator"></span>
-    <a href="https://support.google.com/personfinder/contact/pf_feedback"
-        {{env.target_attr|safe}}>{% trans "Feedback" %}</a>
+    {% if config.feedback_url %}
+      <span class="link-separator"></span>
+      <a href="{{config.feedback_url}}"
+          {{env.target_attr|safe}}>{% trans "Feedback" %}</a>
+    {% endif %}
     <span class="link-separator"></span>
     {% if env.ui != "light" %}
       <a href="http://support.google.com/personfinder/?hl={{env.lang}}"


### PR DESCRIPTION
It's currently hard-coded to use a support.google.com feedback URL, even when the instance is set to "brand as other organization."