### PR TITLE
Translation files for development.

### DIFF
--- a/ui/src/translations/en.js
+++ b/ui/src/translations/en.js
@@ -1,0 +1,2 @@
+module.exports = {
+};

--- a/ui/src/translations/en.js
+++ b/ui/src/translations/en.js
@@ -1,2 +1,7 @@
+/**
+ * The English translation file has to exist to avoid complicating things for
+ * index.js, but it doesn't need to actually have any translations, because that
+ * would just be redundant with the default messages (which are all in English).
+ */
 module.exports = {
 };

--- a/ui/src/translations/es.js
+++ b/ui/src/translations/es.js
@@ -1,3 +1,6 @@
+/**
+ * This file is just for temporary testing use.
+ */
 module.exports = {
   'GlobalHome.howDoesItWork': '¿Como funciona?',
   'RepoCard.repoRecordCount': 'Seguimiento de {recordCount} registros.',

--- a/ui/src/translations/es.js
+++ b/ui/src/translations/es.js
@@ -1,0 +1,4 @@
+module.exports = {
+  'GlobalHome.howDoesItWork': '¿Como funciona?',
+  'RepoCard.repoRecordCount': 'Seguimiento de {recordCount} registros.',
+};


### PR DESCRIPTION
I don't have a pipeline for generating these files for real yet, but
it's useful to have a couple language files just to be sure the
language/translation code is working. The Spanish file just has two
messages as it's just proof-of-concept (for anything else it'll use the
default message). For English, it doesn't really need anything in the
file since it's the default language anyway (at some point I'd like to
explore whether it's possible to avoid including the default messages in
the minified JS, but that doesn't seem like an immediate requirement).