### PR TITLE
Fix #451: Add support for CSV download with sensitive fields in the web UI

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -337,7 +337,7 @@ class Import(utils.BaseHandler):
         if self.auth.full_read_permission:
             object_name = self.config.latest_full_csv_object_name
         else:
-            object_name = self.config.latest_basic_csv_object_name
+            object_name = self.config.latest_filtered_csv_object_name
         if object_name:
             csv_url = storage.sign_url(
                 object_name, url_lifetime=datetime.timedelta(minutes=10))

--- a/app/api.py
+++ b/app/api.py
@@ -334,7 +334,10 @@ class Import(utils.BaseHandler):
             return
 
         storage = cloud_storage.CloudStorage()
-        object_name = self.config.latest_csv_object_name
+        if self.auth.full_read_permission:
+            object_name = self.config.latest_full_csv_object_name
+        else:
+            object_name = self.config.latest_basic_csv_object_name
         if object_name:
             csv_url = storage.sign_url(
                 object_name, url_lifetime=datetime.timedelta(minutes=10))

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -535,7 +535,7 @@ class DumpCSV(utils.BaseHandler):
         if self.params.cursor:
             query.with_cursor(self.params.cursor)
 
-        basic_writer = record_writer.PersonWithNoteCsvWriter(
+        filtered_writer = record_writer.PersonWithNoteCsvWriter(
             StringIO.StringIO(), write_header=is_first)
         full_writer = record_writer.PersonWithNoteCsvWriter(
             StringIO.StringIO(), write_header=is_first)
@@ -553,15 +553,16 @@ class DumpCSV(utils.BaseHandler):
             full_records = self.get_person_records_with_notes(repo, persons)
             full_writer.write(full_records)
 
-            basic_records = copy.deepcopy(full_records)
-            utils.filter_sensitive_fields(basic_records)
-            basic_writer.write(basic_records)
+            filtered_records = copy.deepcopy(full_records)
+            utils.filter_sensitive_fields(filtered_records)
+            filtered_writer.write(filtered_records)
 
             if utils.get_utcnow() >= start_time + self.MAX_FETCH_TIME:
                 break
             query.with_cursor(query.cursor())
 
-        for kind, writer in [('basic', basic_writer), ('full', full_writer)]:
+        for kind, writer in [
+                ('filtered', filtered_writer), ('full', full_writer)]:
             base_name = '%s-persons-%s-%s' % (
                 repo, kind, timestamp.strftime('%Y-%m-%d-%H%M%S'))
             final_csv_name = '%s.csv' % base_name


### PR DESCRIPTION
Generates both "full" version (with sensitive fields) and "basic" version (without sensitive fields) in the cron job, and serves one of them based on the API key permission.