### PR TITLE
Add six library to requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ google-api-python-client==1.7.4
 oauth2client==4.1.3
 pytz==2016.10
 simplejson==3.10.0
+six==1.11.0
 unidecode==0.04.20
 xlrd==1.0.0


### PR DESCRIPTION
This is kinda just a formality, since we already have dependencies that
depend on it (which is why nothing's getting added to app/vendors), but
since we're now depending on it directly it belongs in requirements.txt.