### PR TITLE
Set up Python 3 testing. Fixes #508.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: python
 
 python:
   - 2.7
+  - 3.7
 
 services:
   - docker
@@ -11,7 +12,7 @@ services:
 env:
   DOCKER_COMPOSE_VERSION: 1.10.0
 
-install: true 
+install: true
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ language: python
 
 python:
   - 2.7
-    env: TRAVIS_PY_VERSION=py27
-  - 3.7
-    env: TRAVIS_PY_VERSION=py37
 
 services:
   - docker
@@ -14,7 +11,7 @@ services:
 env:
   DOCKER_COMPOSE_VERSION: 1.10.0
 
-install: true
+install: true 
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,12 @@ sudo: required
 
 language: python
 
-python:
-  - 2.7
-  - 3.7
+matrix:
+    include:
+        - python: 2.7
+          dist: trusty
+        - python: 3.7
+          dist: xenial
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: python
 
 python:
   - 2.7
+    env: TRAVIS_PY_VERSION=py27
+  - 3.7
+    env: TRAVIS_PY_VERSION=py37
 
 services:
   - docker
@@ -11,7 +14,7 @@ services:
 env:
   DOCKER_COMPOSE_VERSION: 1.10.0
 
-install: true 
+install: true
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose
@@ -23,5 +26,4 @@ before_install:
 before_script:
   - npm --prefix ui install
 
-script: docker-compose exec web tools/all_tests
-
+script: docker-compose exec web tools/travis_tests

--- a/app/jautils.py
+++ b/app/jautils.py
@@ -16,12 +16,14 @@
 
 """Utility functions specific for Japanese language."""
 
+from __future__ import absolute_import
+import six
 import re
 import unicodedata
 
 
 # Hiragana to romaji.
