### PR TITLE
Fuzzify ages

### DIFF
--- a/app/create.py
+++ b/app/create.py
@@ -184,7 +184,7 @@ class Handler(BaseHandler):
             description=self.params.description,
             sex=self.params.sex,
             date_of_birth=self.params.date_of_birth,
-            age=self.params.age,
+            age=fuzzify_age(self.params.age),
             home_city=self.params.home_city,
             home_state=self.params.home_state,
             home_postal_code=self.params.home_postal_code,

--- a/app/model.py
+++ b/app/model.py
@@ -357,6 +357,11 @@ class Person(Base):
         return self.alternate_names.splitlines() if self.alternate_names else []
 
     @property
+    def fuzzified_age(self):
+        import utils
+        return utils.fuzzify_age(self.age) if self.age else None
+
+    @property
     def profile_urls_list(self):
         return self.profile_urls.splitlines() if self.profile_urls else []
 

--- a/app/resources/view.html.template
+++ b/app/resources/view.html.template
@@ -106,7 +106,7 @@
               {% if person.age %}
                 <div class="field">
                   <span class="label">{% trans "Age" %}:</span>
-                  <span class="value">{{person.age}}</span>
+                  <span class="value">{{person.fuzzified_age}}</span>
                 </div>
               {% endif %}
               <div class="end-multi-columns"></div>

--- a/app/resources/view.html.template
+++ b/app/resources/view.html.template
@@ -103,7 +103,7 @@
                 <span class="value">{{person.date_of_birth}}</span>
               </div>
               {% endcomment %}
-              {% if person.age %}
+              {% if person.fuzzified_age %}
                 <div class="field">
                   <span class="label">{% trans "Age" %}:</span>
                   <span class="value">{{person.fuzzified_age}}</span>

--- a/app/utils.py
+++ b/app/utils.py
@@ -237,7 +237,7 @@ def validate_approximate_date(string):
     return ''
 
 
-AGE_RE = re.compile(r'^\d+(-\d+)?$')
+AGE_RE = re.compile(r'^(\d+)(-(\d+))?$')
 # Hyphen with possibly surrounding whitespaces.
 HYPHEN_RE = re.compile(
     ur'\s*[-\u2010-\u2015\u2212\u301c\u30fc\ufe58\ufe63\uff0d]\s*',
@@ -365,6 +365,31 @@ def validate_cache_seconds(string):
     if string:
         return float(string)
     return 1.0
+
+
+# ==== Fuzzification functions =================================================
+
+# The range should be no more specific than a five year period.
+MIN_AGE_RANGE = 5
+
+def fuzzify_age(value):
+    parse = AGE_RE.match(value)
+    if not parse:
+        raise ValueError('Invalid age value.')
+    range_start = int(parse.group(1))
+    range_end = int(parse.group(3)) if parse.group(3) else None
+    if not range_end:
+        # If no range was given, use a round five years around the given age.
+        range_start -= range_start % MIN_AGE_RANGE
+        return '%d-%d' % (range_start, range_start + MIN_AGE_RANGE)
+    if (range_end - range_start) >= MIN_AGE_RANGE:
+        # If the range we were given is already acceptably wide, leave it as-is.
+        return value
+    # If we were given too specific a range, pad it out to a round five year
+    # range.
+    range_start -= range_start % MIN_AGE_RANGE
+    range_end += MIN_AGE_RANGE - ((range_end) % MIN_AGE_RANGE)
+    return '%d-%d' % (range_start, range_end)
 
 
 # ==== Other utilities =========================================================

--- a/app/utils.py
+++ b/app/utils.py
@@ -373,6 +373,8 @@ def validate_cache_seconds(string):
 MIN_AGE_RANGE = 5
 
 def fuzzify_age(value):
+    if not value:
+        return None
     parse = AGE_RE.match(value)
     if not parse:
         raise ValueError('Invalid age value.')

--- a/app/utils.py
+++ b/app/utils.py
@@ -373,6 +373,15 @@ def validate_cache_seconds(string):
 MIN_AGE_RANGE = 5
 
 def fuzzify_age(value):
+    """Fuzzifies the age value for privacy.
+
+    Args:
+        value: a PFIF-compliant age value (a number or range, e.g., 45-49).
+
+    Returns:
+        A range of at least five years that includes the given value, or None if
+        the input value is None or invalid.
+    """
     if not value:
         return None
     parse = AGE_RE.match(value)

--- a/app/utils.py
+++ b/app/utils.py
@@ -377,7 +377,7 @@ def fuzzify_age(value):
         return None
     parse = AGE_RE.match(value)
     if not parse:
-        raise ValueError('Invalid age value.')
+        return None
     range_start = int(parse.group(1))
     range_end = int(parse.group(3)) if parse.group(3) else None
     if not range_end:

--- a/tests/server_test_cases/person_note_tests.py
+++ b/tests/server_test_cases/person_note_tests.py
@@ -593,7 +593,7 @@ class PersonNoteTests(ServerTestsBase):
                     '_test_alternate_given_names _test_alternate_family_names',
                 'Sex:': 'female',
                 # 'Date of birth:': '1955',  # currently hidden
-                'Age:': '52',
+                'Age:': '50-55',
                 'Neighborhood:': '_test_home_neighborhood',
                 'City:': '_test_home_city',
                 'Province or state:': '_test_home_state',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -189,6 +189,8 @@ class UtilsTests(unittest.TestCase):
         assert utils.fuzzify_age('21-22') == '20-25'
         assert utils.fuzzify_age('40-48') == '40-48'
         assert utils.fuzzify_age('40-40') == '40-45'
+        assert utils.fuzzify_age(None) == None
+        raises (ValueError, utils.fuzzify_age, 'banana')
 
     def test_set_utcnow_for_test(self):
         max_delta = datetime.timedelta(0,0,100)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -190,7 +190,7 @@ class UtilsTests(unittest.TestCase):
         assert utils.fuzzify_age('40-48') == '40-48'
         assert utils.fuzzify_age('40-40') == '40-45'
         assert utils.fuzzify_age(None) == None
-        raises (ValueError, utils.fuzzify_age, 'banana')
+        assert utils.fuzzify_age('banana') == None
 
     def test_set_utcnow_for_test(self):
         max_delta = datetime.timedelta(0,0,100)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -183,6 +183,13 @@ class UtilsTests(unittest.TestCase):
 
     # TODO: test_validate_image
 
+    def test_fuzzify_age(self):
+        assert utils.fuzzify_age('20') == '20-25'
+        assert utils.fuzzify_age('22') == '20-25'
+        assert utils.fuzzify_age('21-22') == '20-25'
+        assert utils.fuzzify_age('40-48') == '40-48'
+        assert utils.fuzzify_age('40-40') == '40-45'
+
     def test_set_utcnow_for_test(self):
         max_delta = datetime.timedelta(0,0,100)
         utcnow = datetime.datetime.utcnow()


### PR DESCRIPTION
For data we collect from users, fuzzify ages immediately; we don't
ever want to display or share the exact age. For data exchanged
between partners via our API, we want to be an honest broker so we
don't modify their data, but we do fuzzify it when it's displayed on
our site.