### PR TITLE
Use Django template for pfif-tools diff results page

### DIFF
--- a/tools/pfif-tools/app/controller.py
+++ b/tools/pfif-tools/app/controller.py
@@ -17,7 +17,6 @@
 
 from StringIO import StringIO
 
-from django.http import HttpResponse
 from django.shortcuts import render
 from django.views import View
 
@@ -67,7 +66,6 @@ class DiffController(PfifController):
   """Displays the diff results page."""
 
   def post(self, request, *args, **kwargs):
-    self.response = HttpResponse()
     page_ctx = {'page_title': 'PFIF Diff: Results'}
     file_1, filename_1 = self.get_file(1, return_filename=True)
     file_2, filename_2 = self.get_file(2, return_filename=True)
@@ -139,9 +137,7 @@ class DiffController(PfifController):
         messages_by_record[record_id] = record_messages
       page_ctx['msgs_by_record'] = messages_by_record
     else:
-      self.response.write(
-          utils.MessagesOutput.messages_to_str(
-              messages, show_error_type=False, is_html=True))
+      page_ctx['msgs'] = messages
     return render(request, 'diff_results.html', page_ctx)
 
 class ValidatorController(PfifController):

--- a/tools/pfif-tools/app/controller.py
+++ b/tools/pfif-tools/app/controller.py
@@ -84,6 +84,7 @@ class DiffController(PfifController):
         text_is_case_sensitive='text_is_case_sensitive' in options,
         ignore_fields=ignore_fields,
         omit_blank_fields='omit_blank_fields' in options)
+    page_ctx['msgs'] = messages
     page_ctx['msgs_by_category'] = (
         utils.MessagesOutput.group_messages_by_category(messages))
     if 'group_messages_by_record' in options:
@@ -136,8 +137,6 @@ class DiffController(PfifController):
                   changed_field_msgs, 'xml_tag'))
         messages_by_record[record_id] = record_messages
       page_ctx['msgs_by_record'] = messages_by_record
-    else:
-      page_ctx['msgs'] = messages
     return render(request, 'diff_results.html', page_ctx)
 
 class ValidatorController(PfifController):

--- a/tools/pfif-tools/app/controller.py
+++ b/tools/pfif-tools/app/controller.py
@@ -28,25 +28,6 @@ import utils
 class PfifController(View):
   """Provides common functionality to the different PFIF Tools controllers."""
 
