### PR TITLE
Travis CI: Start testing on Python 3.7 in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,21 @@
-sudo: required
-
 language: python
-
-python:
-  - 2.7
 
 services:
   - docker
 
-env:
-  DOCKER_COMPOSE_VERSION: 1.10.0
+matrix:
+  include:
+    - python: 2.7
+      env:
+        - DOCKERFILE="Dockerfile"
+          DOCKER_COMPOSE_VERSION: 1.10.0
+    - python: 3.7
+      env:
+        - DOCKERFILE="Dockerfile_Python37"
+          DOCKER_COMPOSE_VERSION: 1.10.0
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+  allow_failures:
+    - python: 3.7
 
 install: true 
 
@@ -21,4 +27,3 @@ before_install:
   - docker-compose up -d
 
 script: docker-compose exec web tools/all_tests
-

--- a/Dockerfile_Python37
+++ b/Dockerfile_Python37
@@ -1,0 +1,41 @@
+FROM phusion/baseimage
+LABEL authors="Carlo Lobrano <c.lobrano@gmail.com>, Mathieu Tortuyaux <mathieu.tortuyaux@gmail.com>"
+
+CMD ["/sbin/my_init"]
+
+# Get rid of debconf complaining about noninteractive mode
+ENV DEBIAN_FRONTEND noninteractive
+ENV PATH $PATH:/opt/google_appengine
+ENV APPENGINE_DIR /opt/google_appengine/
+ENV PERSONFINDER_DIR /opt/personfinder/
+ENV INIT_DATASTORE 0
+
+RUN apt-get update && apt-get install -y \
+	build-essential \
+	unzip \
+	python3.7 \
+	libpython3.7-dev \
+	curl \
+	git \
+	time \
+	gettext \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && /usr/bin/python3.7 get-pip.py
+RUN pip install cssselect lxml pillow==5.3.0 pytest==4.0.1 
+
+# Install app engine
+WORKDIR /opt/
+ADD https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.50.zip /opt/
+RUN unzip -qq google_appengine_1.9.50.zip && rm google_appengine_1.9.50.zip
+
+ADD docker/gae-run-app.sh      /usr/bin/
+ADD docker/setup_datastore.sh  /usr/bin/
+
+RUN echo "opt_in: false\ntimestamp: $(date +%s)\n" > /root/.appcfg_nag
+
+WORKDIR /opt/personfinder/
+
+# Clean up
+RUN rm -rf /tmp/* /var/tmp/*


### PR DESCRIPTION
* Make an new "shadow" __Dockerfile_Python37__
* Configure Travis CI to run parallel tests on Python 2 and Python 3
    * Run Python 3 in __allow_failures__ mode until all the kinks get worked out