### PR TITLE
Only get auth data when needed (for API and feeds).

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -208,7 +208,7 @@ class BaseApiHandler(utils.BaseHandler):
 
     def __init__(self, request, response, env):
         super(BaseApiHandler, self).__init__(request, response, env)
-        self.set_auth(self.params.key)
+        self.set_auth()
 
 
 # TODO(gimite): Rename this class name and URL because it now supports both

--- a/app/api.py
+++ b/app/api.py
@@ -204,10 +204,17 @@ def convert_xsl_to_csv(contents):
     return csv_output.getvalue(), None
 
 
+class BaseApiHandler(utils.BaseHandler):
+
+    def __init__(self, request, response, env):
+        super(BaseApiHandler, self).__init__(request, response, env)
+        self.set_auth(self.params.key)
+
+
 # TODO(gimite): Rename this class name and URL because it now supports both
 #     import and export, maybe after we decide to use CSV or Excel file for
 #     import and export.
-class Import(utils.BaseHandler):
+class Import(BaseApiHandler):
     """A web UI for users to import or export records in CSV / Excel format.
     """
 
@@ -350,7 +357,7 @@ class Import(utils.BaseHandler):
                 message=_('The data is not ready yet. Try again in 24 hours.'))
 
 
-class Read(utils.BaseHandler):
+class Read(BaseApiHandler):
     https_required = True
 
     def get(self):
@@ -393,7 +400,7 @@ class Read(utils.BaseHandler):
             self, ApiActionLog.READ, len(records), len(notes))
 
 
-class PhotoUpload(utils.BaseHandler):
+class PhotoUpload(BaseApiHandler):
     https_required = True
 
     def post(self):
@@ -431,7 +438,7 @@ class PhotoUpload(utils.BaseHandler):
         self.write('</url></response>')
 
 
-class Write(utils.BaseHandler):
+class Write(BaseApiHandler):
     https_required = True
 
     def post(self):
@@ -503,7 +510,7 @@ class Write(utils.BaseHandler):
 ''' % (type, total, written, ''.join(skipped_records).rstrip()))
 
 
-class Search(utils.BaseHandler):
+class Search(BaseApiHandler):
     https_required = False
 
     def get(self):
@@ -556,7 +563,7 @@ class Search(utils.BaseHandler):
         utils.log_api_action(self, ApiActionLog.SEARCH, len(records))
 
 
-class Subscribe(utils.BaseHandler):
+class Subscribe(BaseApiHandler):
     https_required = True
 
     def post(self):
@@ -579,7 +586,7 @@ class Subscribe(utils.BaseHandler):
         return self.info(200, 'Successfully subscribed')
 
 
-class Unsubscribe(utils.BaseHandler):
+class Unsubscribe(BaseApiHandler):
     https_required = True
 
     def post(self):
@@ -605,7 +612,7 @@ def fetch_all(query):
     return results
 
 
-class Stats(utils.BaseHandler):
+class Stats(BaseApiHandler):
     def get(self):
         if not (self.auth and self.auth.stats_permission):
             self.info(
@@ -644,7 +651,7 @@ class Stats(utils.BaseHandler):
                                      'note': note_counts}))
 
 
-class HandleSMS(utils.BaseHandler):
+class HandleSMS(BaseApiHandler):
     """Person Finder doesn't directly handle SMSes from users. They are handled
     by Google internal SMS gateway. When the gateway receives an SMS, it sends
     an XML HTTP request to Person Finder, and sends back its response to the

--- a/app/feeds.py
+++ b/app/feeds.py
@@ -43,7 +43,14 @@ def make_hidden_notes_blank(notes):
             note.text = ''
 
 
-class Repo(utils.BaseHandler):
+class BaseFeedsHandler(utils.BaseHandler):
+
+    def __init__(self, request, response, env):
+        super(BaseFeedsHandler, self).__init__(request, response, env)
+        self.set_auth(self.params.key)
+
+
+class Repo(BaseFeedsHandler):
     TITLE = 'Person Finder Repository Feed'
 
     repo_required = False
@@ -63,7 +70,7 @@ class Repo(utils.BaseHandler):
         utils.log_api_action(self, model.ApiActionLog.REPO)
 
 
-class Person(utils.BaseHandler):
+class Person(BaseFeedsHandler):
     https_required = True
 
     def get(self):
@@ -118,7 +125,7 @@ class Person(utils.BaseHandler):
                              self.num_notes)
 
 
-class Note(utils.BaseHandler):
+class Note(BaseFeedsHandler):
     # SSL check is done in get() if person_record_id is not specified.
     https_required = False
 

--- a/app/feeds.py
+++ b/app/feeds.py
@@ -47,7 +47,7 @@ class BaseFeedsHandler(utils.BaseHandler):
 
     def __init__(self, request, response, env):
         super(BaseFeedsHandler, self).__init__(request, response, env)
-        self.set_auth(self.params.key)
+        self.set_auth()
 
 
 class Repo(BaseFeedsHandler):

--- a/app/utils.py
+++ b/app/utils.py
@@ -1099,15 +1099,15 @@ class BaseHandler(webapp.RequestHandler):
             params_dict)
         return urlparse.urlunparse(parsed_url)
 
-    def set_auth(self, key):
+    def set_auth(self):
         self.auth = None
-        if key:
+        if self.params.key:
             if self.repo:
                 # check for domain specific one.
-                self.auth = model.Authorization.get(self.repo, key)
+                self.auth = model.Authorization.get(self.repo, self.params.key)
             if not self.auth:
                 # perhaps this is a global key ('*' for consistency with config).
-                self.auth = model.Authorization.get('*', key)
+                self.auth = model.Authorization.get('*', self.params.key)
         if self.auth and not self.auth.is_valid:
             self.auth = None
 


### PR DESCRIPTION
Currently the global base handler is setting the auth field for every
request, but most of them don't need it. This creates parent classes for
API and feed stuff and sets the auth value there.