### PR TITLE
Component for general-purpose notched outline.

### DIFF
--- a/ui/src/components/PFNotchedOutline.js
+++ b/ui/src/components/PFNotchedOutline.js
@@ -1,0 +1,24 @@
+import React, {Component} from 'react';
+
+/**
+ * A component for wrapping something in a notched outline.
+ *
+ * We may be able to get rid of this at some point and use a component built by
+ * the Material team, but a) the documentation for the React NotchedOutline is
+ * pretty sparse and b) I'm not sure Material supports using their
+ * NotchedOutline with anything other than TextField and Select components.
+ */
+class PFNotchedOutline extends Component {
+  render() {
+    return (
+      <div className='pf-notchedoutline'>
+        <label className='mdc-typography--body1 pf-notchedoutline-label'>
+          {this.props.label}
+        </label>
+        <div className='pf-notchedoutline-content'>{this.props.children}</div>
+      </div>
+    );
+  }
+}
+
+export default PFNotchedOutline;

--- a/ui/src/components/PFNotchedOutline.js
+++ b/ui/src/components/PFNotchedOutline.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React, {Component} from 'react';
 
 /**

--- a/ui/src/components/PFNotchedOutline.js
+++ b/ui/src/components/PFNotchedOutline.js
@@ -24,17 +24,13 @@ import React, {Component} from 'react';
  * pretty sparse and b) I'm not sure Material supports using their
  * NotchedOutline with anything other than TextField and Select components.
  */
-class PFNotchedOutline extends Component {
-  render() {
-    return (
-      <div className='pf-notchedoutline'>
-        <label className='mdc-typography--body1 pf-notchedoutline-label'>
-          {this.props.label}
-        </label>
-        <div className='pf-notchedoutline-content'>{this.props.children}</div>
-      </div>
-    );
-  }
-}
+const PFNotchedOutline = () => (
+  <div className='pf-notchedoutline'>
+    <label className='mdc-typography--body1 pf-notchedoutline-label'>
+      {this.props.label}
+    </label>
+    <div className='pf-notchedoutline-content'>{this.props.children}</div>
+  </div>
+);
 
 export default PFNotchedOutline;

--- a/ui/src/css/components/_PFNotchedOutline.scss
+++ b/ui/src/css/components/_PFNotchedOutline.scss
@@ -1,0 +1,18 @@
+.pf-notchedoutline {
+  border: 1px solid #dadce0;
+  border-radius: 4px;
+  margin-top: 2.5ex;
+}
+
+.pf-notchedoutline-label {
+  background: #fff;
+  left: 10px;
+  padding: 0 5px;
+  position: relative;
+  top: -1.5ex;
+}
+
+.pf-notchedoutline-content {
+  margin-top: -1ex;
+  padding: 0 5px 5px;
+}

--- a/ui/src/css/components/_PFNotchedOutline.scss
+++ b/ui/src/css/components/_PFNotchedOutline.scss
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .pf-notchedoutline {
   border: 1px solid #dadce0;
   border-radius: 4px;


### PR DESCRIPTION
The mocks call for a notched outline around sections of the create form.
However, the Material libraries only seem to have support for notched
outlines on input components, so, at least for now, I think we need our
own component for the section outlines.