### PR TITLE
Add Python 3 compatibility check.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && /usr/bin/python2.7 get-pip.py
-RUN pip install pytest==3.7.4 lxml cssselect pillow==4.1.0 mock
+RUN pip install pytest==3.7.4 lxml cssselect pillow==4.1.0 mock modernize
 
 # Install app engine
 WORKDIR   /opt/

--- a/tools/all_tests
+++ b/tools/all_tests
@@ -19,4 +19,5 @@ pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 
 $TOOLS_DIR/unit_tests -q && \
     $TOOLS_DIR/server_tests -q && \
-    echo "Unit and server tests passed."
+    $TOOLS_DIR/p3_compatibility_check && \
+    echo "Unit and server tests, and Python 3 compatibility check, passed."

--- a/tools/p3_compatibility_check
+++ b/tools/p3_compatibility_check
@@ -1,6 +1,0 @@
-python-modernize --enforce \
-  app/amp_start.py \
-  app/const.py \
-  app/text_query.py \
-  tests/test_const.py \
-  tests/test_text_query.py

--- a/tools/p3_compatibility_check
+++ b/tools/p3_compatibility_check
@@ -1,0 +1,6 @@
+python-modernize --enforce \
+  app/amp_start.py \
+  app/const.py \
+  app/text_query.py \
+  tests/test_const.py \
+  tests/test_text_query.py

--- a/tools/p3_compatibility_check
+++ b/tools/p3_compatibility_check
@@ -3,4 +3,4 @@ python-modernize --enforce \
   app/const.py \
   app/text_query.py \
   tests/test_const.py \
-  tests/test_text_query.py
+  tests/test_text_query.py app/utils.py

--- a/tools/p3_compatibility_check
+++ b/tools/p3_compatibility_check
@@ -3,4 +3,4 @@ python-modernize --enforce \
   app/const.py \
   app/text_query.py \
   tests/test_const.py \
-  tests/test_text_query.py app/utils.py
+  tests/test_text_query.py

--- a/tools/python3_compatibility_check
+++ b/tools/python3_compatibility_check
@@ -16,7 +16,7 @@
 # Checks that files that have been made compatible with Python 3 don't regress
 # (at least not as far as python-modernize can tell).
 # We only check the files that have been made compatible; more files should be
-# added to this list as we make the compatible.
+# added to this list as we make them compatible.
 
 python-modernize --enforce \
   app/amp_start.py \

--- a/tools/python3_compatibility_check
+++ b/tools/python3_compatibility_check
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2010 Google Inc.
+# Copyright 2019 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,11 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Runs all the tests.
+# Checks that files that have been made compatible with Python 3 don't regress
+# (at least not as far as python-modernize can tell).
+# We only check the files that have been made compatible; more files should be
+# added to this list as we make the compatible.
 
-pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
-
-$TOOLS_DIR/unit_tests -q && \
-    $TOOLS_DIR/server_tests -q && \
-    $TOOLS_DIR/python3_compatibility_check && \
-    echo "Unit and server tests, and Python 3 compatibility check, passed."
+python-modernize --enforce \
+  app/amp_start.py \
+  app/const.py \
+  app/text_query.py \
+  tests/test_const.py \
+  tests/test_text_query.py


### PR DESCRIPTION
The python-modernize command will fail if one of the files in the list isn't Python 3 compatible. My plan is to add files to that list as I update them, so that once a file is made compatible we don't accidentally break its compatibility later.