-# This table is copied from: http://code.google.com/p/mozc/source/browse/trunk/src/data/preedit/hiragana-romanji.tsv 
+# This table is copied from: http://code.google.com/p/mozc/source/browse/trunk/src/data/preedit/hiragana-romanji.tsv
 HIRAGANA_TO_ROMAJI = [
     [u"う゛ぁ", u"VA", u""],
     [u"う゛ぃ", u"VI", u""],
@@ -473,7 +475,7 @@ def should_normalize(string):
     #  - hiragana
     #  - full/half width katakana
     #  - full width alphabets
-    return re.search(ur'[\u3040-\u30ff\uff00-\uff9f]', string) != None
+    return re.search(six.u(r'[\u3040-\u30ff\uff00-\uff9f]'), string) != None
 
 
 def normalize(string):
@@ -505,7 +507,7 @@ def normalize(string):
 def is_hiragana(string):
     """Returns True if the argument is a non-empty string of only
     hiragana characters."""
-    return re.match(ur'^[\u3040-\u309f]+$', string) != None
+    return re.match(six.u(r'^[\u3040-\u309f]+$'), string) != None
 
 
 def normalize_hiragana(string):

--- a/app/text_query.py
+++ b/app/text_query.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 import six
+
 __author__ = 'eyalf@google.com (Eyal Fink)'
 
 import unicodedata
@@ -43,7 +44,7 @@ class TextQuery():
         # Split out each CJK ideograph as its own word.
         # The main CJK ideograph range is from U+4E00 to U+9FFF.
         # CJK Extension A is from U+3400 to U+4DFF.
-        cjk_separated = re.sub(ur'([\u3400-\u9fff])', r' \1 ', self.normalized)
+        cjk_separated = re.sub(six.u(r'([\u3400-\u9fff])'), r' \1 ', self.normalized)
 
         # Separate the query into words.
         self.words = cjk_separated.split()

--- a/tests/test_text_query.py
+++ b/tests/test_text_query.py
@@ -26,7 +26,7 @@ class TextQueryTests(unittest.TestCase):
         q = text_query.TextQuery(u'foo\u4f59\u5609bar\u5e73')
         assert q.words == ['FOO', u'\u4f59', u'\u5609', 'BAR', u'\u5e73']
         assert q.words == q.query_words
-        
+
     def test_parsing(self):
         q = text_query.TextQuery('abcd  e  fghij')
         assert ['ABCD', 'E', 'FGHIJ'] == q.words

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -21,15 +21,22 @@ which sets up the PYTHONPATH and other necessary environment variables."""
 import argparse
 import os
 import pytest
+import six
 import sys
 
-from google.appengine.api import apiproxy_stub_map
-from google.appengine.api import datastore_file_stub
+PY3_TEST_FILES = [
+    'test_text_query.py',
+]
 
-# Create a new apiproxy and temp datastore to use for this test suite
-apiproxy_stub_map.apiproxy = apiproxy_stub_map.APIProxyStubMap()
-temp_db = datastore_file_stub.DatastoreFileStub('x', None, None, trusted=True)
-apiproxy_stub_map.apiproxy.RegisterStub('datastore', temp_db)
+if six.PY2:
+    from google.appengine.api import apiproxy_stub_map
+    from google.appengine.api import datastore_file_stub
+
+    # Create a new apiproxy and temp datastore to use for this test suite
+    apiproxy_stub_map.apiproxy = apiproxy_stub_map.APIProxyStubMap()
+    temp_db = datastore_file_stub.DatastoreFileStub(
+        'x', None, None, trusted=True)
+    apiproxy_stub_map.apiproxy.RegisterStub('datastore', temp_db)
 
 # An application id is required to access the datastore, so let's create one
 os.environ['APPLICATION_ID'] = 'personfinder-unittest'
@@ -38,6 +45,14 @@ os.environ['SERVER_SOFTWARE'] = 'testing'
 
 # When the appserver is running, the APP_DIR should be the current directory...
 os.chdir(os.environ['APP_DIR'])
+
+if six.PY2:
+    default_test_files = [os.environ['TESTS_DIR']]
+else:
+    default_test_files = [
+        os.path.join(os.environ['TESTS_DIR'], test_file)
+        for test_file in PY3_TEST_FILES
+    ]
 
 # ...but we want pytest to default to finding tests in TESTS_DIR, not the cwd.
 # So, when no arguments are given, we use TESTS_DIR by default for the test
@@ -48,7 +63,7 @@ parser.add_argument('--pyargs', action='store_true')
 parser.add_argument('-q', action='store_true')
 parser.add_argument('-k', type=str,
                     help='Keyword expressions to pass to pytest.')
-parser.add_argument('test_files', nargs='*', default=[os.environ['TESTS_DIR']])
+parser.add_argument('test_files', nargs='*', default=default_test_files)
 args = parser.parse_args()
 pytest_args = []
 if args.tb:

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -24,10 +24,14 @@ import pytest
 import six
 import sys
 
+# The test files that should be run by default when we're running Python 3.
 PY3_TEST_FILES = [
     'test_text_query.py',
 ]
 
+# These dependencies don't support Python 3. Also, they're only used for tests
+# involving App Engine APIs, which we won't be running with Python 3. So, only
+# import them when we're running Python 2.
 if six.PY2:
     from google.appengine.api import apiproxy_stub_map
     from google.appengine.api import datastore_file_stub

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -26,6 +26,7 @@ import sys
 
 # The test files that should be run by default when we're running Python 3.
 PY3_TEST_FILES = [
+    'test_jautils.py',
     'test_text_query.py',
 ]
 

--- a/tools/all_tests
+++ b/tools/all_tests
@@ -18,6 +18,7 @@
 pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 
 $TOOLS_DIR/unit_tests -q && \
+    $TOOLS_DIR/py3_unit_tests -q && \
     $TOOLS_DIR/server_tests -q && \
     $TOOLS_DIR/python3_compatibility_check && \
     $TOOLS_DIR/ui test && \

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -49,6 +49,18 @@ if [ -z "$PYTHON" ]; then
     exit 1
 fi
 
+for python3 in \
+    "$PYTHON3" \
+    $(which python3.7) \
+    /usr/local/bin/python3.7 \
+    /usr/bin/python3.7 \
+    /Library/Frameworks/Python.framework/Versions/3.7/bin/python; do
+    if [ -x "$python3" ]; then
+        export PYTHON3="$python3"
+        break
+    fi
+done
+
 export PYTHONPATH=\
 "$APP_DIR":\
 "$APP_DIR/vendors":\

--- a/tools/py3_unit_tests
+++ b/tools/py3_unit_tests
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# To run all tests that support Python 3 so far:
+#
+#     tools/py3_unit_tests
+#
+# To run just the tests in tests/test_model.py and tests/test_indexing.py:
+#
+#     tools/py3_unit_tests test_model test_indexing
+
+pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
+
+# Some tests assumes that the current directory is the root of the working
+# directory.
+cd "$(dirname $0)/.."
+
+echo
+echo "--- Running Python 3 unit tests"
+TZ=UTC $PYTHON3 $TESTS_DIR/unit_tests.py --pyargs --tb=short "$@"

--- a/tools/travis_tests
+++ b/tools/travis_tests
@@ -17,7 +17,18 @@
 
 pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 
-$TOOLS_DIR/unit_tests -q && \
-    $TOOLS_DIR/server_tests -q && \
-    $TOOLS_DIR/ui test && \
-    echo "All Python 2.7 tests passed."
+case "${TRAVIS_PYTHON_VERSION}" in
+
+    2.7)
+        $TOOLS_DIR/unit_tests -q && \
+            $TOOLS_DIR/server_tests -q && \
+            $TOOLS_DIR/ui test && \
+            echo "All Python 2.7 tests passed."
+        ;;
+    3.7)
+        $TOOLS_DIR/py3_unit_tests -q && \
+            $TOOLS_DIR/python3_compatibility_check && \
+            echo "All Python 3.7 tests passed."
+        ;;
+
+ esac

--- a/tools/travis_tests
+++ b/tools/travis_tests
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright 2010 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs all the tests.
+
+pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
+
+case "${TRAVIS_PY_VERSION}" in
+
+    py27)
+        $TOOLS_DIR/unit_tests -q && \
+            $TOOLS_DIR/server_tests -q && \
+            $TOOLS_DIR/ui test && \
+            echo "All Python 2.7 tests passed."
+        ;;
+    py37)
+        $TOOLS_DIR/py3_unit_tests -q && \
+            $TOOLS_DIR/python3_compatibility_check && \
+            echo "All Python 3.7 tests passed."
+        ;;
+
+esac

--- a/tools/travis_tests
+++ b/tools/travis_tests
@@ -13,7 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Runs all the tests.
+# Runs all the tests for either Python 2.7 or 3.7. Travis will run our tests
+# under two separate environments (one with Python 2.7, one with 3.7), so we
+# can't simply run all the tests at once (like we do locally with
+# tools/all_tests). Instead, we have two separate paths in this file, which will
+# each get executed once on Travis.
 
 pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 

--- a/tools/travis_tests
+++ b/tools/travis_tests
@@ -17,18 +17,7 @@
 
 pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 
-case "${TRAVIS_PY_VERSION}" in
-
-    py27)
-        $TOOLS_DIR/unit_tests -q && \
-            $TOOLS_DIR/server_tests -q && \
-            $TOOLS_DIR/ui test && \
-            echo "All Python 2.7 tests passed."
-        ;;
-    py37)
-        $TOOLS_DIR/py3_unit_tests -q && \
-            $TOOLS_DIR/python3_compatibility_check && \
-            echo "All Python 3.7 tests passed."
-        ;;
-
-esac
+$TOOLS_DIR/unit_tests -q && \
+    $TOOLS_DIR/server_tests -q && \
+    $TOOLS_DIR/ui test && \
+    echo "All Python 2.7 tests passed."


### PR DESCRIPTION
Just includes test_text_query and test_jautils for now. I'll add more files to the PY3_TEST_FILES list as I get them working with Python 3.

I didn't add `app/jautils.py` to `tools/python3_compatibility_check` because it produces a false positive (running `python-modernize -w` produces no changes); it seems to be [a known bug](https://stackoverflow.com/questions/40240229/2to3-says-no-changes-needed-then-files-that-need-to-be-modified) related to strings with escapes. That's likely to be an issue with a bunch of our files, so I might consider dropping the python3 compatibility check (it's kinda redundant with the Python 3 tests), but that's a question for another pull.