### PR TITLE
Only ping sitemap index servers in prod.

### DIFF
--- a/app/sitemap.py
+++ b/app/sitemap.py
@@ -24,9 +24,10 @@ import urllib
 from datetime import datetime, timedelta
 from google.appengine.api import taskqueue
 
+import config
 import const
 from model import Repo
-import utils
+from utils import BaseHandler
 
 
 # Use the App Engine Requests adapter. This makes sure that Requests uses
@@ -35,7 +36,7 @@ import utils
 requests_toolbelt.adapters.appengine.monkeypatch()
 
 
-class SiteMap(utils.BaseHandler):
+class SiteMap(BaseHandler):
 
     repo_required = False
 
@@ -51,7 +52,7 @@ class SiteMap(utils.BaseHandler):
         self.render('sitemap.xml', urlpaths=urlpaths)
 
 
-class SiteMapPing(utils.BaseHandler):
+class SiteMapPing(BaseHandler):
     """Pings the index server."""
     _INDEXER_MAP = {
         'bing': 'http://www.bing.com/ping?sitemap=%s',
@@ -71,9 +72,8 @@ class SiteMapPing(utils.BaseHandler):
                 params={SiteMapPing._GET_PARAM_SEARCH_ENGINE: search_engine})
 
     def get(self):
-        if not utils.is_prod_server():
-            # We don't want to send non-prod sitemap URLs to index servers.
-            logging.info('Skipping sitemap ping because this isn\'t prod.')
+        if not config.get('ping_sitemap_indexers'):
+            logging.info('Skipping sitemap ping because it\'s disabled.')
             return
         search_engine = self.request.get(SiteMapPing._GET_PARAM_SEARCH_ENGINE)
         if not search_engine:

--- a/app/sitemap.py
+++ b/app/sitemap.py
@@ -74,10 +74,10 @@ class SiteMapPing(BaseHandler):
         search_engine = self.request.get(SiteMapPing._GET_PARAM_SEARCH_ENGINE)
         if not search_engine:
             self.error(500)
-        if not self.ping_indexer(search_engine):
+        if not self._ping_indexer(search_engine):
             self.error(500)
 
-    def ping_indexer(self, search_engine):
+    def _ping_indexer(self, search_engine):
         """Pings the server with sitemap updates; returns True if all succeed"""
         sitemap_url = 'https://%s/global/sitemap' % self.env.netloc
         ping_url = self._INDEXER_MAP[search_engine] % urllib.quote(sitemap_url)

--- a/app/sitemap.py
+++ b/app/sitemap.py
@@ -26,7 +26,7 @@ from google.appengine.api import taskqueue
 
 import const
 from model import Repo
-from utils import BaseHandler
+import utils
 
 
 # Use the App Engine Requests adapter. This makes sure that Requests uses
@@ -35,7 +35,7 @@ from utils import BaseHandler
 requests_toolbelt.adapters.appengine.monkeypatch()
 
 
-class SiteMap(BaseHandler):
+class SiteMap(utils.BaseHandler):
 
     repo_required = False
 
@@ -51,7 +51,7 @@ class SiteMap(BaseHandler):
         self.render('sitemap.xml', urlpaths=urlpaths)
 
 
-class SiteMapPing(BaseHandler):
+class SiteMapPing(utils.BaseHandler):
     """Pings the index server."""
     _INDEXER_MAP = {
         'bing': 'http://www.bing.com/ping?sitemap=%s',
@@ -71,6 +71,10 @@ class SiteMapPing(BaseHandler):
                 params={SiteMapPing._GET_PARAM_SEARCH_ENGINE: search_engine})
 
     def get(self):
+        if not utils.is_prod_server():
+            # We don't want to send non-prod sitemap URLs to index servers.
+            logging.info('Skipping sitemap ping because this isn\'t prod.')
+            return
         search_engine = self.request.get(SiteMapPing._GET_PARAM_SEARCH_ENGINE)
         if not search_engine:
             self.error(500)

--- a/app/utils.py
+++ b/app/utils.py
@@ -597,6 +597,10 @@ def strip_url_scheme(url):
 def is_dev_app_server():
     return os.environ['APPLICATION_ID'].startswith('dev~')
 
+
+def is_prod_server():
+    return os.environ['APPLICATION_ID'] == 'googlepersonfinder'
+
 # ==== Struct ==================================================================
 
 class Struct:

--- a/app/utils.py
+++ b/app/utils.py
@@ -597,17 +597,6 @@ def strip_url_scheme(url):
 def is_dev_app_server():
     return os.environ['APPLICATION_ID'].startswith('dev~')
 
-
-def is_prod_server():
-    """Returns True if this is the production server.
-
-    This is not the simple opposite of is_dev_app_server (above), because it
-    only returns True if this is "the" prod server (i.e., the one that serves
-    google.org/personfinder). It won't return True for other servers that happen
-    to be running on App Engine (e.g., people's dev instances).
-    """
-    return os.environ['APPLICATION_ID'] == 'googlepersonfinder'
-
 # ==== Struct ==================================================================
 
 class Struct:

--- a/app/utils.py
+++ b/app/utils.py
@@ -599,6 +599,13 @@ def is_dev_app_server():
 
 
 def is_prod_server():
+    """Returns True if this is the production server.
+
+    This is not the simple opposite of is_dev_app_server (above), because it
+    only returns True if this is "the" prod server (i.e., the one that serves
+    google.org/personfinder). It won't return True for other servers that happen
+    to be running on App Engine (e.g., people's dev instances).
+    """
     return os.environ['APPLICATION_ID'] == 'googlepersonfinder'
 
 # ==== Struct ==================================================================

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -1,4 +1,4 @@
-from mock import patch
+from mock import patch, MagicMock
 import unittest
 
 from google.appengine.ext import testbed
@@ -29,7 +29,12 @@ class SitemapTests(unittest.TestCase):
             tasks[1].url, '/global/sitemap/ping?search_engine=google')
 
     def testPingIndexer(self):
-        with patch('requests.get') as requests_mock:
+        with patch('requests.get') as requests_mock, \
+             patch('utils.is_prod_server') as is_prod_server_mock:
+            # We pretend it's prod, so that it will really try to ping the index
+            # server. Since we're also mocking out requests.get though, it won't
+            # really ping anything.
+            is_prod_server_mock.return_value = True
             handler = test_handler.initialize_handler(
                 sitemap.SiteMapPing, action='sitemap/ping', repo='global',
                 params={'search_engine': 'google'})

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -31,8 +31,9 @@ class SitemapTests(unittest.TestCase):
     def testPingIndexer(self):
         with patch('requests.get') as requests_mock:
             handler = test_handler.initialize_handler(
-                sitemap.SiteMapPing, 'sitemap/ping')
-            handler.ping_indexer('google')
+                sitemap.SiteMapPing, action='sitemap/ping', repo='global',
+                params={'search_engine': 'google'})
+            handler.get()
             assert len(requests_mock.call_args_list) == 1
             call_args, _ = requests_mock.call_args_list[0]
             assert call_args[0] == ('http://www.google.com/ping?sitemap='

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -3,6 +3,7 @@ import unittest
 
 from google.appengine.ext import testbed
 
+import config
 import sitemap
 import test_handler
 
@@ -29,12 +30,11 @@ class SitemapTests(unittest.TestCase):
             tasks[1].url, '/global/sitemap/ping?search_engine=google')
 
     def testPingIndexer(self):
-        with patch('requests.get') as requests_mock, \
-             patch('utils.is_prod_server') as is_prod_server_mock:
-            # We pretend it's prod, so that it will really try to ping the index
-            # server. Since we're also mocking out requests.get though, it won't
-            # really ping anything.
-            is_prod_server_mock.return_value = True
+        # We set it to "really" ping index servers for the test. Since we're
+        # also mocking out requests.get though, it won't really succeed in
+        # pinging anything.
+        config.set(ping_sitemap_indexers=True)
+        with patch('requests.get') as requests_mock:
             handler = test_handler.initialize_handler(
                 sitemap.SiteMapPing, action='sitemap/ping', repo='global',
                 params={'search_engine': 'google'})


### PR DESCRIPTION
The proximate reason for this is that PR #549 caused admin config tests to really try to ping Google and Bing's index servers, which is bad for the obvious reason and also seems to be causing test flakes. I decided to fix it by having the sitemap ping handler check if it was in prod, rather than mocking stuff out in the admin config tests, because it's probably a good idea to stop local servers or dev instances from really pinging sitemap indexers too (plus, this way we won't have to worry about remembering it when we write new admin tests).