### PR TITLE
Reduce datastore queries for config settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -125,6 +125,10 @@ class ConfigEntry(db.Model):
     value = db.TextProperty(default='')
 
 
+# If calling from code where a Configuration object is available (e.g., from
+# within a handler), prefer Configuration.get. Configuration objects get all
+# config entries when they're initialized, so they don't need to make an
+# additional Datastore query.
 def get(name, default=None, repo='*'):
     """Gets a configuration setting from cache if it is enabled,
        otherwise from the database."""
@@ -145,6 +149,10 @@ def set(repo='*', **kwargs):
            value=simplejson.dumps(value)) for name, value in kwargs.items())
     cache.delete(repo)
 
+# If calling from code where a Configuration object is available (e.g., from
+# within a handler), prefer Configuration.get. Configuration objects get all
+# config entries when they're initialized, so they don't need to make an
+# additional Datastore query.
 def get_for_repo(repo, name, default=None):
     """Gets a configuration setting for a particular repository.  Looks for a
     setting specific to the repository, then falls back to a global setting."""

--- a/app/config.py
+++ b/app/config.py
@@ -195,5 +195,8 @@ class Configuration(UserDict.DictMixin):
             return self.global_config[name]
         return None
 
+    def get(self, name, default=None):
+        return self[name] or default
+
     def keys(self):
         return self.entries.keys()

--- a/app/config.py
+++ b/app/config.py
@@ -204,7 +204,13 @@ class Configuration(UserDict.DictMixin):
         return None
 
     def get(self, name, default=None):
-        return self[name] or default
+        # UserDict.DictMixin.get isn't going to do what we want, because it only
+        # returns the default if __getitem__ raises an exception (which ours
+        # never does).
+        res = self[name]
+        if res is None:
+            return default
+        return res
 
     def keys(self):
         return self.entries.keys()

--- a/app/config.py
+++ b/app/config.py
@@ -163,6 +163,8 @@ def set_for_repo(repo, **kwargs):
 class Configuration(UserDict.DictMixin):
     def __init__(self, repo):
         self.repo = repo
