### PR TITLE
Add some absolute_import imports.

### DIFF
--- a/app/amp_start.py
+++ b/app/amp_start.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import start
 
 

--- a/app/const.py
+++ b/app/const.py
@@ -16,6 +16,7 @@
 """Constants that aren't specific to a particular module or handler."""
 
 # We use lazy translation in this file because the language isn't set yet.
+from __future__ import absolute_import
 import django_setup
 from django_setup import gettext_lazy as _
 

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -16,6 +16,7 @@
 
 """Tests for const."""
 
+from __future__ import absolute_import
 import const
 import pfif
 import unittest


### PR DESCRIPTION
For const.py, its unit test file, and amp_start.py. These files don't appear to
need any changes to be compatible with Python 3. Adding absolute_import will
make them use Python 3's default importing behavior (so we don't accidentally
mess it up later). Plus, python-modernize adds it to all files, and we want to
be able to use it for enforcement later (so anything it adds, we kinda have to
add).

Details at: https://www.python.org/dev/peps/pep-0328/