### PR TITLE
Drop YAPF from tools/all_tests.

### DIFF
--- a/tools/all_tests
+++ b/tools/all_tests
@@ -17,7 +17,7 @@
 
 pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 
-$TOOLS_DIR/lint pylint-check && $TOOLS_DIR/lint yapf-check && \
+$TOOLS_DIR/lint pylint-check && \
     $TOOLS_DIR/unit_tests -q && \
     $TOOLS_DIR/py3_unit_tests -q && \
     $TOOLS_DIR/server_tests -q && \


### PR DESCRIPTION
I dropped this from travis_tests earlier because it turns out it's not
really suitable for continuous testing (discussed on PR #630), but I
forgot to take it out of tools/all_tests.