### PR TITLE
Drop UserAgentLog.

### DIFF
--- a/app/model.py
+++ b/app/model.py
@@ -983,17 +983,6 @@ class UserActionLog(db.Expando):
         entry.put()
 
 
-class UserAgentLog(db.Model):
-    """Logs information about the user agent."""
-    timestamp = db.DateTimeProperty(auto_now=True)
-    repo = db.StringProperty()
-    user_agent = db.StringProperty()
-    lang = db.StringProperty()
-    accept_charset = db.StringProperty()
-    ip_address = db.StringProperty()
-    sample_rate = db.FloatProperty()
-
-
 class StaticSiteMapInfo(db.Model):
     """Holds static sitemaps file info."""
     static_sitemaps = db.StringListProperty()

--- a/app/utils.py
+++ b/app/utils.py
@@ -1101,16 +1101,6 @@ class BaseHandler(webapp.RequestHandler):
                                      self.config.referrer_whitelist):
             setattr(self.params, 'referrer', '')
 
-        # Log the User-Agent header.
-        sample_rate = float(
-            self.config and self.config.user_agent_sample_rate or 0)
-        if random.random() < sample_rate:
-            model.UserAgentLog(
-                repo=self.repo, sample_rate=sample_rate,
-                user_agent=self.request.headers.get('User-Agent'), lang=lang,
-                accept_charset=self.request.headers.get('Accept-Charset', ''),
-                ip_address=self.request.remote_addr).put()
-
         # Check for SSL (unless running local dev app server).
         if self.https_required and not is_dev_app_server():
             if self.env.scheme != 'https':


### PR DESCRIPTION
As far as I can tell, this has been disabled since 2011. I think Analytics covers everything this might be used for (and, if it doesn't, IMO it'd be better to change our Analytics setup to support something than maintain our own separate system for certain data).