### PR TITLE
Store photos from user-provided URLs

### DIFF
--- a/app/create.py
+++ b/app/create.py
@@ -61,7 +61,7 @@ def create_photo_from_input(handler, photo_upload, photo_url):
     if photo_upload is not None:
         return create_photo(photo_upload, handler)
     elif photo_url:
-        return create_photo_from_url(handler, photo_url)
+        return create_photo_from_url(photo_url, handler)
     return (None, None)
 
 

--- a/app/create.py
+++ b/app/create.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import requests
-import requests_toolbelt.adapters.appengine
-
 from model import *
 from photo import create_photo_with_url, PhotoError
 from utils import *
@@ -25,12 +22,6 @@ import simplejson
 from django.core.validators import URLValidator, ValidationError
 from django.utils.translation import ugettext as _
 from const import NOTE_STATUS_TEXT
-
-
-# Use the App Engine Requests adapter. This makes sure that Requests uses
-# URLFetch.
-# TODO(nworden): see if we should condition this on the runtime (Python 2 vs. 3)
-requests_toolbelt.adapters.appengine.monkeypatch()
 
 
 def validate_date(string):

--- a/app/create.py
+++ b/app/create.py
@@ -23,7 +23,6 @@ from django.core.validators import URLValidator, ValidationError
 from django.utils.translation import ugettext as _
 from const import NOTE_STATUS_TEXT
 
-
 def validate_date(string):
     """Parses a date in YYYY-MM-DD format.    This is a special case for manual
     entry of the source_date in the creation form.    Unlike the validators in

--- a/app/create.py
+++ b/app/create.py
@@ -37,6 +37,10 @@ def days_to_date(days):
       None if days is None, else now + days (in utc)"""
     return days and get_utcnow() + timedelta(days=days)
 
+# TODO(nworden): find a more appropriate place for this
+# This function is going to get used by other record/note-creation code (the CSV
+# importer, the React frontend's API, and the partner API). Those things should
+# share a bunch of code, but I haven't made a place for it yet.
 def create_photo_from_input(handler, photo_upload, photo_url):
     """Creates a photo from a user-provided photo or URL.
 

--- a/app/photo.py
+++ b/app/photo.py
@@ -54,6 +54,15 @@ def create_photo_with_url(handler, photo_upload, photo_url):
     return a Photo object and a URL with which to serve it.
 
     If neither parameter is provided, returns (None, None).
+
+    Args:
+      handler: a request handler (needed to generate URLs)
+      photo_upload: optional; an images.Image for an uploaded photo
+      photo_url: optional; a user-provided URL for a photo
+
+    Returns:
+      A tuple with an Image and URL with which to serve it, or (None, None) if
+      neither an uploaded photo nor a URL was provided.
     """
     if photo_upload is not None:
         return create_photo(photo_upload, handler)

--- a/app/photo.py
+++ b/app/photo.py
@@ -16,6 +16,8 @@
 """Handler for retrieving uploaded photos for display."""
 
 import os
+import requests
+import requests_toolbelt.adapters.appengine
 
 import model
 import utils
@@ -23,6 +25,11 @@ import utils
 from django.utils.translation import ugettext_lazy as _
 from google.appengine.api import images
 from google.appengine.runtime.apiproxy_errors import RequestTooLargeError
+
+# Use the App Engine Requests adapter. This makes sure that Requests uses
+# URLFetch.
+# TODO(nworden): see if we should condition this on the runtime (Python 2 vs. 3)
+requests_toolbelt.adapters.appengine.monkeypatch()
 
 MAX_IMAGE_DIMENSION = 300
 MAX_THUMBNAIL_DIMENSION = 80

--- a/app/photo.py
+++ b/app/photo.py
@@ -55,7 +55,7 @@ def create_photo_with_url(handler, photo_upload, photo_url):
 
     If neither parameter is provided, returns (Note, None).
     """
-    if photo_upload:
+    if photo_upload is not None:
         return create_photo(photo_upload, handler)
     elif photo_url:
         response = requests.get(photo_url)

--- a/app/photo.py
+++ b/app/photo.py
@@ -53,13 +53,13 @@ def create_photo_with_url(handler, photo_upload, photo_url):
     Either of the parameters may be used (but not both). Either way, it will
     return a Photo object and a URL with which to serve it.
 
-    If neither parameter is provided, returns (Note, None).
+    If neither parameter is provided, returns (None, None).
     """
     if photo_upload is not None:
         return create_photo(photo_upload, handler)
     elif photo_url:
         response = requests.get(photo_url)
