### PR TITLE
Automatic redirect for webapp2 pages that require HTTPS.

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1146,7 +1146,12 @@ class BaseHandler(webapp.RequestHandler):
         # Check for SSL (unless running local dev app server).
         if self.https_required and not is_dev_app_server():
             if self.env.scheme != 'https':
-                return self.error(403, 'HTTPS is required.')
+                url_parts = list(urlparse.urlparse(self.request.url))
+                url_parts[0] = 'https'  # The 0th part is the scheme.
+                webapp.RequestHandler.redirect(
+                    self, urlparse.urlunparse(url_parts))
+                self.terminate_response()
+                return
 
         # Handles repository alias.
         if self.maybe_redirect_for_repo_alias(request):


### PR DESCRIPTION
Django will handle redirects for us, but for pages that are still on webapp2 (i.e., most of them), we have to do the redirect manually.