### PR TITLE
Add ip_address and key_state fields to API management log.

### DIFF
--- a/app/model.py
+++ b/app/model.py
@@ -772,6 +772,10 @@ class ApiKeyManagementLog(db.Model):
     repo = db.StringProperty(required=True)
     api_key = db.StringProperty(required=True)
     action = db.StringProperty(required=True, choices=ACTIONS)
+    # The IP address of the admin making the change.
+    ip_address = db.StringProperty()
+    # A string representation of the state of the key after this action.
+    key_state = db.TextProperty()
 
     @property
     def authorization(self):


### PR DESCRIPTION
This PR just adds the fields; I'll populate them in a separate PR. I want to keep PRs that change the model simple, so we don't have to worry about them breaking anything (if my actual code breaks something and we have to roll back, we could still safely patch this in and run it in prod).