### PR TITLE
 Restrict flush param to local servers.

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -543,7 +543,9 @@ class Main(webapp.RequestHandler):
                 utils.set_utcnow_for_test(float(utcnow))
 
         # If requested, flush caches before we touch anything that uses them.
-        flush_caches(*request.get('flush', '').split(','))
+        # This is used for certain tests.
+        if utils.is_dev_app_server():
+            flush_caches(*request.get('flush', '').split(','))
 
         # Gather commonly used information into self.env.
         self.env = setup_env(request)

--- a/app/utils.py
+++ b/app/utils.py
@@ -1179,9 +1179,6 @@ class XsrfTool(object):
     # XSRF tokens expire after 4 hours.
     TOKEN_EXPIRATION_TIME = 60 * 60 * 4
 
-    # Characters with which to choose a key if it's not set yet.
-    TOKEN_CHARACTER_SET = string.letters + string.digits
-
     def __init__(self):
         configured_key = config.get('xsrf_token_key')
         if configured_key:


### PR DESCRIPTION
Also drop unused TOKEN_CHARACTER_SET constant (unrelated cleanup).