### PR TITLE
Use urlparse.parse_qsl instead of cgi.parse_qsl.

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -18,7 +18,6 @@ __author__ = 'kpy@google.com (Ka-Ping Yee) and many other Googlers'
 from django_setup import ugettext as _  # always keep this first
 
 import calendar
-import cgi
 import copy
 from datetime import datetime, timedelta
 import hmac
@@ -138,7 +137,7 @@ def urlencode(params, encoding='utf-8'):
 def set_param(params, param, value):
     """Take the params from a urlparse and override one of the values."""
     # This will strip out None-valued params and collapse repeated params.
-    params = dict(cgi.parse_qsl(params))
+    params = dict(urlparse.parse_qsl(params))
     if value is None:
         if param in params:
             del(params[param])


### PR DESCRIPTION
You get a deprecation warning with newer versions of Python when you use the one from the cgi module.