### PR TITLE
 Add forgotten i18n load in React index template.

### DIFF
--- a/app/resources/react_index.html.template
+++ b/app/resources/react_index.html.template
@@ -1,3 +1,5 @@
+{% load i18n %}
+
 <!--
   Copyright 2019 Google LLC
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/app/resources/react_index.html.template
+++ b/app/resources/react_index.html.template
@@ -1,5 +1,3 @@
-{% load i18n %}
-
 <!--
   Copyright 2019 Google LLC
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +10,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
+
+{% load i18n %}
 
 <!DOCTYPE html>
 


### PR DESCRIPTION
This is needed to support the trans tag. I'm not sure how things were
working before.