### PR TITLE
Python 3 testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
       unzip
   - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.62.zip -O /tmp/appengine.zip
   - unzip -qq /tmp/appengine.zip
-  - pip install cssselect lxml mock modernize pillow==4.1.0 pytest
+  - pip install --user cssselect lxml mock modernize pillow==4.1.0 pytest
   - npm --prefix ui install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 
+language: python
+
 matrix:
   include:
   - name: "Python 2 tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
 
 install:
   - |
-    apt-get install -y \
+    sudo apt-get install -y \
       build-essential \
       curl \
       gettext \

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
       unzip
   - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.62.zip -O /tmp/appengine.zip
   - unzip -qq /tmp/appengine.zip
-  - pip install --user cssselect lxml mock modernize pillow==4.1.0 pytest
+  - pip install cssselect lxml mock modernize pillow==4.1.0 pytest
   - npm --prefix ui install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
       unzip
   - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.62.zip -O /tmp/appengine.zip
   - unzip -qq /tmp/appengine.zip
-  - pip install cssselect lxml mock modernize pillow=4.1.0 pytest
+  - pip install cssselect lxml mock modernize pillow==4.1.0 pytest
   - npm --prefix ui install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,30 @@
 sudo: required
 
-language: python
+matrix:
+  include:
+  - name: "Python 2 tests"
+    python: 2.7
+  - name: "Python 3 tests"
+    python: 3.7
+    # The default is currently Trusty, which doesn't have Python 3.7 available.
+    dist: xenial
 
-python:
-  - 2.7
-
-services:
-  - docker
-
-env:
-  DOCKER_COMPOSE_VERSION: 1.10.0
-
-install: true 
-
-before_install:
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod a+x docker-compose
-  - sudo mv docker-compose /usr/local/bin
-  - docker-compose up -d
-
-before_script:
+install:
+  - |
+    apt-get install -y \
+      build-essential \
+      curl \
+      gettext \
+      git \
+      time \
+      unzip
+  - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.62.zip -O /tmp/appengine.zip
+  - unzip -qq /tmp/appengine.zip
+  - pip install cssselect lxml mock modernize pillow=4.1.0 pytest
   - npm --prefix ui install
 
-script: docker-compose exec web tools/all_tests
+before_script:
+  - export APPENGINE_DIR=google_appengine
 
+script:
+  - tools/travis_tests

--- a/tests/server_tests.py
+++ b/tests/server_tests.py
@@ -160,6 +160,11 @@ class AppServerRunner(ProcessRunner):
             # write then test if it's visible in the web page. This flag makes
             # sure that the query see the data after the write is applied.
             '--datastore_consistency_policy=consistent',
+            # We'll get notified if we're behind when we run local instances,
+            # and we don't want this to get in the way of automated tests (it
+            # will stop everything and wait for user input when it asks
+            # permission to check).
+            '--skip_sdk_update_check',
         ])
 
     def flush_output(self):

--- a/tests/test_text_query.py
+++ b/tests/test_text_query.py
@@ -13,9 +13,6 @@ import unittest
 
 class TextQueryTests(unittest.TestCase):
     def test_normalize(self):
