### PR TITLE
Don't include test translate_api_key in setup_pf.py.

### DIFF
--- a/app/setup_pf.py
+++ b/app/setup_pf.py
@@ -61,8 +61,6 @@ def setup_configs():
     # They should be replaced with real keys upon launch.
     config.set(captcha_site_key='6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI',
                captcha_secret_key='6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe',
-    # A Google Translate API key with a very low quota, just for testing.
-               translate_api_key='AIzaSyCXdz9x7LDL3BvieEP8Wcze64CC_iqslSE',
                repo_aliases={},
                sms_number_to_repo={},
                referrer_whitelist=[],


### PR DESCRIPTION
I think this was intended to help make it easier for developers to get
started, but it means that we're putting an API key out in the world.
You don't need a key to develop anything that isn't directly related to
use of the Translate API (the Translation features get disabled
automatically if the config doesn't include a Translate key), so we can
just drop it from the setup script.