### PR TITLE
Upgrade lxml to version 3.7.3.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
 	unzip \
 	python2.7 \
 	libpython2.7-dev \
+        python-lxml \
 	curl \
 	git \
 	time \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update && apt-get install -y \
 	unzip \
 	python2.7 \
 	libpython2.7-dev \
-        python-lxml \
 	curl \
 	git \
 	time \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ RUN pip install pytest==3.7.4 lxml cssselect pillow==4.1.0 mock
 
 # Install app engine
 WORKDIR   /opt/
-ADD https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.50.zip /opt/
-RUN unzip -qq google_appengine_1.9.50.zip && rm google_appengine_1.9.50.zip
+ADD https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.62.zip /opt/
+RUN unzip -qq google_appengine_1.9.62.zip && rm google_appengine_1.9.62.zip
 
 ADD docker/gae-run-app.sh      /usr/bin/
 ADD docker/setup_datastore.sh  /usr/bin/

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 Person Finder is a searchable missing person database written in Python and
 hosted on App Engine.
 
-Person Finder implements [the PFIF data model](http://zesty.ca/pfif/) and
-provides PFIF import and export as well as PFIF Atom feeds. It was initially
-created by Google volunteers in response to the Haiti earthquake in January
-2010, and today contains contributions from many volunteers inside and outside
-of Google. It was used again for the earthquakes in Chile, Yushu, and Japan, and
-now runs at http://google.org/personfinder/.
+Person Finder implements the PFIF data model and provides PFIF import and export
+as well as PFIF Atom feeds. It was initially created by Google volunteers in
+response to the Haiti earthquake in January 2010, and today contains
+contributions from many volunteers inside and outside of Google. It was used
+again for the earthquakes in Chile, Yushu, and Japan, and now runs at
+http://google.org/personfinder/.
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 Person Finder is a searchable missing person database written in Python and
 hosted on App Engine.
 
-Person Finder implements the PFIF data model and provides PFIF import and export
-as well as PFIF Atom feeds. It was initially created by Google volunteers in
-response to the Haiti earthquake in January 2010, and today contains
-contributions from many volunteers inside and outside of Google. It was used
-again for the earthquakes in Chile, Yushu, and Japan, and now runs at
-http://google.org/personfinder/.
+Person Finder implements [the PFIF data model](http://zesty.ca/pfif/) and
+provides PFIF import and export as well as PFIF Atom feeds. It was initially
+created by Google volunteers in response to the Haiti earthquake in January
+2010, and today contains contributions from many volunteers inside and outside
+of Google. It was used again for the earthquakes in Chile, Yushu, and Japan, and
+now runs at http://google.org/personfinder/.
 
 ## How to Contribute
 

--- a/app/app.yaml
+++ b/app/app.yaml
@@ -44,4 +44,4 @@ libraries:
 - name: django
   version: "1.9"
 - name: lxml
-  version: "2.3"
+  version: "3.7.3"


### PR DESCRIPTION
This isn't the latest version of lxml, but it is the latest version that App
Engine supports (we can't app/vendors it because it's a wrapper around C
libraries). It's listed as supporting up to Python 3.5, which hopefully means
it'll work on 3.7 too (version 2.3 only officially supports up to Python 3.2).

Assigning to Avi.