### PR TITLE
Eliminate extra dependencies on django_setup.py

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -18,8 +18,6 @@
 
 __author__ = 'kpy@google.com (Ka-Ping Yee)'
 
-import django_setup  # always keep this first
-
 import calendar
 import csv
 import datetime
@@ -34,6 +32,7 @@ import urllib2
 import uuid
 
 import django.utils.html
+from django.utils.translation import activate
 from django.utils.translation import ugettext as _
 from google.appengine import runtime
 from google.appengine.ext import db
@@ -42,7 +41,6 @@ from unidecode import unidecode
 
 import cloud_storage
 import config
-from django_setup import ugettext as _
 import full_text_search
 import importer
 import indexing
@@ -724,7 +722,7 @@ class HandleSMS(utils.BaseHandler):
 
         if query_lang:
             # Use the language for the following calls of _().
-            django_setup.activate(query_lang)
+            activate(query_lang)
 
         responses = []
 

--- a/app/api.py
+++ b/app/api.py
@@ -32,7 +32,7 @@ import urllib2
 import uuid
 
 import django.utils.html
-from django.utils.translation import activate
+from django.utils import translation
 from django.utils.translation import ugettext as _
 from google.appengine import runtime
 from google.appengine.ext import db
@@ -722,7 +722,7 @@ class HandleSMS(utils.BaseHandler):
 
         if query_lang:
             # Use the language for the following calls of _().
-            activate(query_lang)
+            translation.activate(query_lang)
 
         responses = []
 

--- a/app/const.py
+++ b/app/const.py
@@ -17,8 +17,7 @@
 
 # We use lazy translation in this file because the language isn't set yet.
 from __future__ import absolute_import
-import django_setup
-from django_setup import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # The root URL of this application.
 ROOT_URL = 'http://google.org/personfinder'
@@ -216,7 +215,9 @@ LANGUAGE_SYNONYMS = {
 }
 
 # RTL languages.
-LANGUAGES_BIDI = django_setup.LANGUAGES_BIDI + ['ps', 'prs']
+# This is mostly the same as LANGUAGES_BIDI set in django_setup, with the
+# addition of 'ps' and 'prs'.
+LANGUAGES_BIDI = ['ar', 'he', 'fa', 'iw', 'ps', 'prs', 'ur']
 
 # Mapping from language codes to Facebook locale codes.
 #

--- a/app/resources.py
+++ b/app/resources.py
@@ -25,8 +25,6 @@ Similar to App Engine's app versions, there is a concept of an "active bundle"
 from which resources are obtained.  Previewing or releasing a new set of
 resources is a matter of setting the active bundle."""
 
-import django_setup
-
 import datetime
 import logging
 import os

--- a/app/tos.py
+++ b/app/tos.py
@@ -17,8 +17,7 @@
 
 __author__ = 'ichikawa@google.com (Hiroshi Ichikawa)'
 
-from django_setup import ugettext as _  # always keep this first
-
+from django.utils.translation import ugettext as _
 import logging
 import traceback
 import urllib2

--- a/app/utils.py
+++ b/app/utils.py
@@ -15,8 +15,6 @@
 
 __author__ = 'kpy@google.com (Ka-Ping Yee) and many other Googlers'
 
-from django_setup import ugettext as _  # always keep this first
-
 import calendar
 import cgi
 from datetime import datetime, timedelta
@@ -36,6 +34,7 @@ import urlparse
 import base64
 
 import django.utils.html
+from django.utils.translation import ugettext as _
 from django.template.defaulttags import register
 from google.appengine.api import images
 from google.appengine.api import taskqueue

--- a/tests/server_test_cases/person_note_tests.py
+++ b/tests/server_test_cases/person_note_tests.py
@@ -24,6 +24,10 @@ import re
 import time
 import urlparse
 
+# This has to be imported before const, so that Django will get set up before
+# const tries to use Django's translation functions. When the server's actually
+# running, main.py will import it, but main.py doesn't get involved here.
+import django_setup
 from const import ROOT_URL, PERSON_STATUS_TEXT, NOTE_STATUS_TEXT
 from model import *
 import reveal


### PR DESCRIPTION
It needs to be imported once, but not more than once. Since main.py runs before everything else, the import there is all we really need. Getting rid of the extra imports will make it simpler to change stuff to get it running on Django in place of webapp2.