### PR TITLE
Show ellipsis when the title doesn't fit in a single line.

### DIFF
--- a/app/resources/css-default.template
+++ b/app/resources/css-default.template
@@ -154,6 +154,11 @@ pre {  /* code samples */
   background-color: #616161;
   height: 64px;
   line-height: 64px;  /* Vertically center the text */
+
+  /* Shows ellipsis when the title doesn't fit in a single line. */
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .title-bar-button {


### PR DESCRIPTION
This happens e.g., in Japanese mobile UI.

Before: 
<img width="310" alt="bn15smtvrnz" src="https://user-images.githubusercontent.com/15363/46119275-2db26c80-c245-11e8-96ea-806854354fa1.png">
After:
<img width="305" alt="3rnjrgdppbk" src="https://user-images.githubusercontent.com/15363/46119279-330fb700-c245-11e8-9fdf-22a17f683a68.png">