-  def write_header(self, title):
-    """Writes an HTML page header and open the body."""
-    self.response.write("""<!DOCTYPE HTML>
-  <html>
-    <head>
-      <meta charset="utf-8">
-      <title>""" + title + """</title>
-      <link rel="stylesheet" type="text/css" href="/static/style.css">
-    </head>
-    <body>""")
-
-  def write_footer(self):
-    """Closes the body and html tags."""
-    self.response.write('</body></html>')
-
-  def write_missing_input_file(self):
-    """Writes that there is a missing input file."""
-    self.response.write('<h1>Missing Input File</h1>')
-
   def get_file(self, file_number=1, return_filename=False):
     """Gets a file that was pasted in, uploaded, or given by a URL.  If multiple
     files are provided, specify the number of the desired file as file_number.
@@ -82,53 +63,86 @@ class PfifController(View):
       else:
         return None
 
-  def write_filename(self, filename, shorthand_name):
-    """Writes out a mapping from shorthand_name to filename."""
-    self.response.write('<p>File ' + shorthand_name + ': ')
-    if filename is None:
-      self.response.write('pasted in')
-    else:
-      self.response.write(filename)
-    self.response.write('</p>\n')
-
-  def write_filenames(self, filename_1, filename_2):
-    """Writes the names of filename_1 and filename_2."""
-    self.write_filename(filename_1, 'A')
-    self.write_filename(filename_2, 'B')
-
 class DiffController(PfifController):
   """Displays the diff results page."""
 
   def post(self, request, *args, **kwargs):
     self.response = HttpResponse()
+    page_ctx = {'page_title': 'PFIF Diff: Results'}
     file_1, filename_1 = self.get_file(1, return_filename=True)
     file_2, filename_2 = self.get_file(2, return_filename=True)
-    self.write_header('PFIF Diff: Results')
     if file_1 is None or file_2 is None:
-      self.write_missing_input_file()
+      page_ctx['error'] = 'Missing Input File'
+      return render(request, 'error.html', page_ctx)
+    page_ctx['filenames'] = [
+        {'filename': filename_1, 'shorthand_name': 'A'},
+        {'filename': filename_2, 'shorthand_name': 'B'},
+    ]
+    options = self.request.POST.getlist('options')
+    ignore_fields = self.request.POST.get(
+        'ignore_fields', default='').split()
+    messages = pfif_diff.pfif_file_diff(
+        file_1, file_2,
+        text_is_case_sensitive='text_is_case_sensitive' in options,
+        ignore_fields=ignore_fields,
+        omit_blank_fields='omit_blank_fields' in options)
+    page_ctx['msgs_by_category'] = (
+        utils.MessagesOutput.group_messages_by_category(messages))
+    if 'group_messages_by_record' in options:
+      page_ctx['group_messages'] = True
+      messages = utils.MessagesOutput.truncate(
+          messages, utils.MessagesOutput.GROUPED_TRUNCATE_THRESHOLD)
+      messages_by_category = utils.MessagesOutput.group_messages_by_category(
+          messages)
+      added_record_msgs = messages_by_category.get(
+          utils.Categories.ADDED_RECORD)
+      if added_record_msgs:
+          page_ctx['added_record_ids'] = (
+          utils.MessagesOutput.get_field_from_messages(
+              added_record_msgs, 'record_id'))
+      deleted_record_msgs = messages_by_category.get(
+          utils.Categories.DELETED_RECORD)
+      if deleted_record_msgs:
+          page_ctx['deleted_record_ids'] = (
+              utils.MessagesOutput.get_field_from_messages(
+                  deleted_record_msgs, 'record_id'))
+      field_change_messages = []
+      for category in [utils.Categories.ADDED_FIELD,
+                       utils.Categories.DELETED_FIELD,
+                       utils.Categories.CHANGED_FIELD]:
+        field_change_messages.extend(messages_by_category.get(category, []))
+      messages_by_record = {}
+      for record_id, record_list in (
+          utils.MessagesOutput.group_messages_by_record(
+              field_change_messages).items()):
+        record_messages = {'list': record_list}
+        record_messages_by_category = (
+            utils.MessagesOutput.group_messages_by_category(record_list))
+        added_field_msgs = record_messages_by_category.get(
+            utils.Categories.ADDED_FIELD, [])
+        if added_field_msgs:
+          record_messages['added_field_tags'] = (
+              utils.MessagesOutput.get_field_from_messages(
+                  added_field_msgs, 'xml_tag'))
+        deleted_field_msgs = record_messages_by_category.get(
+            utils.Categories.DELETED_FIELD, [])
+        if deleted_field_msgs:
+          record_messages['deleted_field_tags'] = (
+              utils.MessagesOutput.get_field_from_messages(
+                  deleted_field_msgs, 'xml_tag'))
+        changed_field_msgs = record_messages_by_category.get(
+            utils.Categories.CHANGED_FIELD, [])
+        if changed_field_msgs:
+          record_messages['changed_field_tags'] = (
+              utils.MessagesOutput.get_field_from_messages(
+                  changed_field_msgs, 'xml_tag'))
+        messages_by_record[record_id] = record_messages
+      page_ctx['msgs_by_record'] = messages_by_record
     else:
-      options = self.request.POST.getlist('options')
-      ignore_fields = self.request.POST.get(
-          'ignore_fields', default='').split()
-      messages = pfif_diff.pfif_file_diff(
-          file_1, file_2,
-          text_is_case_sensitive='text_is_case_sensitive' in options,
-          ignore_fields=ignore_fields,
-          omit_blank_fields='omit_blank_fields' in options)
       self.response.write(
-          '<h1>Diff: ' + str(len(messages)) + ' Messages</h1>')
-      self.response.write(
-          utils.MessagesOutput.generate_message_summary(messages, is_html=True))
-      self.write_filenames(filename_1, filename_2)
-      if 'group_messages_by_record' in options:
-        self.response.write(
-            utils.MessagesOutput.messages_to_str_by_id(messages, is_html=True))
-      else:
-        self.response.write(
-            utils.MessagesOutput.messages_to_str(
-                messages, show_error_type=False, is_html=True))
-    self.write_footer()
-    return self.response
+          utils.MessagesOutput.messages_to_str(
+              messages, show_error_type=False, is_html=True))
+    return render(request, 'diff_results.html', page_ctx)
 
 class ValidatorController(PfifController):
   """Displays the validation results page."""

--- a/tools/pfif-tools/app/controller.py
+++ b/tools/pfif-tools/app/controller.py
@@ -91,52 +91,7 @@ class DiffController(PfifController):
       page_ctx['group_messages'] = True
       messages = utils.MessagesOutput.truncate(
           messages, utils.MessagesOutput.GROUPED_TRUNCATE_THRESHOLD)
-      messages_by_category = utils.MessagesOutput.group_messages_by_category(
-          messages)
-      added_record_msgs = messages_by_category.get(
-          utils.Categories.ADDED_RECORD)
-      if added_record_msgs:
-          page_ctx['added_record_ids'] = (
-          utils.MessagesOutput.get_field_from_messages(
-              added_record_msgs, 'record_id'))
-      deleted_record_msgs = messages_by_category.get(
-          utils.Categories.DELETED_RECORD)
-      if deleted_record_msgs:
-          page_ctx['deleted_record_ids'] = (
-              utils.MessagesOutput.get_field_from_messages(
-                  deleted_record_msgs, 'record_id'))
-      field_change_messages = []
-      for category in [utils.Categories.ADDED_FIELD,
-                       utils.Categories.DELETED_FIELD,
-                       utils.Categories.CHANGED_FIELD]:
-        field_change_messages.extend(messages_by_category.get(category, []))
-      messages_by_record = {}
-      for record_id, record_list in (
-          utils.MessagesOutput.group_messages_by_record(
-              field_change_messages).items()):
-        record_messages = {'list': record_list}
-        record_messages_by_category = (
-            utils.MessagesOutput.group_messages_by_category(record_list))
-        added_field_msgs = record_messages_by_category.get(
-            utils.Categories.ADDED_FIELD, [])
-        if added_field_msgs:
-          record_messages['added_field_tags'] = (
-              utils.MessagesOutput.get_field_from_messages(
-                  added_field_msgs, 'xml_tag'))
-        deleted_field_msgs = record_messages_by_category.get(
-            utils.Categories.DELETED_FIELD, [])
-        if deleted_field_msgs:
-          record_messages['deleted_field_tags'] = (
-              utils.MessagesOutput.get_field_from_messages(
-                  deleted_field_msgs, 'xml_tag'))
-        changed_field_msgs = record_messages_by_category.get(
-            utils.Categories.CHANGED_FIELD, [])
-        if changed_field_msgs:
-          record_messages['changed_field_tags'] = (
-              utils.MessagesOutput.get_field_from_messages(
-                  changed_field_msgs, 'xml_tag'))
-        messages_by_record[record_id] = record_messages
-      page_ctx['msgs_by_record'] = messages_by_record
+      page_ctx['msg_grouping'] = utils.MessageGroupingById(messages)
     return render(request, 'diff_results.html', page_ctx)
 
 class ValidatorController(PfifController):

--- a/tools/pfif-tools/app/pfif_diff.py
+++ b/tools/pfif-tools/app/pfif_diff.py
@@ -230,7 +230,7 @@ def main():
       text_is_case_sensitive=options.text_is_case_sensitive,
       ignore_fields=options.ignore_fields,
       omit_blank_fields=options.omit_blank_fields)
-  print(utils.MessagesOutput.generate_message_summary(messages, is_html=False))
+  print(utils.MessagesOutput.generate_message_summary(messages))
   if options.group_by_record_id:
     print(utils.MessagesOutput.messages_to_str_by_id(messages))
   else:

--- a/tools/pfif-tools/app/pfif_validator.py
+++ b/tools/pfif-tools/app/pfif_validator.py
@@ -826,7 +826,7 @@ def main():
   assert len(sys.argv) == 2, 'Usage: python pfif_validator.py my-pyif-xml-file'
   validator = PfifValidator(utils.open_file(sys.argv[1], 'r'))
   messages = validator.run_validations()
-  print(utils.MessagesOutput.generate_message_summary(messages, is_html=False))
+  print(utils.MessagesOutput.generate_message_summary(messages))
   print(validator.validator_messages_to_str(messages))
 
 if __name__ == '__main__':

--- a/tools/pfif-tools/app/resources/diff_results.html
+++ b/tools/pfif-tools/app/resources/diff_results.html
@@ -39,58 +39,58 @@
 
 <div class="all_messages">
   {% if group_messages %}
-    {% if added_record_ids %}
+    {% if msg_grouping.added_record_ids %}
       <div class="message">
         <div class="grouped_record_header">
-          B has extra records: {{ added_record_ids|length }} messages.
+          B has extra records: {{ msg_grouping.added_record_ids|length }} messages.
         </div>
         <div class="grouped_record_list">
           Record IDs:
           <span class="message_data">
-            {{ added_record_ids|join:', ' }}
+            {{ msg_grouping.added_record_ids|join:', ' }}
           </span>
         </div>
       </div>
     {% endif %}
-    {% if deleted_record_ids %}
+    {% if msg_grouping.deleted_record_ids %}
       <div class="message">
         <div class="grouped_record_header">
-          B is missing records: {{ deleted_record_ids|length }} messages.
+          B is missing records: {{ msg_grouping.deleted_record_ids|length }} messages.
         </div>
         <div class="grouped_record_list">
           Record IDs:
           <span class="message_data">
-            {{ deleted_record_ids|join:', ' }}
+            {{ msg_grouping.deleted_record_ids|join:', ' }}
           </span>
         </div>
       </div>
     {% endif %}
-    {% for record_id, record_msgs in msgs_by_record.items %}
+    {% for record_id, record_data in msg_grouping.messages_by_record.items %}
       <div class="message">
         <div class="grouped_record_header">
-          {{ record_msgs.list|length }} messages for record: {{ record_id }}
+          {{ record_data.count }} messages for record: {{ record_id }}
         </div>
-        {% if record_msgs.added_field_tags %}
+        {% if record_data.added_tags %}
           <div class="grouped_record_list">
             B has extra fields:
             <span class="message_data">
-              {{ record_msgs.added_field_tags|join:', ' }}
+              {{ record_data.added_tags|join:', ' }}
             </span>
           </div>
         {% endif %}
-        {% if record_msgs.deleted_field_tags %}
+        {% if record_data.deleted_tags %}
           <div class="grouped_record_list">
             B is missing fields:
             <span class="message_data">
-              {{ record_msgs.deleted_field_tags|join:', ' }}
+              {{ record_data.deleted_tags|join:', ' }}
             </span>
           </div>
         {% endif %}
-        {% if record_msgs.changed_field_tags %}
+        {% if record_data.changed_tags %}
           <div class="grouped_record_list">
             Values changed:
             <span class="message_data">
-              {{ record_msgs.changed_field_tags|join:', ' }}
+              {{ record_data.changed_tags|join:', ' }}
             </span>
           </div>
         {% endif %}

--- a/tools/pfif-tools/app/resources/diff_results.html
+++ b/tools/pfif-tools/app/resources/diff_results.html
@@ -29,7 +29,7 @@
 {% for filename in filenames %}
   <p>
     File {{ filename.shorthand_name }}:
-    {% if filename %}
+    {% if filename.filename %}
       {{ filename.filename }}
     {% else %}
       pasted in

--- a/tools/pfif-tools/app/resources/diff_results.html
+++ b/tools/pfif-tools/app/resources/diff_results.html
@@ -9,7 +9,7 @@
 
 <body>
 
-<h1>Diff: {{ messages|length }} Messages</h1>
+<h1>Diff: {{ msgs|length }} Messages</h1>
 
 {% if msgs_by_category %}
   <table>
@@ -97,6 +97,7 @@
       </div>
     {% endfor %}
   {% else %}
+    {% include "messages.html" with show_record_ids=True show_xml_tag=True show_xml_text=True %}
   {% endif %}
 </div>
 

--- a/tools/pfif-tools/app/resources/diff_results.html
+++ b/tools/pfif-tools/app/resources/diff_results.html
@@ -1,0 +1,105 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>{{ page_title }}</title>
+  <link rel="stylesheet" type="text/css" href="/static/style.css">
+</head>
+
+<body>
+
+<h1>Diff: {{ messages|length }} Messages</h1>
+
+{% if msgs_by_category %}
+  <table>
+    <tr>
+      <th>Category</th>
+      <th>Number of Messages</th>
+    </tr>
+    {% for category, msgs in msgs_by_category.items %}
+      <tr>
+        <td>{{ category }}</td>
+        <td>{{ msgs|length }}</td>
+      </tr>
+    {% endfor %}
+  </table>
+{% endif %}
+
+{% for filename in filenames %}
+  <p>
+    File {{ filename.shorthand_name }}:
+    {% if filename %}
+      {{ filename.filename }}
+    {% else %}
+      pasted in
+    {% endif %}
+  </p>
+{% endfor %}
+
+<div class="all_messages">
+  {% if group_messages %}
+    {% if added_record_ids %}
+      <div class="message">
+        <div class="grouped_record_header">
+          B has extra records: {{ added_record_ids|length }} messages.
+        </div>
+        <div class="grouped_record_list">
+          Record IDs:
+          <span class="message_data">
+            {{ added_record_ids|join:', ' }}
+          </span>
+        </div>
+      </div>
+    {% endif %}
+    {% if deleted_record_ids %}
+      <div class="message">
+        <div class="grouped_record_header">
+          B is missing records: {{ deleted_record_ids|length }} messages.
+        </div>
+        <div class="grouped_record_list">
+          Record IDs:
+          <span class="message_data">
+            {{ deleted_record_ids|join:', ' }}
+          </span>
+        </div>
+      </div>
+    {% endif %}
+    {% for record_id, record_msgs in msgs_by_record.items %}
+      <div class="message">
+        <div class="grouped_record_header">
+          {{ record_msgs.list|length }} messages for record: {{ record_id }}
+        </div>
+        {% if record_msgs.added_field_tags %}
+          <div class="grouped_record_list">
+            B has extra fields:
+            <span class="message_data">
+              {{ record_msgs.added_field_tags|join:', ' }}
+            </span>
+          </div>
+        {% endif %}
+        {% if record_msgs.deleted_field_tags %}
+          <div class="grouped_record_list">
+            B is missing fields:
+            <span class="message_data">
+              {{ record_msgs.deleted_field_tags|join:', ' }}
+            </span>
+          </div>
+        {% endif %}
+        {% if record_msgs.changed_field_tags %}
+          <div class="grouped_record_list">
+            Values changed:
+            <span class="message_data">
+              {{ record_msgs.changed_field_tags|join:', ' }}
+            </span>
+          </div>
+        {% endif %}
+      </div>
+    {% endfor %}
+  {% else %}
+  {% endif %}
+</div>
+
+</body>
+
+</html>

--- a/tools/pfif-tools/app/resources/messages.html
+++ b/tools/pfif-tools/app/resources/messages.html
@@ -1,0 +1,53 @@
+{% for msg in msgs %}
+  <div class="message">
+    {% if show_error_type %}
+      <span class="message_type">
+        {% if msg.is_error %}
+          ERROR
+        {% else %}
+          WARNING
+        {% endif %}
+      </span>
+    {% endif %}
+    {% if show_line_numbers and msg.xml_line_number %}
+      <span class="message_line_number">
+        LINE {{ msg.xml_line_number }}:
+      </span>
+    {% endif %}
+    <span class="message_category">
+      {{ msg.category }}
+      {% if msg.extra_data %}
+        <span class="message_data">: {{msg.extra_data}}</span>
+      {% endif %}
+    </span>
+    {% if show_record_ids %}
+      {% if msg.person_record_id %}
+        <div class="message_person_record_id">
+          The relevant person_record_id is:
+          <span class="message_data">{{ msg.person_record_id }}</span>
+        </div>
+      {% endif %}
+      {% if msg.note_record_id %}
+        <div class="message_note_record_id">
+          The relevant note_record_id is:
+          <span class="message_data">{{ msg.note_record_id }}</span>
+        </div>
+      {% endif %}
+    {% endif %}
+    {% if show_xml_tag and msg.xml_tag %}
+      <div class="message_xml_tag">
+        The tag of the relevant PFIF XML node:
+        <span class="message_data">{{ msg.xml_tag }}</span>
+      </div>
+    {% endif %}
+    {% if show_xml_text and msg.xml_text %}
+      <div class="message_xml_text">
+        The text of the relevant PFIF XML node:
+        <span class="message_data">{{ msg.xml_text }}</span>
+      </div>
+    {% endif %}
+    {% if show_full_line and msg.full_xml_line %}
+      <div class="message_xml_full_line">{{ msg.full_xml_line }}</div>
+    {% endif %}
+  </div>
+{% endfor %}

--- a/tools/pfif-tools/app/resources/validate_results.html
+++ b/tools/pfif-tools/app/resources/validate_results.html
@@ -27,57 +27,7 @@
 {% endif %}
 
 <div class="all_messages">
-  {% for msg in msgs %}
-    <div class="message">
-      <span class="message_type">
-        {% if msg.is_error %}
-          ERROR
-        {% else %}
-          WARNING
-        {% endif %}
-      </span>
-      {% if show_line_numbers %}
-        <span class="message_line_number">
-          LINE {{ msg.xml_line_number }}:
-        </span>
-      {% endif %}
-      <span class="message_category">
-        {{ msg.category }}
-        {% if msg.extra_data %}
-          <span class="message_data">: {{msg.extra_data}}</span>
-        {% endif %}
-      </span>
-      {% if show_record_ids %}
-        {% if msg.person_record_id %}
-          <div class="message_person_record_id">
-            The relevant person_record_id is:
-            <span class="message_data">{{ msg.person_record_id }}</span>
-          </div>
-        {% endif %}
-        {% if msg.note_record_id %}
-          <div class="message_note_record_id">
-            The relevant note_record_id is:
-            <span class="message_data">{{ msg.note_record_id }}</span>
-          </div>
-        {% endif %}
-      {% endif %}
-      {% if show_xml_tag and msg.xml_tag %}
-        <div class="message_xml_tag">
-          The tag of the relevant PFIF XML node:
-          <span class="message_data">{{ msg.xml_tag }}</span>
-        </div>
-      {% endif %}
-      {% if show_xml_text and msg.xml_text %}
-        <div class="message_xml_text">
-          The text of the relevant PFIF XML node:
-          <span class="message_data">{{ msg.xml_text }}</span>
-        </div>
-      {% endif %}
-      {% if show_full_line and msg.full_xml_line %}
-        <div class="message_xml_full_line">{{ msg.full_xml_line }}</div>
-      {% endif %}
-    </div>
-  {% endfor %}
+  {% include "messages.html" with show_error_type=True %}
 </div>
 
 </body>

--- a/tools/pfif-tools/app/utils.py
+++ b/tools/pfif-tools/app/utils.py
@@ -189,7 +189,11 @@ class Categories: # pylint: disable=W0232
 
 
 class MessageGroupingById(object):
-  """A class to help group messages by record ID."""
+  """A class to help group messages by record ID.
+
+  This should contain the logic for grouping messages by record ID, but no UI
+  code (it's meant for sharing logic between the HTML and plain text displays).
+  """
 
   def __init__(self, messages):
     self.messages = messages

--- a/tools/pfif-tools/tests/test_utils.py
+++ b/tools/pfif-tools/tests/test_utils.py
@@ -136,18 +136,17 @@ class UtilTests(unittest.TestCase):
     message for removed records, and one message for each other record."""
     # an empty messages list should produce no errors and return a string with
     # no messages
-    output_str = utils.MessagesOutput.messages_to_str_by_id([], is_html=True)
-    self.assertEqual(output_str.count('"message"'), 0)
+    output_str = utils.MessagesOutput.messages_to_str_by_id([])
+    self.assertEqual(output_str, '')
 
     # there should be an added section, a deleted section, and one section for
     # each of the records that had fields added, removed, or changed
     messages = pfif_diff.pfif_file_diff(
         StringIO(PfifXml.XML_ADDED_DELETED_CHANGED_1),
         StringIO(PfifXml.XML_ADDED_DELETED_CHANGED_2))
-    output_str = utils.MessagesOutput.messages_to_str_by_id(messages,
-                                                            is_html=True)
-    self.assertEqual(output_str.count('grouped_record_header'), 3)
-    self.assertEqual(output_str.count('"message"'), 3)
+    output_str = utils.MessagesOutput.messages_to_str_by_id(messages)
+    self.assertEqual(output_str.count('1 messages'), 2)
+    self.assertEqual(output_str.count('3 messages'), 1)
     self.assertTrue('foo' in output_str)
     self.assertTrue('bar' in output_str)
     self.assertTrue('source_date' in output_str)
@@ -157,11 +156,9 @@ class UtilTests(unittest.TestCase):
     messages = pfif_diff.pfif_file_diff(
         StringIO(PfifXml.XML_ONE_PERSON_ONE_FIELD),
         StringIO(PfifXml.XML_ONE_PERSON_TWO_FIELDS))
-    output_str = utils.MessagesOutput.messages_to_str_by_id(messages,
-                                                            is_html=True)
-    self.assertEqual(output_str.count('grouped_record_header'), 1)
-    self.assertEqual(output_str.count('"message"'), 1)
-    self.assertEqual(output_str.count('grouped_record_list'), 1)
+    output_str = utils.MessagesOutput.messages_to_str_by_id(messages)
+    self.assertEqual(output_str.count('1 messages'), 1)
+    self.assertEqual(output_str.count('extra fields'), 1)
 
   def test_truncate(self):
     """truncate should leave there with the specified number of messages per

--- a/tools/pfif-tools/tests/test_validator.py
+++ b/tools/pfif-tools/tests/test_validator.py
@@ -116,12 +116,6 @@ class ValidatorTests(unittest.TestCase):
         messages, show_full_line=True, xml_lines=lines)
     self.assertNotEqual(output.find("ZZZ 11"), -1)
 
-    # is_html should output a div somewhere
-    self.assertEqual(output.find("div"), -1)
-    output = validator.validator_messages_to_str(
-        messages, is_html=True, xml_lines=lines)
-    self.assertNotEqual(output.find("div"), -1)
-
   # validate_root_has_child
 
   def test_root_has_child(self):


### PR DESCRIPTION
It turns out the pfif-tools code also supports a command-line interface, so I couldn't delete as much code as I'd hoped, but at least all the HTML-outputting code is gone.