+        # We fetch all the config entries at once here, so that we don't have to
+        # make many Datastore queries for each individual entry later.
         db_entries = model.filter_by_prefix(
             ConfigEntry.all(), self.repo + ':')
         self.entries = {

--- a/app/create.py
+++ b/app/create.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 from model import *
 from photo import create_photo, PhotoError
 from utils import *
@@ -41,8 +42,11 @@ def days_to_date(days):
 class Handler(BaseHandler):
     def get(self):
         self.params.create_mode = True
-        profile_websites = [add_profile_icon_url(website, self)
-                for website in self.config.profile_websites or []]
+        profile_websites = [
+            # add_profile_icon_url is going to modify website, so we make a copy
+            # of the config setting to avoid modifying the original.
+            add_profile_icon_url(website, self)
+            for website in copy.deepcopy(self.config.profile_websites) or []]
         self.render('create.html',
                     profile_websites=profile_websites,
                     profile_websites_json=simplejson.dumps(profile_websites),

--- a/app/create.py
+++ b/app/create.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 from model import *
 from photo import create_photo, PhotoError
 from utils import *
@@ -43,10 +42,8 @@ class Handler(BaseHandler):
     def get(self):
         self.params.create_mode = True
         profile_websites = [
-            # add_profile_icon_url is going to modify website, so we make a copy
-            # of the config setting to avoid modifying the original.
             add_profile_icon_url(website, self)
-            for website in copy.deepcopy(self.config.profile_websites) or []]
+            for website in self.config.profile_websites or []]
         self.render('create.html',
                     profile_websites=profile_websites,
                     profile_websites_json=simplejson.dumps(profile_websites),

--- a/app/main.py
+++ b/app/main.py
@@ -298,9 +298,9 @@ def setup_env(request):
     env.repo, env.action = get_repo_and_action(request)
     env.config = config.Configuration(env.repo or '*')
 
-    env.analytics_id = config.get('analytics_id')
-    env.amp_gtm_id = config.get('amp_gtm_id')
-    env.maps_api_key = config.get('maps_api_key')
+    env.analytics_id = env.config.get('analytics_id')
+    env.amp_gtm_id = env.config.get('amp_gtm_id')
+    env.maps_api_key = env.config.get('maps_api_key')
 
     # Internationalization-related stuff.
     env.charset = select_charset(request)
@@ -308,7 +308,8 @@ def setup_env(request):
     env.rtl = env.lang in const.LANGUAGES_BIDI
 
     # Determine the resource bundle to use.
-    env.default_resource_bundle = config.get('default_resource_bundle', '1')
+    env.default_resource_bundle = (
+        env.config.get('default_resource_bundle') or '1')
     env.resource_bundle = (request.cookies.get('resource_bundle', '') or
                            env.default_resource_bundle)
 
@@ -560,7 +561,7 @@ class Main(webapp.RequestHandler):
         # If the Person Finder instance has not been initialized yet,
         # prepend to any served page a warning and a link to the admin
         # page where the datastore can be initialized.
-        if not config.get('initialized'):
+        if not env.config.get('initialized'):
             if request.get('operation') == 'setup_datastore':
                 setup_pf.setup_datastore()
                 self.redirect(env.global_url + '/')
@@ -571,7 +572,7 @@ class Main(webapp.RequestHandler):
                         (env.repo, env.charset), get_vars)
                 response.out.write(content)
 
-        if config.get('enable_react_ui'):
+        if env.config.get('enable_react_ui'):
             # TODO(nworden): serve static files from /global/static
             if env.repo == 'static':
                 self.serve_static_content(self.env.action)

--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""The main request handler.  All dynamic requests except for remote_api are
+"""The main request handler. All dynamic requests except for remote_api are
 handled by this handler, which dispatches to all other dynamic handlers."""
 
 import django_setup  # always keep this first

--- a/app/main.py
+++ b/app/main.py
@@ -308,8 +308,7 @@ def setup_env(request):
     env.rtl = env.lang in const.LANGUAGES_BIDI
 
     # Determine the resource bundle to use.
-    env.default_resource_bundle = (
-        env.config.get('default_resource_bundle') or '1')
+    env.default_resource_bundle = env.config.get('default_resource_bundle', '1')
     env.resource_bundle = (request.cookies.get('resource_bundle', '') or
                            env.default_resource_bundle)
 

--- a/app/subscribe.py
+++ b/app/subscribe.py
@@ -122,7 +122,7 @@ class Handler(BaseHandler):
 
         form_action = self.get_url('/subscribe', id=self.params.id)
         back_url = self.get_url('/view', id=self.params.id)
-        site_key = config.get('captcha_site_key')
+        site_key = self.config.get('captcha_site_key')
         self.render('subscribe_captcha.html',
                     site_key=site_key,
                     person=person,
@@ -142,7 +142,7 @@ class Handler(BaseHandler):
         if not validate_email(self.params.subscribe_email):
             # Invalid email
             captcha_html = self.get_captcha_html()
-            site_key = config.get('captcha_site_key')
+            site_key = self.config.get('captcha_site_key')
             form_action = self.get_url('/subscribe', id=self.params.id)
             return self.render('subscribe_captcha.html',
                                person=person,
@@ -160,7 +160,7 @@ class Handler(BaseHandler):
         if not captcha_response.is_valid:
             # Captcha is incorrect
             captcha_html = self.get_captcha_html(captcha_response.error_code)
-            site_key = config.get('captcha_site_key')
+            site_key = self.config.get('captcha_site_key')
             form_action = self.get_url('/subscribe', id=self.params.id)
             return self.render('subscribe_captcha.html',
                                person=person,

--- a/app/utils.py
+++ b/app/utils.py
@@ -19,6 +19,7 @@ from django_setup import ugettext as _  # always keep this first
 
 import calendar
 import cgi
+import copy
 from datetime import datetime, timedelta
 import hmac
 import httplib
@@ -614,6 +615,7 @@ def get_url(request, repo, action, charset='utf-8', scheme=None, **params):
 
 
 def add_profile_icon_url(website, handler):
+    website = copy.deepcopy(website) # avoid modifying the original
     website['icon_url'] = \
         handler.env.global_url + '/' + website['icon_filename']
     return website

--- a/app/utils.py
+++ b/app/utils.py
@@ -615,7 +615,7 @@ def get_url(request, repo, action, charset='utf-8', scheme=None, **params):
 
 
 def add_profile_icon_url(website, handler):
-    website = copy.deepcopy(website) # avoid modifying the original
+    website = copy.deepcopy(website)  # avoid modifying the original
     website['icon_url'] = \
         handler.env.global_url + '/' + website['icon_filename']
     return website

--- a/app/view.py
+++ b/app/view.py
@@ -76,7 +76,7 @@ class Handler(BaseHandler):
         person.source_time_local_string = self.to_formatted_local_time(
             person.source_date)
         person.expiry_date_local_string = self.to_formatted_local_date(
-            person.get_effective_expiry_date())        
+            person.get_effective_expiry_date())
         person.expiry_time_local_string = self.to_formatted_local_time(
             person.get_effective_expiry_date())
 

--- a/app/view.py
+++ b/app/view.py
@@ -15,7 +15,6 @@
 
 from google.appengine.api import datastore_errors
 
-import copy
 from model import *
 from photo import create_photo, PhotoError
 from utils import *
@@ -41,9 +40,7 @@ def get_profile_pages(profile_urls, handler):
         profile_page = {
             'name': urlparse.urlparse(profile_url).hostname,
             'url': profile_url }
-        # add_profile_icon_url is going to modify website, so we make a copy of
-        # the config setting to avoid modifying the original.
-        for website in copy.deepcopy(handler.config.profile_websites) or []:
+        for website in handler.config.profile_websites or []:
             if ('url_regexp' in website and
                 re.match(website['url_regexp'], profile_url)):
                 profile_page = add_profile_icon_url(website, handler)

--- a/app/view.py
+++ b/app/view.py
@@ -15,6 +15,7 @@
 
 from google.appengine.api import datastore_errors
 
+import copy
 from model import *
 from photo import create_photo, PhotoError
 from utils import *
@@ -22,6 +23,9 @@ from detect_spam import SpamDetector
 import extend
 import reveal
 import subscribe
+
+import logging
+import pprint
 
 from django.utils.translation import ugettext as _
 import urlparse
@@ -37,7 +41,9 @@ def get_profile_pages(profile_urls, handler):
         profile_page = {
             'name': urlparse.urlparse(profile_url).hostname,
             'url': profile_url }
-        for website in handler.config.profile_websites or []:
+        # add_profile_icon_url is going to modify website, so we make a copy of
+        # the config setting to avoid modifying the original.
+        for website in copy.deepcopy(handler.config.profile_websites) or []:
             if ('url_regexp' in website and
                 re.match(website['url_regexp'], profile_url)):
                 profile_page = add_profile_icon_url(website, handler)

--- a/tests/server_test_cases/config_tests.py
+++ b/tests/server_test_cases/config_tests.py
@@ -85,13 +85,11 @@ class ConfigTests(ServerTestsBase):
     def test_config_namespaces(self):
         # Tests the cache's ability to retrieve global or repository-specific
         # configuration entries.
-        cfg_sub = config.Configuration('_foo')
-        cfg_global = config.Configuration('*')
-
         config.set_for_repo('*',
                             captcha_private_key='global_abcd',
                             captcha_public_key='global_efgh',
                             translate_api_key='global_hijk')
+        cfg_global = config.Configuration('*')
         assert cfg_global.captcha_private_key == 'global_abcd'
         assert cfg_global.captcha_public_key == 'global_efgh'
         assert cfg_global.translate_api_key == 'global_hijk'
@@ -99,6 +97,7 @@ class ConfigTests(ServerTestsBase):
         config.set_for_repo('_foo',
                             captcha_private_key='abcd',
                             captcha_public_key='efgh')
+        cfg_sub = config.Configuration('_foo')
         assert cfg_sub.captcha_private_key == 'abcd'
         assert cfg_sub.captcha_public_key == 'efgh'
         # If a key isn't present for a repository, its value for

--- a/tests/server_test_cases/config_tests.py
+++ b/tests/server_test_cases/config_tests.py
@@ -114,6 +114,11 @@ class ConfigTests(ServerTestsBase):
         assert cfg['good_key_2'] == 'def'
         assert cfg['unknown_key'] == None
 
+    def test_get_with_default(self):
+        config.set_for_repo('foo', key_1='abc')
+        cfg = config.Configuration('foo')
+        assert cfg.get('unknown_key', 'default_value') == 'default_value'
+
     def test_repo_admin_page(self):
         # Load the page to create a repository.
         doc = self.go_as_admin('/global/admin/create_repo')

--- a/tests/server_test_cases/config_tests.py
+++ b/tests/server_test_cases/config_tests.py
@@ -104,6 +104,16 @@ class ConfigTests(ServerTestsBase):
         # the global domain is retrieved.
         assert cfg_sub.translate_api_key == 'global_hijk'
 
+    def test_no_exception_for_unset_key(self):
+        # Tests that a config will return None, and not throw an exception, when
+        # asked for the value of an unknown key.
+        config.set_for_repo('*', good_key_1='abc', good_key_2='def')
+        config.set_for_repo('foo', good_key_1='ghi')
+        cfg = config.Configuration('foo')
+        assert cfg['good_key_1'] == 'ghi'
+        assert cfg['good_key_2'] == 'def'
+        assert cfg['unknown_key'] == None
+
     def test_repo_admin_page(self):
         # Load the page to create a repository.
         doc = self.go_as_admin('/global/admin/create_repo')

--- a/tests/server_test_cases/config_tests.py
+++ b/tests/server_test_cases/config_tests.py
@@ -112,7 +112,7 @@ class ConfigTests(ServerTestsBase):
         cfg = config.Configuration('foo')
         assert cfg['good_key_1'] == 'ghi'
         assert cfg['good_key_2'] == 'def'
-        assert cfg['unknown_key'] == None
+        assert cfg['unknown_key'] is None
 
     def test_get_with_default(self):
         config.set_for_repo('foo', key_1='abc')


### PR DESCRIPTION
The main change is to have Configuration.\_\_init\_\_ get all config settings.
Currently, a separate query is made each time a config entry needs to be
accessed. With this change, all the config entries are pulled at once in
just two queries (one for the repo config, one for the global config)
when the Configuration object is initialized. Individual entries can
then be accessed without additional datastore queries. It's pretty
similar to what gimite suggested on issue #349, except I didn't change
the datastore model (there's still a separate ConfigEntry object for
each setting, just now we get them all at once).

According to Stackdriver this reduces /datastore_v3.Get RPCs for the
repo homepages by about half (from 146 to 62). Datastore queries seem to
be the biggest contributor to latency, so this speeds things up a
noticeable amount (from ~1500-1700ms to ~700-800ms).

This means skipping the cache codepath, but the config cache seems to
be disabled in prod anyway.

There are some places where a Configuration object is unavailable (e.g.,
when HANDLER_CLASSES is built), and for them I've just left things
as they are for now.