### PR TITLE
Drop the AdminEnv class.

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -42,36 +42,6 @@ import user_agents
 import setup_pf
 
 
-class AdminEnv(object):
-    """Template variables for admin pages."""
-
-    def __init__(self, request):
-        self.request = request
-        self.user = users.get_current_user()
-        self.logout_url = users.create_logout_url(self.request.url)
-
-    @property
-    def repo_options(self):
-        """This is different from env.repo_options because this contains all
-        repositories including deactivated ones.
-
-        This is defined as a property so that it is evaluated lazily only
-        when necessary.
-        """
-        try:
-            return [
-                utils.Struct(
-                    repo=repo,
-                    url=utils.get_repo_url(self.request, repo) + '/admin')
-                for repo in sorted(model.Repo.list())]
-        except:
-            # Logs the exception here because exceptions thrown during template
-            # variable evaluation is silently ignored. Note that
-            # logging.exception() logs the current exception by default.
-            logging.exception('Exception thrown')
-            return None
-
-
 # When no action or repo is specified, redirect to this action.
 HOME_ACTION = 'home.html'
 
@@ -434,8 +404,6 @@ def setup_env(request):
         env.enable_javascript
         and not env.config.zero_rating_mode
         and env.config.translate_api_key)
-
-    env.admin = AdminEnv(request)
 
     # Repo-specific information.
     if env.repo:

--- a/app/resources/admin-base.html.template
+++ b/app/resources/admin-base.html.template
@@ -42,7 +42,7 @@
 {% endblock body %}
 
 {% block sidenav %}
-  <div><span class="email">{{env.admin.user.email}}<a href="{{env.admin.logout_url}}">Sign out</a></div>
+  <div><span class="email">{{env.user.email}}<a href="{{env.logout_url}}">Sign out</a></div>
 
   <h2>Global</h2>
     <a href="{{env.global_url}}/admin">Global settings</a>
@@ -57,7 +57,7 @@
       {% if not env.repo %}
         <option>Select a repository:</option>
       {% endif %}
-      {% for option in env.admin.repo_options %}
+      {% for option in env.all_repo_options %}
         <option value="{{option.url}}"
           {% ifequal option.repo env.repo %}
             selected

--- a/app/utils.py
+++ b/app/utils.py
@@ -1157,8 +1157,8 @@ class BaseHandler(webapp.RequestHandler):
         # If we use it, user can't sign out
         # because the error page of "login: admin" doesn't have sign-out link.
         if self.admin_required:
-            user = users.get_current_user()
-            if not user:
+            self.env.user = users.get_current_user()
+            if not self.env.user:
                 login_url = users.create_login_url(self.request.url)
                 webapp.RequestHandler.redirect(self, login_url)
                 self.terminate_response()
@@ -1168,6 +1168,21 @@ class BaseHandler(webapp.RequestHandler):
                 self.render('not_admin_error.html', logout_url=logout_url, user=user)
                 self.terminate_response()
                 return
+            self.env.logout_url = users.create_logout_url(self.request.url)
+            try:
+                # This is different from env.repo_options because this contains
+                # all repositories including deactivated ones.
+                self.env.all_repo_options = [
+                    Struct(
+                        repo=repo,
+                        url=get_repo_url(self.request, repo) + '/admin')
+                    for repo in sorted(model.Repo.list())]
+            except:
+                # Logs the exception here because exceptions thrown during
+                # tempalate variable evaluation is silently ignored anyway. Note
+                # that logging.exception() logs the current exception by
+                # default.
+                logging.exception('Exception thrown')
 
         # Handlers that don't need a repository configuration can skip it.
         if not self.repo:

--- a/app/utils.py
+++ b/app/utils.py
@@ -1169,20 +1169,13 @@ class BaseHandler(webapp.RequestHandler):
                 self.terminate_response()
                 return
             self.env.logout_url = users.create_logout_url(self.request.url)
-            try:
-                # This is different from env.repo_options because this contains
-                # all repositories including deactivated ones.
-                self.env.all_repo_options = [
-                    Struct(
-                        repo=repo,
-                        url=get_repo_url(self.request, repo) + '/admin')
-                    for repo in sorted(model.Repo.list())]
-            except:
-                # Logs the exception here because exceptions thrown during
-                # tempalate variable evaluation is silently ignored anyway. Note
-                # that logging.exception() logs the current exception by
-                # default.
-                logging.exception('Exception thrown')
+            # This is different from env.repo_options because this contains all
+            # repositories including deactivated ones.
+            self.env.all_repo_options = [
+                Struct(
+                    repo=repo,
+                    url=get_repo_url(self.request, repo) + '/admin')
+                for repo in sorted(model.Repo.list())]
 
         # Handlers that don't need a repository configuration can skip it.
         if not self.repo:


### PR DESCRIPTION
This is only used in one place, and each field is only referenced once,
so I don't think we need it anymore. It's kinda a problem because it
causes a shared template to depend directly on the request object. This
is particularly an issue now because it's an obstacle to the incremental
migration from webapp2 to Django (which has different request objects).