### PR TITLE
Upgrade to Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
       git \
       time \
       unzip
-  - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.74.zip -O /tmp/appengine.zip
+  - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.84.zip -O /tmp/appengine.zip
   - unzip -qq /tmp/appengine.zip
   - pip install cssselect lxml mock modernize pillow==4.1.0 pytest
   - npm --prefix ui install

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
       git \
       time \
       unzip
-  - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.80.zip -O /tmp/appengine.zip
+  - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.83.zip -O /tmp/appengine.zip
   - unzip -qq /tmp/appengine.zip
   - pip install cssselect lxml mock modernize pillow==4.1.0 pytest
   - npm --prefix ui install

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
       git \
       time \
       unzip
-  - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.84.zip -O /tmp/appengine.zip
+  - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.76.zip -O /tmp/appengine.zip
   - unzip -qq /tmp/appengine.zip
   - pip install cssselect lxml mock modernize pillow==4.1.0 pytest
   - npm --prefix ui install

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
       git \
       time \
       unzip
-  - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.76.zip -O /tmp/appengine.zip
+  - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.80.zip -O /tmp/appengine.zip
   - unzip -qq /tmp/appengine.zip
   - pip install cssselect lxml mock modernize pillow==4.1.0 pytest
   - npm --prefix ui install

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
       git \
       time \
       unzip
-  - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.62.zip -O /tmp/appengine.zip
+  - wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.74.zip -O /tmp/appengine.zip
   - unzip -qq /tmp/appengine.zip
   - pip install cssselect lxml mock modernize pillow==4.1.0 pytest
   - npm --prefix ui install

--- a/app/app.yaml
+++ b/app/app.yaml
@@ -42,7 +42,7 @@ handlers:
 
 libraries:
 - name: django
-  version: "1.9"
+  version: "1.11"
 - name: lxml
   version: "3.7.3"
 - name: webapp2

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -67,7 +67,7 @@ export PYTHONPATH=\
 "$TESTS_DIR":\
 "$TOOLS_DIR":\
 "$APPENGINE_DIR":\
-"$APPENGINE_DIR/lib/django-1.9":\
+"$APPENGINE_DIR/lib/django-1.11":\
 "$APPENGINE_DIR/lib/fancy_urllib":\
 "$APPENGINE_DIR/lib/webapp2-2.5.2":\
 "$APPENGINE_DIR/lib/webob-1.2.3":\


### PR DESCRIPTION
This also upgrades the SDK version we use for Travis tests, to the second-most-recent version. I got some errors with the version we used to use, but that version's a year and a half old so I didn't think it was worth debugging and just upgraded instead. However, I didn't upgrade it to the very latest version (1.9.84), because of a known issue with dev_appserver.