### PR TITLE
Use a Django template for pfif-tools validation results

### DIFF
--- a/tools/pfif-tools/app/controller.py
+++ b/tools/pfif-tools/app/controller.py
@@ -138,28 +138,28 @@ class ValidatorController(PfifController):
     xml_file = self.get_file()
     if xml_file is None:
       page_ctx['error'] = 'Missing Input File'
-    else:
-      validator = pfif_validator.PfifValidator(xml_file)
-      messages = validator.run_validations()
-      for msg in messages:
-        if msg.xml_line_number != None:
-          msg.full_xml_line = validator.tree.lines[msg.xml_line_number - 1]
-      page_ctx['messages'] = messages
-      page_ctx['msgs_by_category'] = (
-          utils.MessagesOutput.group_messages_by_category(messages))
-      # print_options is a list of all printing options passed in via
-      # checkboxes.  It will contain 'show_errors' if the user checked that box,
-      # for instance.  Thus, saying show_errors='show_errors' in print_options
-      # will set show_errors to True if the box was checked and false otherwise.
-      print_options = self.request.POST.getlist('print_options')
-      show_errors = 'show_errors' in print_options
-      show_warnings = 'show_warnings' in print_options
-      page_ctx['msgs'] = list(filter(
-          lambda msg: ((show_errors and msg.is_error) or
-                       (show_warnings and not msg.is_error)), messages))
-      page_ctx['show_line_numbers'] = 'show_line_numbers' in print_options
-      page_ctx['show_record_ids'] = 'show_record_ids' in print_options
-      page_ctx['show_xml_tag'] = 'show_xml_tag' in print_options
-      page_ctx['show_xml_text'] = 'show_xml_text' in print_options
-      page_ctx['show_full_line'] = 'show_full_line' in print_options
+      return render(request, 'error.html', page_ctx)
+    validator = pfif_validator.PfifValidator(xml_file)
+    messages = validator.run_validations()
+    for msg in messages:
+      if msg.xml_line_number != None:
+        msg.full_xml_line = validator.tree.lines[msg.xml_line_number - 1]
+    page_ctx['messages'] = messages
+    page_ctx['msgs_by_category'] = (
+        utils.MessagesOutput.group_messages_by_category(messages))
+    # print_options is a list of all printing options passed in via checkboxes.
+    # It will contain 'show_errors' if the user checked that box, for instance.
+    # Thus, saying show_errors='show_errors' in print_options will set
+    # show_errors to True if the box was checked and false otherwise.
+    print_options = self.request.POST.getlist('print_options')
+    show_errors = 'show_errors' in print_options
+    show_warnings = 'show_warnings' in print_options
+    page_ctx['msgs'] = list(filter(
+        lambda msg: ((show_errors and msg.is_error) or
+                     (show_warnings and not msg.is_error)), messages))
+    page_ctx['show_line_numbers'] = 'show_line_numbers' in print_options
+    page_ctx['show_record_ids'] = 'show_record_ids' in print_options
+    page_ctx['show_xml_tag'] = 'show_xml_tag' in print_options
+    page_ctx['show_xml_text'] = 'show_xml_text' in print_options
+    page_ctx['show_full_line'] = 'show_full_line' in print_options
     return render(request, 'validate_results.html', page_ctx)

--- a/tools/pfif-tools/app/controller.py
+++ b/tools/pfif-tools/app/controller.py
@@ -18,6 +18,7 @@
 from StringIO import StringIO
 
 from django.http import HttpResponse
+from django.shortcuts import render
 from django.views import View
 
 import pfif_validator
@@ -133,35 +134,32 @@ class ValidatorController(PfifController):
   """Displays the validation results page."""
 
   def post(self, request, *args, **kwargs):
-    self.response = HttpResponse()
+    page_ctx = {'page_title': 'PFIF Validator: Results'}
     xml_file = self.get_file()
-    self.write_header('PFIF Validator: Results')
     if xml_file is None:
-      self.write_missing_input_file()
+      page_ctx['error'] = 'Missing Input File'
     else:
       validator = pfif_validator.PfifValidator(xml_file)
       messages = validator.run_validations()
