### PR TITLE
Drop standalone param.

### DIFF
--- a/app/add_note.py
+++ b/app/add_note.py
@@ -51,14 +51,12 @@ class Handler(BaseHandler):
         if not person:
             return self.error(404,
                 _("This person's entry does not exist or has been deleted."))
-        standalone = self.request.get('standalone')
 
         # Render the page.
         enable_notes_url = self.get_url('/enable_notes', id=self.params.id)
 
         self.render('add_note.html',
                     person=person,
-                    standalone=standalone,
                     enable_notes_url=enable_notes_url)
 
     def post(self):

--- a/app/multiview.py
+++ b/app/multiview.py
@@ -64,8 +64,6 @@ class Handler(BaseHandler):
         reveal_url = reveal.make_reveal_url(self, content_id)
         show_private_info = reveal.verify(content_id, self.params.signature)
 
-        standalone = self.request.get('standalone')
-
         # TODO: Handle no persons found.
 
         person['profile_pages'] = [view.get_profile_pages(profile_urls, self)
@@ -75,7 +73,7 @@ class Handler(BaseHandler):
         # Note: we're not showing notes and linked persons information
         # here at the moment.
         self.render('multiview.html',
-                    person=person, any=any_person, standalone=standalone,
+                    person=person, any=any_person,
                     cols=len(person['full_name']) + 1,
                     onload_function='view_page_loaded()', markdup=True,
                     show_private_info=show_private_info, reveal_url=reveal_url)

--- a/app/resources/add_note.html.template
+++ b/app/resources/add_note.html.template
@@ -47,9 +47,7 @@
 {% endblock head %}
 
 {% block content %}
-  {% if not standalone %}
-    {% include "map.html.template" %}
-  {% endif %}
+  {% include "map.html.template" %}
   <form method="post" enctype="multipart/form-data" action="{{env.repo_path}}/add_note">
     {{env.hidden_input_tags_for_preserved_query_params|safe}}
     <input type="hidden" name="id" value="{{person.record_id}}">

--- a/app/resources/multiview.html.template
+++ b/app/resources/multiview.html.template
@@ -17,9 +17,7 @@
   {% for val in person.full_name %}{{val}} - {% endfor %} {{block.super}}
 {% endblock %}
 {% block content %}
-{% if not standalone %}
-  {% include "map.html.template" %}
-{% endif %}
+{% include "map.html.template" %}
 <form method="post" action="{{env.repo_path}}/multiview">
   {{env.hidden_input_tags_for_preserved_query_params|safe}}
   {% for val in person.person_record_id %}

--- a/app/resources/view.html.template
+++ b/app/resources/view.html.template
@@ -60,9 +60,7 @@
 {% endblock head %}
 
 {% block content %}
-  {% if not standalone %}
-    {% include "map.html.template" %}
-  {% endif %}
+  {% include "map.html.template" %}
 
   <div class="view">
 

--- a/app/view.py
+++ b/app/view.py
@@ -63,7 +63,6 @@ class Handler(BaseHandler):
         if not person:
             return self.error(404,
                 _("This person's entry does not exist or has been deleted."))
-        standalone = self.request.get('standalone')
 
         # Check if private info should be revealed.
         content_id = 'view:' + self.params.id
@@ -153,7 +152,6 @@ class Handler(BaseHandler):
                     person=person,
                     notes=notes,
                     linked_person_info=linked_person_info,
-                    standalone=standalone,
                     onload_function='view_page_loaded()',
                     show_private_info=show_private_info,
                     admin=users.is_current_user_admin(),


### PR DESCRIPTION
This seems to only ever be read, never actually used. It's unclear what
its purpose was (it was part of the original PF code checkin), but its
only effect is to disable the map (maybe it did other things in the past
and what we see now is just leftover code that didn't get cleaned up).