### PR TITLE
Permit only HTTP and HTTPS links.

### DIFF
--- a/app/create.py
+++ b/app/create.py
@@ -134,7 +134,7 @@ class Handler(BaseHandler):
             lambda url: url, [self.params.profile_url1,
                               self.params.profile_url2,
                               self.params.profile_url3])
-        url_validator = URLValidator()
+        url_validator = URLValidator(schemes=['http', 'https'])
         for profile_url in profile_urls:
             try:
                 url_validator(profile_url)

--- a/app/utils.py
+++ b/app/utils.py
@@ -383,7 +383,7 @@ def sanitize_urls(record):
     We check URLs submitted through Person Finder, but bad data might come in
     through the API.
     """
-    url_validator = URLValidator()
+    url_validator = URLValidator(schemes=['http', 'https'])
     # Single-line URLs.
     for field in ['photo_url', 'source_url']:
         url = getattr(record, field, None)


### PR DESCRIPTION
By default, Django also permits FTP links:
https://docs.djangoproject.com/en/2.1/ref/validators/#urlvalidator