### PR TITLE
Changed link schema from http to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ as well as PFIF Atom feeds. It was initially created by Google volunteers in
 response to the Haiti earthquake in January 2010, and today contains
 contributions from many volunteers inside and outside of Google. It was used
 again for the earthquakes in Chile, Yushu, and Japan, and now runs at
-http://google.org/personfinder/.
+https://google.org/personfinder/.
 
 ## How to Contribute
 


### PR DESCRIPTION
Changed the schema for the link to use https, so that when a user clicks on the link through this README, they use SSL to ensure a trusted exchange.