-        image = validate_image(response.content)
+        image = utils.validate_image(response.content)
         if image:
             return create_photo(image, handler)
     return (None, None)

--- a/app/photo.py
+++ b/app/photo.py
@@ -40,6 +40,24 @@ class SizeTooLargeError(PhotoError):
                 'Please upload a smaller one.')
 
 
+def create_photo_with_url(handler, photo_upload, photo_url):
+    """Gets a photo based on an upload parameter and a URL parameter.
+
+    Either of the parameters may be used (but not both). Either way, it will
+    return a Photo object and a URL with which to serve it.
+
+    If neither parameter is provided, returns (Note, None).
+    """
+    if photo_upload:
+        return create_photo(photo_upload, handler)
+    elif photo_url:
+        response = requests.get(photo_url)
+        image = validate_image(response.content)
+        if image:
+            return create_photo(image, handler)
+    return (None, None)
+
+
 def create_photo(image, handler):
     """Creates a new Photo entity for the provided image of type images.Image
     after resizing it and converting to PNG.  It may throw a PhotoError on

--- a/app/photo.py
+++ b/app/photo.py
@@ -47,29 +47,16 @@ class SizeTooLargeError(PhotoError):
                 'Please upload a smaller one.')
 
 
-def create_photo_with_url(handler, photo_upload, photo_url):
-    """Gets a photo based on an upload parameter and a URL parameter.
-
-    Either of the parameters may be used (but not both). Either way, it will
-    return a Photo object and a URL with which to serve it.
-
-    If neither parameter is provided, returns (None, None).
-
-    Args:
-      handler: a request handler (needed to generate URLs)
-      photo_upload: optional; an images.Image for an uploaded photo
-      photo_url: optional; a user-provided URL for a photo
+def create_photo_from_url(handler, photo_url):
+    """Creates a photo from a URL.
 
     Returns:
       A tuple with an Image and URL with which to serve it, or (None, None) if
-      neither an uploaded photo nor a URL was provided.
+      the image is invalid.
     """
-    if photo_upload is not None:
-        return create_photo(photo_upload, handler)
-    elif photo_url:
-        response = requests.get(photo_url)
-        image = utils.validate_image(response.content)
-        if image:
+    response = requests.get(photo_url)
+    image = utils.validate_image(response.content)
+    if image:
             return create_photo(image, handler)
     return (None, None)
 

--- a/app/photo.py
+++ b/app/photo.py
@@ -47,7 +47,7 @@ class SizeTooLargeError(PhotoError):
                 'Please upload a smaller one.')
 
 