-      self.response.write('<h1>Validation: ' +
-                              str(len(messages)) + ' Messages</h1>')
-      self.response.write(
-          utils.MessagesOutput.generate_message_summary(messages, is_html=True))
+      for msg in messages:
+        if msg.xml_line_number != None:
+          msg.full_xml_line = validator.tree.lines[msg.xml_line_number - 1]
+      page_ctx['messages'] = messages
+      page_ctx['msgs_by_category'] = (
+          utils.MessagesOutput.group_messages_by_category(messages))
       # print_options is a list of all printing options passed in via
       # checkboxes.  It will contain 'show_errors' if the user checked that box,
       # for instance.  Thus, saying show_errors='show_errors' in print_options
       # will set show_errors to True if the box was checked and false otherwise.
       print_options = self.request.POST.getlist('print_options')
-      marked_up_message = validator.validator_messages_to_str(
-          messages,
-          show_errors='show_errors' in print_options,
-          show_warnings='show_warnings' in print_options,
-          show_line_numbers='show_line_numbers' in print_options,
-          show_record_ids='show_record_ids' in print_options,
-          show_xml_tag='show_xml_tag' in print_options,
-          show_xml_text='show_xml_text' in print_options,
-          show_full_line='show_full_line' in print_options,
-          is_html=True)
-      # don't escape the message since is_html escapes all input and contains
-      # html that should be interpreted as html
-      self.response.write(marked_up_message)
-    self.write_footer()
-    return self.response
+      show_errors = 'show_errors' in print_options
+      show_warnings = 'show_warnings' in print_options
+      page_ctx['msgs'] = list(filter(
+          lambda msg: ((show_errors and msg.is_error) or
+                       (show_warnings and not msg.is_error)), messages))
+      page_ctx['show_line_numbers'] = 'show_line_numbers' in print_options
+      page_ctx['show_record_ids'] = 'show_record_ids' in print_options
+      page_ctx['show_xml_tag'] = 'show_xml_tag' in print_options
+      page_ctx['show_xml_text'] = 'show_xml_text' in print_options
+      page_ctx['show_full_line'] = 'show_full_line' in print_options
+    return render(request, 'validate_results.html', page_ctx)

--- a/tools/pfif-tools/app/pfif_validator.py
+++ b/tools/pfif-tools/app/pfif_validator.py
@@ -762,7 +762,7 @@ class PfifValidator:
           link_field = linking_note.find(
               self.tree.add_namespace_to_tag('linked_person_record_id'))
           messages.append(self.make_message(
-              'There is an asymmetric linked record.  That is, a note has a'
+              'There is an asymmetric linked record.  That is, a note has a '
               'linked_person_record_id to another person, but that person '
               'does not link back.',
               record=linking_note, element=link_field, is_error=False))

--- a/tools/pfif-tools/app/pfif_validator.py
+++ b/tools/pfif-tools/app/pfif_validator.py
@@ -762,7 +762,7 @@ class PfifValidator:
           link_field = linking_note.find(
               self.tree.add_namespace_to_tag('linked_person_record_id'))
           messages.append(self.make_message(
-              'There is an asymmetric linked record.  That is, a note has a '
+              'There is an asymmetric linked record. That is, a note has a '
               'linked_person_record_id to another person, but that person '
               'does not link back.',
               record=linking_note, element=link_field, is_error=False))

--- a/tools/pfif-tools/app/resources/error.html
+++ b/tools/pfif-tools/app/resources/error.html
@@ -1,0 +1,16 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>{{ page_title }}</title>
+  <link rel="stylesheet" type="text/css" href="/static/style.css">
+</head>
+
+<body>
+
+<h1>{{error}}</h1>
+
+</body>
+
+</html>

--- a/tools/pfif-tools/app/resources/validate_results.html
+++ b/tools/pfif-tools/app/resources/validate_results.html
@@ -9,80 +9,76 @@
 
 <body>
 
