### PR TITLE
Upgrade to WebOB 1.2.3.

### DIFF
--- a/app/app.yaml
+++ b/app/app.yaml
@@ -45,3 +45,7 @@ libraries:
   version: "1.9"
 - name: lxml
   version: "3.7.3"
+- name: webapp2
+  version: "2.5.2"
+- name: webob
+  version: "1.2.3"

--- a/tests/server_test_cases/read_only_tests.py
+++ b/tests/server_test_cases/read_only_tests.py
@@ -144,49 +144,6 @@ class ReadOnlyTests(ServerTestsBase):
         doc = self.go('/haiti')
         assert 'I\'m looking for someone' in doc.text
 
-    def test_charsets(self):
-        """Checks that pages are delivered in the requested charset."""
-
-        # Try with no specified charset.
-        doc = self.go('/haiti?lang=ja')
-        assert self.s.headers['content-type'] == 'text/html; charset=utf-8'
-        assert 'charset="utf-8"' in doc.content
-        # UTF-8 encoding of text (U+5B89 U+5426 U+60C5 U+5831) in title
-        assert ('\xe5\xae\x89\xe5\x90\xa6\xe6\x83\x85\xe5\xa0\xb1' in
-                doc.content_bytes)
-
-        # Try with a specific requested charset.
-        doc = self.go('/haiti?lang=ja&charsets=shift_jis')
-        assert self.s.headers['content-type'] == 'text/html; charset=shift_jis'
-        assert 'charset="shift_jis"' in doc.content
-        # Shift_JIS encoding of title text
-        assert '\x88\xc0\x94\xdb\x8f\xee\x95\xf1' in doc.content_bytes
-
-        # Confirm that spelling of charset is preserved.
-        doc = self.go('/haiti?lang=ja&charsets=Shift-JIS')
-        assert self.s.headers['content-type'] == 'text/html; charset=Shift-JIS'
-        assert 'charset="Shift-JIS"' in doc.content
-        # Shift_JIS encoding of title text
-        assert '\x88\xc0\x94\xdb\x8f\xee\x95\xf1' in doc.content_bytes
-
-        # Confirm that UTF-8 takes precedence.
-        doc = self.go('/haiti?lang=ja&charsets=Shift-JIS,utf8')
-        assert self.s.headers['content-type'] == 'text/html; charset=utf-8'
-        assert 'charset="utf-8"' in doc.content
-        # UTF-8 encoding of title text
-        assert ('\xe5\xae\x89\xe5\x90\xa6\xe6\x83\x85\xe5\xa0\xb1' in
-                doc.content_bytes)
-
-    def test_kddi_charsets(self):
-        """Checks that pages are delivered in Shift_JIS if the user agent is a
-        feature phone by KDDI."""
-        self.s.agent = 'KDDI-HI31 UP.Browser/6.2.0.5 (GUI) MMP/2.0'
-        doc = self.go('/haiti?lang=ja')
-        assert self.s.headers['content-type'] == 'text/html; charset=Shift_JIS'
-        assert 'charset="Shift_JIS"' in doc.content
-        # Shift_JIS encoding of title text
-        assert '\x88\xc0\x94\xdb\x8f\xee\x95\xf1' in doc.content_bytes
-
     def test_query(self):
         """Check the query page."""
         doc = self.go('/haiti/query')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -59,25 +59,6 @@ class MainTests(unittest.TestCase):
         assert '\n' not in env.lang, env.lang
         assert ':' not in env.lang, env.lang
 
-    def test_shiftjis_get(self):
-        """Tests Shift-JIS encoding of GET query parameters."""
-        request = setup_request(
-            '/japan/results?charsets=shift_jis&query=%8D%B2%93%A1&role=seek&')
-        handler = main.Main(request, webapp.Response())
-        assert handler.env.charset == 'shift_jis'
-        assert request.charset == 'shift_jis'
-        assert request.get('query') == u'\u4F50\u85E4'
-
-    def test_shiftjis_post(self):
-        """Tests Shift-JIS encoding of POST query parameters."""
-        request = setup_request('/japan/post?')
-        request.body = 'charsets=shift_jis&given_name=%8D%B2%93%A1'
-        request.method = 'POST'
-        handler = main.Main(request, webapp.Response())
-        assert handler.env.charset == 'shift_jis'
-        assert request.charset == 'shift_jis'
-        assert request.get('given_name') == u'\u4F50\u85E4'
-
     def test_default_language(self):
         """Verify that language_menu_options[0] is used as the default."""
         request = setup_request('/haiti/start')

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -57,8 +57,8 @@ export PYTHONPATH=\
 "$APPENGINE_DIR":\
 "$APPENGINE_DIR/lib/django-1.9":\
 "$APPENGINE_DIR/lib/fancy_urllib":\
-"$APPENGINE_DIR/lib/webapp2-2.5.1":\
-"$APPENGINE_DIR/lib/webob_0_9":\
+"$APPENGINE_DIR/lib/webapp2-2.5.2":\
+"$APPENGINE_DIR/lib/webob-1.2.3":\
 "$APPENGINE_DIR/lib/yaml-3.10"
 
 export APPENGINE_RUNTIME=python27


### PR DESCRIPTION
The motivation for this is to keep us from breaking if/when App Engine
upgrades its Python 2.7 runtime to 2.7.15 (see issue #575). I'm
upgrading webapp2 to 2.5.2 too, because webapp2 depends heavily on WebOB
so it just seems better to run versions from similar times.

I'm also dropping support for character sets other than UTF-8, at least
for now. The reason for this is that WebOB made a change to how it
handles that which there's no good way to handle with any verison of
webapp2 (further details about this are also on issue #575). I'd like to
revisit this once we migrate to Django (which should make it
considerably easier to handle other charsets), but we've talked this
over with the team in Japan and it's not worth the work to support other
charsets with webapp2.