-        import six
-        if six.PY2:
-            assert 1 == 2
         assert text_query.normalize(u'hi there') == u'HI THERE'
         assert text_query.normalize(u'salut l\xe0') == u'SALUT LA'
         assert text_query.normalize(

--- a/tests/test_text_query.py
+++ b/tests/test_text_query.py
@@ -13,6 +13,7 @@ import unittest
 
 class TextQueryTests(unittest.TestCase):
     def test_normalize(self):
+        print('oh no a Python 3 print statement')
         assert text_query.normalize(u'hi there') == u'HI THERE'
         assert text_query.normalize(u'salut l\xe0') == u'SALUT LA'
         assert text_query.normalize(

--- a/tests/test_text_query.py
+++ b/tests/test_text_query.py
@@ -13,7 +13,6 @@ import unittest
 
 class TextQueryTests(unittest.TestCase):
     def test_normalize(self):
-        print 'oh no, a Python 2 print statement'
         assert text_query.normalize(u'hi there') == u'HI THERE'
         assert text_query.normalize(u'salut l\xe0') == u'SALUT LA'
         assert text_query.normalize(

--- a/tests/test_text_query.py
+++ b/tests/test_text_query.py
@@ -13,6 +13,7 @@ import unittest
 
 class TextQueryTests(unittest.TestCase):
     def test_normalize(self):
+        print 'oh no, a Python 2 print statement'
         assert text_query.normalize(u'hi there') == u'HI THERE'
         assert text_query.normalize(u'salut l\xe0') == u'SALUT LA'
         assert text_query.normalize(

--- a/tests/test_text_query.py
+++ b/tests/test_text_query.py
@@ -13,7 +13,9 @@ import unittest
 
 class TextQueryTests(unittest.TestCase):
     def test_normalize(self):
-        print('oh no a Python 3 print statement')
+        import six
+        if six.PY2:
+            assert 1 == 2
         assert text_query.normalize(u'hi there') == u'HI THERE'
         assert text_query.normalize(u'salut l\xe0') == u'SALUT LA'
         assert text_query.normalize(

--- a/tools/all_tests
+++ b/tools/all_tests
@@ -18,6 +18,7 @@
 pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 
 $TOOLS_DIR/unit_tests -q && \
+    $TOOLS_DIR/py3_unit_tests -q && \
     $TOOLS_DIR/server_tests -q && \
     $TOOLS_DIR/python3_compatibility_check && \
     $TOOLS_DIR/ui test && \

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -37,6 +37,18 @@ for python in \
     fi
 done
 
+for python3 in \
+    "$PYTHON3" \
+    $(which python3.7) \
+    /usr/local/bin/python3.7 \
+    /usr/bin/python3.7 \
+    /Library/Frameworks/Python.framework/Versions/3.7/bin/python; do
+    if [ -x "$python3" ]; then
+        export PYTHON3="$python3"
+        break
+    fi
+done
+
 if [ -z "$PYTHON" ]; then
     DEFAULT_PYTHON=$(which python)
     if [[ "$($DEFAULT_PYTHON -V 2>&1)" =~ "Python 2.7" ]]; then

--- a/tools/py3_unit_tests
+++ b/tools/py3_unit_tests
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# To run all tests we expect to pass with Python 3:
+#
+#     tools/py3_unit_tests
+#
+# To run just the tests in tests/test_model.py and tests/test_indexing.py:
+#
+#     tools/py3_unit_tests test_model test_indexing
+
+pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
+
+# Some tests assumes that the current directory is the root of the working
+# directory.
+cd "$(dirname $0)/.."
+
+echo
+echo "--- Running Python 3 unit tests"
+TZ=UTC $PYTHON3 $TESTS_DIR/unit_tests.py --pyargs --tb=short "$@"

--- a/tools/travis_tests
+++ b/tools/travis_tests
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright 2010 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is meant for use with the Travis build (if you're a person, you
+# should run tools/all_tests instead). If it's run with Python 2, it will run
+# all tests; if it's run with Python 3, it will run only the tests that we
+# expect to pass with Python 3 so far.
+
+pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
+
+case "${TRAVIS_PYTHON_VERSION}" in
+
+    2.7)
+        $TOOLS_DIR/unit_tests -q && \
+            $TOOLS_DIR/server_tests -q && \
+            $TOOLS_DIR/python3_compatibility_check && \
+            $TOOLS_DIR/ui test && \
+            echo "All tests passed."
+        ;;
+    3.7)
+        $TOOLS_DIR/py3_unit_tests -q &&
+            echo "All Python 3.7 tests passed."
+        ;;
+    *)
+        echo "Unrecognized Python version from Travis: $TRAVIS_PYTHON_VERSION"
+        exit(1)
+        ;;
+
+esac

--- a/tools/travis_tests
+++ b/tools/travis_tests
@@ -20,6 +20,9 @@
 
 pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 
+# Print the Python version, it's useful to have for debugging.
+python -V
+
 case "${TRAVIS_PYTHON_VERSION}" in
 
     "2.7")

--- a/tools/travis_tests
+++ b/tools/travis_tests
@@ -22,20 +22,20 @@ pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 
 case "${TRAVIS_PYTHON_VERSION}" in
 
-    2.7)
+    "2.7")
         $TOOLS_DIR/unit_tests -q && \
             $TOOLS_DIR/server_tests -q && \
             $TOOLS_DIR/python3_compatibility_check && \
             $TOOLS_DIR/ui test && \
             echo "All tests passed."
         ;;
-    3.7)
+    "3.7")
         $TOOLS_DIR/py3_unit_tests -q &&
             echo "All Python 3.7 tests passed."
         ;;
     *)
         echo "Unrecognized Python version from Travis: $TRAVIS_PYTHON_VERSION"
-        exit(1)
+        exit 1
         ;;
 
 esac

--- a/tools/travis_tests
+++ b/tools/travis_tests
@@ -20,9 +20,6 @@
 
 pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 
-# Print the Python version, it's useful to have for debugging.
-python -V
-
 case "${TRAVIS_PYTHON_VERSION}" in
 
     "2.7")


### PR DESCRIPTION
This sets up Python 3 testing for both local development and Travis CI, for the (currently quite limited) set of tests that we expect to pass with Python 3 (listed in `tests/unit_tests.py`).
As part of doing this, I changed the way our Travis tests run by taking them out of Docker and running on Travis directly. As far as I know there wasn't a particular reason to run them in a Docker container; I guess once you have a Docker setup it might just be the easiest path to Travis tests, but it's kinda limiting if you need to run tests in multiple environments. We'll keep the Docker setup around though (it's useful for other things).
Also, minor change: we no longer specify the version of pytest to install, so pip will just get the latest version. We might be able to do the same with Pillow later, but I haven't looked into it (App Engine might be using an older version, so maybe we should be too).
Fixes issue #508.