-{% if error %}
-  <h1>{{error}}</h1>
-{% else %}
-  <h1>Validation: {{ messages|length }} Messages</h1>
+<h1>Validation: {{ messages|length }} Messages</h1>
 
-  {% if msgs_by_category %}
-    <table>
+{% if msgs_by_category %}
+  <table>
+    <tr>
+      <th>Category</th>
+      <th>Number of Messages</th>
+    </tr>
+    {% for category, msgs in msgs_by_category.items %}
       <tr>
-        <th>Category</th>
-        <th>Number of Messages</th>
+        <td>{{ category }}</td>
+        <td>{{ msgs|length }}</td>
       </tr>
-      {% for category, msgs in msgs_by_category.items %}
-        <tr>
-          <td>{{ category }}</td>
-          <td>{{ msgs|length }}</td>
-        </tr>
-      {% endfor %}
-    </table>
-  {% endif %}
-
-  <div class="all_messages">
-    {% for msg in msgs %}
-      <div class="message">
-        <span class="message_type">
-          {% if msg.is_error %}
-            ERROR
-          {% else %}
-            WARNING
-          {% endif %}
-        </span>
-        {% if show_line_numbers %}
-          <span class="message_line_number">
-            LINE {{ msg.xml_line_number }}:
-          </span>
-        {% endif %}
-        <span class="message_category">
-          {{ msg.category }}
-          {% if msg.extra_data %}
-            <span class="message_data">: {{msg.extra_data}}</span>
-          {% endif %}
-        </span>
-        {% if show_record_ids %}
-          {% if msg.person_record_id %}
-            <div class="message_person_record_id">
-              The relevant person_record_id is:
-              <span class="message_data">{{ msg.person_record_id }}</span>
-            </div>
-          {% endif %}
-          {% if msg.note_record_id %}
-            <div class="message_note_record_id">
-              The relevant note_record_id is:
-              <span class="message_data">{{ msg.note_record_id }}</span>
-            </div>
-          {% endif %}
-        {% endif %}
-        {% if show_xml_tag and msg.xml_tag %}
-          <div class="message_xml_tag">
-            The tag of the relevant PFIF XML node:
-            <span class="message_data">{{ msg.xml_tag }}</span>
-          </div>
-        {% endif %}
-        {% if show_xml_text and msg.xml_text %}
-          <div class="message_xml_text">
-            The text of the relevant PFIF XML node:
-            <span class="message_data">{{ msg.xml_text }}</span>
-          </div>
-        {% endif %}
-        {% if show_full_line and msg.full_xml_line %}
-          <div class="message_xml_full_line">{{ msg.full_xml_line }}</div>
-        {% endif %}
-      </div>
     {% endfor %}
-  </div>
+  </table>
 {% endif %}
+
+<div class="all_messages">
+  {% for msg in msgs %}
+    <div class="message">
+      <span class="message_type">
+        {% if msg.is_error %}
+          ERROR
+        {% else %}
+          WARNING
+        {% endif %}
+      </span>
+      {% if show_line_numbers %}
+        <span class="message_line_number">
+          LINE {{ msg.xml_line_number }}:
+        </span>
+      {% endif %}
+      <span class="message_category">
+        {{ msg.category }}
+        {% if msg.extra_data %}
+          <span class="message_data">: {{msg.extra_data}}</span>
+        {% endif %}
+      </span>
+      {% if show_record_ids %}
+        {% if msg.person_record_id %}
+          <div class="message_person_record_id">
+            The relevant person_record_id is:
+            <span class="message_data">{{ msg.person_record_id }}</span>
+          </div>
+        {% endif %}
+        {% if msg.note_record_id %}
+          <div class="message_note_record_id">
+            The relevant note_record_id is:
+            <span class="message_data">{{ msg.note_record_id }}</span>
+          </div>
+        {% endif %}
+      {% endif %}
+      {% if show_xml_tag and msg.xml_tag %}
+        <div class="message_xml_tag">
+          The tag of the relevant PFIF XML node:
+          <span class="message_data">{{ msg.xml_tag }}</span>
+        </div>
+      {% endif %}
+      {% if show_xml_text and msg.xml_text %}
+        <div class="message_xml_text">
+          The text of the relevant PFIF XML node:
+          <span class="message_data">{{ msg.xml_text }}</span>
+        </div>
+      {% endif %}
+      {% if show_full_line and msg.full_xml_line %}
+        <div class="message_xml_full_line">{{ msg.full_xml_line }}</div>
+      {% endif %}
+    </div>
+  {% endfor %}
+</div>
 
 </body>
 

