### PR TITLE
Run Travis with both Python 2.7.12 and a recent 2.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,14 @@ language: python
 
 matrix:
   include:
-  - name: "Python 2 tests"
+  # As of 2019-03-15, App Engine's Python 2.7 runtime uses 2.7.12.
+  - name: "Python 2.7.12 tests"
+    python: 2.7.12
+  # To be safe if/when App Engine upgrades, also run tests on a recent version
+  # of Python 2.7.
+  - name: "Python 2.7.recent tests"
     python: 2.7
+    dist: xenial
   - name: "Python 3 tests"
     python: 3.7
     # The default is currently Trusty, which doesn't have Python 3.7 available.

--- a/tools/travis_tests
+++ b/tools/travis_tests
@@ -20,16 +20,16 @@
 
 pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 
-case "${TRAVIS_PYTHON_VERSION}" in
+case "${TRAVIS_PYTHON_VERSION:0:1}" in
 
-    "2.7")
+    "2")
         $TOOLS_DIR/unit_tests -q && \
             $TOOLS_DIR/server_tests -q && \
             $TOOLS_DIR/python3_compatibility_check && \
             $TOOLS_DIR/ui test && \
             echo "All tests passed."
         ;;
-    "3.7")
+    "3")
         $TOOLS_DIR/py3_unit_tests -q &&
             echo "All Python 3.7 tests passed."
         ;;


### PR DESCRIPTION
We recently discovered that we would break with Python 2.7.15 (see issue
#575). We'd been ok because App Engine uses Python 2.7.12 for its Python
2.7 runtime. However, it seems possible that they could upgrade to a
more recent version at any time, without giving us a heads-up (since no
one generally expects a patch version to be a breaking change). So, I
want to run our Travis tests with both Python 2.7.12 (because it's what
we currently get in prod) and a recent version (because we might get
something more recent in prod at any time).
Fixes #576.