### PR TITLE
Python 3 tests, in shared Docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage
+FROM ubuntu:bionic
 LABEL authors="Carlo Lobrano <c.lobrano@gmail.com>, Mathieu Tortuyaux <mathieu.tortuyaux@gmail.com>"
 
 CMD ["/sbin/my_init"]
@@ -15,6 +15,8 @@ RUN apt-get update && apt-get install -y \
 	unzip \
 	python2.7 \
 	libpython2.7-dev \
+	python3.7 \
+	python3-distutils \
 	curl \
 	git \
 	time \
@@ -22,8 +24,11 @@ RUN apt-get update && apt-get install -y \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && /usr/bin/python2.7 get-pip.py
-RUN pip install pytest==3.7.4 lxml cssselect pillow==4.1.0 mock modernize
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+	&& /usr/bin/python2.7 get-pip.py \
+	&& /usr/bin/python3.7 get-pip.py
+RUN python2.7 -m pip install pytest==3.7.4 lxml cssselect pillow==4.1.0 mock modernize six
+RUN python3.7 -m pip install pytest lxml cssselect pillow mock modernize six
 
 # Just apt-get installing nodejs doesn't work; these commands come from:
 # https://askubuntu.com/questions/720784/how-to-install-latest-node-inside-a-docker-container

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -21,15 +21,27 @@ which sets up the PYTHONPATH and other necessary environment variables."""
 import argparse
 import os
 import pytest
+import six
 import sys
 
-from google.appengine.api import apiproxy_stub_map
-from google.appengine.api import datastore_file_stub
+# The test files that should be run by default when we're running Python 3.
+PY3_TEST_FILES = [
+    'test_jautils.py',
+    'test_text_query.py',
+]
 
-# Create a new apiproxy and temp datastore to use for this test suite
-apiproxy_stub_map.apiproxy = apiproxy_stub_map.APIProxyStubMap()
-temp_db = datastore_file_stub.DatastoreFileStub('x', None, None, trusted=True)
-apiproxy_stub_map.apiproxy.RegisterStub('datastore', temp_db)
+# These dependencies don't support Python 3. Also, they're only used for tests
+# involving App Engine APIs, which we won't be running with Python 3. So, only
+# import them when we're running Python 2.
+if six.PY2:
+    from google.appengine.api import apiproxy_stub_map
+    from google.appengine.api import datastore_file_stub
+
+    # Create a new apiproxy and temp datastore to use for this test suite
+    apiproxy_stub_map.apiproxy = apiproxy_stub_map.APIProxyStubMap()
+    temp_db = datastore_file_stub.DatastoreFileStub(
+        'x', None, None, trusted=True)
+    apiproxy_stub_map.apiproxy.RegisterStub('datastore', temp_db)
 
 # An application id is required to access the datastore, so let's create one
 os.environ['APPLICATION_ID'] = 'personfinder-unittest'
@@ -48,7 +60,16 @@ parser.add_argument('--pyargs', action='store_true')
 parser.add_argument('-q', action='store_true')
 parser.add_argument('-k', type=str,
                     help='Keyword expressions to pass to pytest.')
-parser.add_argument('test_files', nargs='*', default=[os.environ['TESTS_DIR']])
+
+if six.PY2:
+    default_test_files = [os.environ['TESTS_DIR']]
+else:
+    default_test_files = [
+        os.path.join(os.environ['TESTS_DIR'], test_file)
+        for test_file in PY3_TEST_FILES
+    ]
+parser.add_argument('test_files', nargs='*', default=default_test_files)
+
 args = parser.parse_args()
 pytest_args = []
 if args.tb:

--- a/tools/all_tests
+++ b/tools/all_tests
@@ -18,6 +18,7 @@
 pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 
 $TOOLS_DIR/unit_tests -q && \
+    $TOOLS_DIR/py3_unit_tests -q && \
     $TOOLS_DIR/server_tests -q && \
     $TOOLS_DIR/python3_compatibility_check && \
     $TOOLS_DIR/ui test && \

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -37,6 +37,18 @@ for python in \
     fi
 done
 
+for python3 in \
+    "$PYTHON3" \
+    $(which python3.7) \
+    /usr/local/bin/python3.7 \
+    /usr/bin/python3.7 \
+    /Library/Frameworks/Python.framework/Versions/3.7/bin/python; do
+    if [ -x "$python3" ]; then
+        export PYTHON3="$python3"
+        break
+    fi
+done
+
 if [ -z "$PYTHON" ]; then
     DEFAULT_PYTHON=$(which python)
     if [[ "$($DEFAULT_PYTHON -V 2>&1)" =~ "Python 2.7" ]]; then

--- a/tools/py3_unit_tests
+++ b/tools/py3_unit_tests
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# To run all tests:
+# To run all tests that are expected to pass under Python 3:
 #
 #     tools/py3_unit_tests
 #

--- a/tools/py3_unit_tests
+++ b/tools/py3_unit_tests
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# To run all tests:
+#
+#     tools/py3_unit_tests
+#
+# To run just the tests in tests/test_model.py and tests/test_indexing.py:
+#
+#     tools/py3_unit_tests test_model test_indexing
+
+pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
+
+# Some tests assumes that the current directory is the root of the working
+# directory.
+cd "$(dirname $0)/.."
+
+echo
+echo "--- Running Python 3 unit tests"
+TZ=UTC $PYTHON3 $TESTS_DIR/unit_tests.py --pyargs --tb=short "$@"


### PR DESCRIPTION
Similar to PR #553, but does everything within a single Docker container rather than trying to have Travis handle the different Python versions (which didn't work because Docker's actually the one deciding what version(s) of Python get installed).
Fixes #508.