--- a/tools/pfif-tools/app/resources/validate_results.html
+++ b/tools/pfif-tools/app/resources/validate_results.html
@@ -1,0 +1,89 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>{{ page_title }}</title>
+  <link rel="stylesheet" type="text/css" href="/static/style.css">
+</head>
+
+<body>
+
+{% if error %}
+  <h1>{{error}}</h1>
+{% else %}
+  <h1>Validation: {{ messages|length }} Messages</h1>
+
+  {% if msgs_by_category %}
+    <table>
+      <tr>
+        <th>Category</th>
+        <th>Number of Messages</th>
+      </tr>
+      {% for category, msgs in msgs_by_category.items %}
+        <tr>
+          <td>{{ category }}</td>
+          <td>{{ msgs|length }}</td>
+        </tr>
+      {% endfor %}
+    </table>
+  {% endif %}
+
+  <div class="all_messages">
+    {% for msg in msgs %}
+      <div class="message">
+        <span class="message_type">
+          {% if msg.is_error %}
+            ERROR
+          {% else %}
+            WARNING
+          {% endif %}
+        </span>
+        {% if show_line_numbers %}
+          <span class="message_line_number">
+            LINE {{ msg.xml_line_number }}:
+          </span>
+        {% endif %}
+        <span class="message_category">
+          {{ msg.category }}
+          {% if msg.extra_data %}
+            <span class="message_data">: {{msg.extra_data}}</span>
+          {% endif %}
+        </span>
+        {% if show_record_ids %}
+          {% if msg.person_record_id %}
+            <div class="message_person_record_id">
+              The relevant person_record_id is:
+              <span class="message_data">{{ msg.person_record_id }}</span>
+            </div>
+          {% endif %}
+          {% if msg.note_record_id %}
+            <div class="message_note_record_id">
+              The relevant note_record_id is:
+              <span class="message_data">{{ msg.note_record_id }}</span>
+            </div>
+          {% endif %}
+        {% endif %}
+        {% if show_xml_tag and msg.xml_tag %}
+          <div class="message_xml_tag">
+            The tag of the relevant PFIF XML node:
+            <span class="message_data">{{ msg.xml_tag }}</span>
+          </div>
+        {% endif %}
+        {% if show_xml_text and msg.xml_text %}
+          <div class="message_xml_text">
+            The text of the relevant PFIF XML node:
+            <span class="message_data">{{ msg.xml_text }}</span>
+          </div>
+        {% endif %}
+        {% if show_full_line and msg.full_xml_line %}
+          <div class="message_xml_full_line">{{ msg.full_xml_line }}</div>
+        {% endif %}
+      </div>
+    {% endfor %}
+  </div>
+{% endif %}
+
+</body>
+
+</html>

--- a/tools/pfif-tools/app/settings.py
+++ b/tools/pfif-tools/app/settings.py
@@ -38,7 +38,7 @@ ROOT_URLCONF = 'urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': ['resources'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/tools/pfif-tools/app/settings.py
+++ b/tools/pfif-tools/app/settings.py
@@ -39,7 +39,7 @@ TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': ['resources'],
-        'APP_DIRS': True,
+        'APP_DIRS': False,
         'OPTIONS': {
             'context_processors': [
                 'django.template.context_processors.debug',


### PR DESCRIPTION
For context: pfif-tools is a small standalone app, separate from Person Finder itself, running at pfif-tools.appspot.com. It's a tool to help partners validate their data is in proper PFIF format.

It currently has a bunch of code to produce HTML piece-by-piece. This moves one of the dynamic pages into a template instead (the code it used to use can't be deleted yet though, because it's shared with another page I'm doing later).