### PR TITLE
Upgrade to Django 1.11.

### DIFF
--- a/app/app.yaml
+++ b/app/app.yaml
@@ -42,6 +42,6 @@ handlers:
 
 libraries:
 - name: django
-  version: "1.9"
+  version: "1.11"
 - name: lxml
   version: "2.3"


### PR DESCRIPTION
I went through the release notes for 1.10 and 1.11 and couldn't find
anything that required code changes in our app (which is a little
surprising but not shocking, since we don't use Django for database
access).

One of our dependencies, oauth2client, uses the old location for
django.core.urlresolvers (it's now django.urls). The old location is
deprecated in 1.10 but apparently not yet removed. So, oauth2client
might eventually be a blocker for upgrading to Django 2.x, but it's
still fine for Django 1.11.