### PR TITLE
Drop YAPF from Travis tests for now.

### DIFF
--- a/tools/travis_tests
+++ b/tools/travis_tests
@@ -23,7 +23,7 @@ pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 case "${TRAVIS_PYTHON_VERSION:0:1}" in
 
     "2")
-        $TOOLS_DIR/lint pylint-check && $TOOLS_DIR/lint yapf-check && \
+        $TOOLS_DIR/lint pylint-check && \
             $TOOLS_DIR/unit_tests -q && \
             $TOOLS_DIR/server_tests -q && \
             $TOOLS_DIR/python3_compatibility_check && \


### PR DESCRIPTION
Although YAPF docs suggest using it as part of a CI workflow, we've run
into a risk associated with that: YAPF might change its implementation,
and if its output changes your CI will break. This may not sound like a
significant risk, but we set up YAPF for two files on Thursday and it
broke our Travis tests on Sunday.

This takes YAPF out of our Travis setup to unbreak things. I've left the
YAPF option in the tools/lint script for now, since I'm not sure what
the new plan is going to be and we might still end up using it (even if
it's not part of our Travis setup).