-def create_photo_from_url(handler, photo_url):
+def create_photo_from_url(photo_url, handler):
     """Creates a photo from a URL.
 
     Returns:

--- a/tests/server_test_cases/api_key_management_tests.py
+++ b/tests/server_test_cases/api_key_management_tests.py
@@ -37,7 +37,6 @@ import config
 from const import ROOT_URL, PERSON_STATUS_TEXT, NOTE_STATUS_TEXT
 import download_feed
 from model import *
-from photo import MAX_IMAGE_DIMENSION
 import remote_api
 from resources import Resource, ResourceBundle
 import reveal

--- a/tests/server_test_cases/person_note_tests.py
+++ b/tests/server_test_cases/person_note_tests.py
@@ -579,7 +579,7 @@ class PersonNoteTests(ServerTestsBase):
                       home_state='_test_home_state',
                       home_postal_code='_test_home_postal_code',
                       home_country='_test_home_country',
-                      photo_url='_test_photo_url',
+                      photo=open('tests/testdata/small_image.png'),
                       profile_url1='http://www.facebook.com/_test_account1',
                       profile_url2='http://www.twitter.com/_test_account2',
                       profile_url3='http://www.foo.com/_test_account3',
@@ -936,7 +936,7 @@ class PersonNoteTests(ServerTestsBase):
                       home_state='_test_home_state',
                       home_postal_code='_test_home_postal_code',
                       home_country='_test_home_country',
-                      photo_url='_test_photo_url',
+                      photo=open('tests/testdata/small_image.png'),
                       profile_url1='http://www.facebook.com/_test_account',
                       expiry_option='20',
                       description='_test_description',
@@ -947,7 +947,7 @@ class PersonNoteTests(ServerTestsBase):
                       phone_of_found_person='_test_phone_of_found_person',
                       last_known_location='_test_last_known_location',
                       text='_test A note body',
-                      note_photo_url='_test_note_photo_url')
+                      note_photo=open('tests/testdata/small_image.png'))
 
         self.verify_details_page(
             num_notes=1,

--- a/tests/server_test_cases/photo_tests.py
+++ b/tests/server_test_cases/photo_tests.py
@@ -143,7 +143,7 @@ class PhotoTests(ServerTestsBase):
         handler.get_url.return_value = 'photo_url_value'
         with mock.patch('requests.get') as mock_requests_get:
             mock_requests_get.return_value = photo_response
-            res = photo.create_photo_with_url(handler, None, photo_url)
+            res = photo.create_photo_from_url(handler, photo_url)
             mock_requests_get.assert_called_once_with(photo_url)
             res_image = images.Image(res[0].image_data)
             assert res_image.height == 40

--- a/tests/server_test_cases/photo_tests.py
+++ b/tests/server_test_cases/photo_tests.py
@@ -143,7 +143,7 @@ class PhotoTests(ServerTestsBase):
         handler.get_url.return_value = 'photo_url_value'
         with mock.patch('requests.get') as mock_requests_get:
             mock_requests_get.return_value = photo_response
-            res = photo.create_photo_from_url(handler, photo_url)
+            res = photo.create_photo_from_url(photo_url, handler)
             mock_requests_get.assert_called_once_with(photo_url)
             res_image = images.Image(res[0].image_data)
             assert res_image.height == 40

--- a/tests/server_test_cases/photo_tests.py
+++ b/tests/server_test_cases/photo_tests.py
@@ -17,8 +17,10 @@
 """Test cases for end-to-end testing.  Run with the server_tests script."""
 
 
+import mock
 
 import model
+import photo
 
 from google.appengine.api import images
 from photo import MAX_IMAGE_DIMENSION, MAX_THUMBNAIL_DIMENSION, set_thumbnail
@@ -131,3 +133,18 @@ class PhotoTests(ServerTestsBase):
         assert image.format == images.PNG
         assert image.height == 40
         assert image.width == 40
+
+    def test_download_photo(self):
+        photo_url = 'http://www.example.com/photo.jpg'
+        photo_response = mock.MagicMock()
+        photo_response.content = open('tests/testdata/tiny_image.png').read()
+        handler = mock.MagicMock()
+        handler.repo = 'test'
+        handler.get_url.return_value = 'photo_url_value'
+        with mock.patch('requests.get') as mock_requests_get:
+            mock_requests_get.return_value = photo_response
+            res = photo.create_photo_with_url(handler, None, photo_url)
+            mock_requests_get.assert_called_once_with(photo_url)
+            res_image = images.Image(res[0].image_data)
+            assert res_image.height == 40
+            assert res_image.width == 40

--- a/tests/server_tests.py
+++ b/tests/server_tests.py
@@ -144,6 +144,8 @@ class AppServerRunner(ProcessRunner):
 
     def __init__(self, port, smtp_port):
         self.__datastore_file = tempfile.NamedTemporaryFile()
+        # The requests library needs this to be set.
+        os.environ['SERVER_SOFTWARE'] = 'testing'
         ProcessRunner.__init__(self, 'appserver', [
             os.environ['PYTHON'],
             os.path.join(os.environ['APPENGINE_DIR'], 'dev_appserver.py'),

--- a/tests/server_tests_base.py
+++ b/tests/server_tests_base.py
@@ -38,7 +38,6 @@ import config
 from const import ROOT_URL, PERSON_STATUS_TEXT, NOTE_STATUS_TEXT
 import download_feed
 from model import *
-from photo import MAX_IMAGE_DIMENSION
 import remote_api
 from resources import Resource, ResourceBundle
 import reveal


### PR DESCRIPTION
Currently, if a user wants to provide a photo, they can either upload one or give us a link. In the latter case, we'll hotlink it. This changes it to pull the image from the given URL and store it in our DB, same as we do for uploaded photos. I'll set up a cron job or something later to do the same with image links we get from API partners.

The reasons for this change are that:
- Hotlinking images is a problem for zero-rating (which requires that everything be served off the same domain).
- It lets us shrink large images and generate thumbnails for the results page.
- The current arrangement allows a way around moderation -- we wouldn't want people changing images after the record's been reviewed.