### PR TITLE
Use HTTPS everywhere, except for tasks.

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -509,7 +509,7 @@ class Write(BaseApiHandler):
 
 
 class Search(BaseApiHandler):
-    https_required = False
+    https_required = True
 
     def get(self):
         if self.config.search_auth_key_required and not (

--- a/app/const.py
+++ b/app/const.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 from django.utils.translation import gettext_lazy as _
 
 # The root URL of this application.
-ROOT_URL = 'http://google.org/personfinder'
+ROOT_URL = 'https://google.org/personfinder'
 
 # The domain name of this application.  The application hosts multiple
 # repositories; each repository ID is https://<HOME_DOMAIN>/<REPO>.

--- a/app/feeds.py
+++ b/app/feeds.py
@@ -54,7 +54,7 @@ class Repo(BaseFeedsHandler):
     TITLE = 'Person Finder Repository Feed'
 
     repo_required = False
-    https_required = False
+    https_required = True
     # For a deactivated repo, return an empty feed instead of an error page.
     ignore_deactivation = True
 
@@ -127,7 +127,7 @@ class Person(BaseFeedsHandler):
 
 class Note(BaseFeedsHandler):
     # SSL check is done in get() if person_record_id is not specified.
-    https_required = False
+    https_required = True
 
     def get(self):
         # SSL and auth key is not required if a feed for a specific person

--- a/app/main.py
+++ b/app/main.py
@@ -282,7 +282,7 @@ def setup_env(request):
     # Information about the request.
     env.url = utils.set_url_param(request.url, 'lang', env.lang)
     env.scheme, env.netloc, env.path, _, _ = urlparse.urlsplit(request.url)
-    env.force_https = False
+    env.force_https = True
     env.domain = env.netloc.split(':')[0]
     env.global_url = utils.get_repo_url(request, 'global')
 

--- a/app/resources/static-base.html.template
+++ b/app/resources/static-base.html.template
@@ -57,7 +57,7 @@
     {% endif %}
     <span class="link-separator"></span>
     {% if env.ui != "light" %}
-      <a href="http://support.google.com/personfinder/?hl={{env.lang}}"
+      <a href="https://support.google.com/personfinder/?hl={{env.lang}}"
           {% comment %}
             Translators: The title of a page of frequently asked questions.
           {% endcomment %}

--- a/app/settings.py
+++ b/app/settings.py
@@ -62,6 +62,14 @@ ROOT_URLCONF = 'urls'
 # configuration.
 APPEND_SLASH = False
 
+SECURE_SSL_REDIRECT = True
+
+# App Engine issues HTTP requests for tasks, so we don't force HTTPS for them.
+SECURE_REDIRECT_EXEMPT = [r'^.*/tasks/.*']
+if site_settings.OPTIONAL_PATH_PREFIX:
+  SECURE_REDIRECT_EXEMPT += [
+      r'^%s/.*/tasks/.*' % site_settings.OPTIONAL_PATH_PREFIX]
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/app/sitemap.py
+++ b/app/sitemap.py
@@ -63,6 +63,9 @@ class SiteMapPing(BaseHandler):
 
     repo_required = False
 
+    # App Engine issues HTTP requests to tasks.
+    https_required = False
+
     @staticmethod
     def add_ping_tasks():
         for search_engine in SiteMapPing._INDEXER_MAP:

--- a/app/sitemap.py
+++ b/app/sitemap.py
@@ -52,6 +52,7 @@ class SiteMap(BaseHandler):
         self.render('sitemap.xml', urlpaths=urlpaths)
 
 
+# TODO(nworden): move this under a /tasks URL for consistency
 class SiteMapPing(BaseHandler):
     """Pings the index server."""
     _INDEXER_MAP = {

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -55,6 +55,9 @@ class ScanForExpired(utils.BaseHandler):
     Subclasses set the query and task_name."""
     repo_required = False
 
+    # App Engine issues HTTP requests to tasks.
+    https_required = False
+
     def task_name(self):
         """Subclasses should implement this."""
         pass
@@ -131,6 +134,9 @@ class CleanUpInTestMode(utils.BaseHandler):
     """
     repo_required = False
     ACTION = 'tasks/clean_up_in_test_mode'
+
+    # App Engine issues HTTP requests to tasks.
+    https_required = False
 
     # Entries older than this age in seconds are deleted in test mode.
     #
@@ -244,6 +250,9 @@ class CountBase(utils.BaseHandler):
 
     SCAN_NAME = ''  # Each subclass should choose a unique scan_name.
     ACTION = ''  # Each subclass should set the action path that it handles.
+
+    # App Engine issues HTTP requests to tasks.
+    https_required = False
 
     def get(self):
         if self.repo:  # Do some counting.
@@ -397,6 +406,9 @@ class NotifyManyUnreviewedNotes(utils.BaseHandler):
     repo_required = False  # can run without a repo
     ACTION = 'tasks/notify_many_unreviewed_notes'
 
+    # App Engine issues HTTP requests to tasks.
+    https_required = False
+
     def task_name(self):
         return 'notify-bad-review-status'
 
@@ -451,6 +463,9 @@ class ThumbnailPreparer(utils.BaseHandler):
     repo_required = False
     ACTION = 'tasks/thumbnail_preparer'
 
+    # App Engine issues HTTP requests to tasks.
+    https_required = False
+
     def get(self):
         # We don't retry this task automatically, because it's looking for
         # everything that doesn't already have a thumbnail every time --
@@ -481,6 +496,9 @@ class DumpCSV(utils.BaseHandler):
 
     repo_required = False
     ACTION = 'tasks/dump_csv'
+
+    # App Engine issues HTTP requests to tasks.
+    https_required = False
 
     # Lifetime of a single task is 10 min. It stops fetching and starts
     # uploading after 4 min, assuming uploading takes similar time as

--- a/app/utils.py
+++ b/app/utils.py
@@ -723,7 +723,7 @@ class BaseHandler(webapp.RequestHandler):
     repo_required = True
 
     # Handlers that require HTTPS can set this to True.
-    https_required = False
+    https_required = True
 
     # Set this to True to enable a handler even for deactivated repositories.
     ignore_deactivation = False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -212,6 +212,8 @@ class HandlerTests(unittest.TestCase):
     """Tests for the base handler implementation."""
 
     def setUp(self):
+        # Make it look like the dev server so HTTPS isn't required.
+        os.environ['APPLICATION_ID'] = 'dev~abc'
         self.testbed = testbed.Testbed()
         self.testbed.activate()
         self.testbed.init_user_stub()

--- a/tests/views/test_access_restriction.py
+++ b/tests/views/test_access_restriction.py
@@ -37,8 +37,8 @@ class AccessRestrictionTests(django_tests_base.DjangoTestsBase):
             ) in filter(lambda item: item[1],
                         AccessRestrictionTests.IS_RESTRICTED_TO_ADMINS.items()):
             path = django.urls.reverse(path_name)
-            assert self.client.get(path).status_code == 403
-            assert self.client.post(path).status_code == 403
+            assert self.client.get(path, secure=True).status_code == 403
+            assert self.client.post(path, secure=True).status_code == 403
 
     def test_available_to_admins(self):
         """Tests that admin-only pages are available to admins.
@@ -54,7 +54,7 @@ class AccessRestrictionTests(django_tests_base.DjangoTestsBase):
             ) in filter(lambda item: item[1],
                         AccessRestrictionTests.IS_RESTRICTED_TO_ADMINS.items()):
             path = django.urls.reverse(path_name)
-            assert self.client.get(path).status_code == 200
+            assert self.client.get(path, secure=True).status_code == 200
             # Don't test POST requests here; they'll need an XSRF token and
             # that'll be covered in a separate test.
 
@@ -65,7 +65,7 @@ class AccessRestrictionTests(django_tests_base.DjangoTestsBase):
             ) in filter(lambda item: not item[1],
                         AccessRestrictionTests.IS_RESTRICTED_TO_ADMINS.items()):
             path = django.urls.reverse(path_name)
-            assert self.client.get(path).status_code != 403
+            assert self.client.get(path, secure=True).status_code != 403
 
     def test_all_paths_included(self):
         """Tests that all (Django-served) pages are listed.

--- a/tests/views/test_admin_statistics.py
+++ b/tests/views/test_admin_statistics.py
@@ -18,10 +18,14 @@ class AdminStatisticsViewTests(django_tests_base.DjangoTestsBase):
         self.counter = model.UsageCounter.create('haiti')
         self.login(is_admin=True)
 
+    def get_page_doc(self):
+        return self.to_doc(self.client.get('/global/admin/statistics/',
+                                           secure=True))
+
     def test_person_counter(self):
         self.counter.person = 3
         self.counter.put()
-        doc = self.to_doc(self.client.get('/global/admin/statistics/'))
+        doc = self.get_page_doc()
         assert 'haiti' in doc.text
         assert '# Persons' in doc.text
         assert doc.cssselect_one('#haiti-persons').text == '3'
@@ -30,7 +34,7 @@ class AdminStatisticsViewTests(django_tests_base.DjangoTestsBase):
         self.counter.note = 5
         self.counter.unspecified = 5
         self.counter.put()
-        doc = self.to_doc(self.client.get('/global/admin/statistics/'))
+        doc = self.get_page_doc()
         assert 'haiti' in doc.text
         assert '# Note' in doc.text
         assert doc.cssselect_one('#haiti-notes').text == '5'
@@ -40,7 +44,7 @@ class AdminStatisticsViewTests(django_tests_base.DjangoTestsBase):
         self.counter.note = 1
         self.counter.is_note_author = 1
         self.counter.put()
-        doc = self.to_doc(self.client.get('/global/admin/statistics/'))
+        doc = self.get_page_doc()
         assert doc.cssselect_one('#haiti-num_notes_is_note_author').text == '1'
 
     def test_status_counter(self):
@@ -48,7 +52,7 @@ class AdminStatisticsViewTests(django_tests_base.DjangoTestsBase):
         def set_counter_and_check(status_name, num):
             setattr(self.counter, status_name, num)
             self.counter.put()
-            doc = self.to_doc(self.client.get('/global/admin/statistics/'))
+            doc = self.get_page_doc()
             assert 'haiti' in doc.text
             assert status_name in doc.text
             assert doc.cssselect_one(


### PR DESCRIPTION
I was initially hesitant to require HTTPS, because of performance concerns, but I did some research and here's what I found:
- All else held equal, HTTPS is slower than HTTP, generally by a couple hundred milliseconds.
- However, if you use HTTPS, it's possible to use HTTP/2 instead of HTTP/1.1, and (all else held equal) HTTP/2 is faster than HTTP/1.1. (Nobody really supports HTTP/2 without HTTPS.)

The top answer here was helpful in understanding it: https://stackoverflow.com/questions/36293889/why-might-an-https-page-request-be-faster-than-http

I had a hard time finding hard numbers comparing the two, but there's a post on the Akamai blog that says HTTP/2 generally makes up for the HTTPS overhead and comes out ahead of insecure HTTP/1.1:
https://blogs.akamai.com/2015/08/is-http2-worth-the-performance-price-of-tls.html

App Engine will use HTTP/2 automatically if you're serving over HTTPS:
https://cloudplatform.googleblog.com/2015/10/Full-Speed-Ahead-with-HTTP2-on-Google-Cloud-Platform.html

So, I'm sold on HTTPS. On the Django side, it's easy (there's a boolean you set in your settings module). For the short-term, I'll make force-HTTPs the default option for new repos (being done as part of PR #625) and make sure the webapp2 handlers are have https_required set to True (I don't want to spend time going out of my way to clean that up immediately; it'll get eliminated as we migrate to Django).

We can't use HTTPS for task pages, because App Engine makes HTTP requests for stuff you put in the task queue.