### PR TITLE
Store activation status on repo objects, step 2

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -26,6 +26,11 @@ import const
 import tasks
 
 
+_REPO_STATUS_VALUE_STAGING = 'staging'
+_REPO_STATUS_VALUE_ACTIVATED = 'activated'
+_REPO_STATUS_VALUE_DEACTIVATED = 'deactivated'
+
+
 class Handler(BaseHandler):
     # After a repository is deactivated, we still need the admin page to be
     # accessible so we can edit its settings.
@@ -199,11 +204,11 @@ class Handler(BaseHandler):
                 view_config[name] = value
 
         if model_config.deactivated:
-            view_config['launch_status'] = 'deactivated'
+            view_config['launch_status'] = _REPO_STATUS_VALUE_DEACTIVATED
         elif model_config.launched:
-            view_config['launch_status'] = 'activated'
+            view_config['launch_status'] = _REPO_STATUS_VALUE_ACTIVATED
         else:
-            view_config['launch_status'] = 'staging'
+            view_config['launch_status'] = _REPO_STATUS_VALUE_STAGING
 
         return view_config
 
@@ -213,13 +218,13 @@ class Handler(BaseHandler):
         model_config = {}
         for name, value in view_config.iteritems():
             if name == 'launch_status':
-                if value == 'staging':
+                if value == _REPO_STATUS_VALUE_STAGING:
                     model_config['deactivated'] = False
                     model_config['launched'] = False
-                elif value == 'activated':
+                elif value == _REPO_STATUS_VALUE_ACTIVATED:
                     model_config['deactivated'] = False
                     model_config['launched'] = True
-                elif value == 'deactivated':
+                elif value == _REPO_STATUS_VALUE_DEACTIVATED:
                     model_config['deactivated'] = True
                     model_config['launched'] = False
                 else:
@@ -233,11 +238,11 @@ class Handler(BaseHandler):
     def __update_repo_status(self, view_config):
         repo_entity = model.Repo.get_by_key_name(self.env.repo)
         launch_status = view_config['launch_status']
-        if launch_status == 'staging':
+        if launch_status == _REPO_STATUS_VALUE_STAGING:
             repo_entity.activation_status = model.Repo.ActivationStatus.STAGING
-        elif launch_status == 'activated':
+        elif launch_status == _REPO_STATUS_VALUE_ACTIVATED:
             repo_entity.activation_status = model.Repo.ActivationStatus.ACTIVE
-        elif launch_status == 'deactivated':
+        elif launch_status == _REPO_STATUS_VALUE_DEACTIVATED:
             repo_entity.activation_status = (
                 model.Repo.ActivationStatus.DEACTIVATED)
         else:

--- a/app/views/admin/create_repo.py
+++ b/app/views/admin/create_repo.py
@@ -73,7 +73,10 @@ class AdminCreateRepoView(views.admin.base.AdminBaseView):
                 self.ACTION_ID)):
             return self.error(403)
         new_repo = self.params.new_repo
-        model.Repo(key_name=new_repo).put()
+        model.Repo(
+            key_name=new_repo,
+            activation_status=model.Repo.ActivationStatus.STAGING,
+            test_mode=False).put()
         # Provide some defaults.
         config.set_for_repo(
             new_repo,

--- a/tests/server_test_cases/config_tests.py
+++ b/tests/server_test_cases/config_tests.py
@@ -133,6 +133,8 @@ class ConfigTests(ServerTestsBase):
         # Change some settings for the new repository.
         settings_form = doc.cssselect_one('form#save_repo')
         doc = self.s.submit(settings_form,
+            launch_status='activated',
+            test_mode='true',
             language_menu_options='["no"]',
             repo_titles='{"no": "Jordskjelv"}',
             keywords='foo, bar',
@@ -157,6 +159,9 @@ class ConfigTests(ServerTestsBase):
             force_https = 'false'
         )
         self.assertEquals(self.s.status, 200)
+        repo = Repo.get_by_key_name('xyz')
+        assert repo.activation_status == Repo.ActivationStatus.ACTIVE
+        assert repo.test_mode
         cfg = config.Configuration('xyz')
         self.assertEquals(cfg.language_menu_options, ['no'])
         assert cfg.repo_titles == {'no': 'Jordskjelv'}

--- a/tests/views/test_admin_create_repo.py
+++ b/tests/views/test_admin_create_repo.py
@@ -61,9 +61,9 @@ class AdminCreateRepoViewTests(view_tests_base.ViewTestsBase):
         self.assertIsNotNone(repo)
         self.assertEqual(
             repo.activation_status, model.Repo.ActivationStatus.STAGING)
-        self.assertEqual(repo.test_mode, False)
+        self.assertIs(repo.test_mode, False)
         # Check a couple of the config fields that are set by default.
         repo_conf = config.Configuration('idaho')
         self.assertEqual(repo_conf.language_menu_options, ['en', 'fr'])
-        self.assertEqual(repo_conf.launched, False)
+        self.assertIs(repo_conf.launched, False)
         self.assertEqual(repo_conf.time_zone_abbreviation, 'UTC')

--- a/tests/views/test_admin_create_repo.py
+++ b/tests/views/test_admin_create_repo.py
@@ -41,7 +41,7 @@ class AdminCreateRepoViewTests(view_tests_base.ViewTestsBase):
         """Tests GET requests."""
         doc = self.to_doc(self.client.get(
             '/global/admin/create_repo/', secure=True))
-        assert doc.cssselect_one('input[name="new_repo"]') is not None
+        self.assertIsNotNone(doc.cssselect_one('input[name="new_repo"]'))
 
     def test_create_repo(self):
         """Tests POST requests to create a new repo."""
@@ -54,13 +54,16 @@ class AdminCreateRepoViewTests(view_tests_base.ViewTestsBase):
             'new_repo': 'idaho'
         }, secure=True)
         # Check that the user's redirected to the repo's main admin page.
-        assert isinstance(post_resp, django.http.HttpResponseRedirect)
-        assert post_resp.url == '/idaho/admin'
+        self.assertIsInstance(post_resp, django.http.HttpResponseRedirect)
+        self.assertEqual(post_resp.url, '/idaho/admin')
         # Check that the repo object is put in datastore.
         repo = model.Repo.get_by_key_name('idaho')
-        assert repo
+        self.assertIsNotNone(repo)
+        self.assertEqual(
+            repo.activation_status, model.Repo.ActivationStatus.STAGING)
+        self.assertFalse(repo.test_mode)
         # Check a couple of the config fields that are set by default.
         repo_conf = config.Configuration('idaho')
-        assert repo_conf.language_menu_options == ['en', 'fr']
-        assert not repo_conf.launched
-        assert repo_conf.time_zone_abbreviation == 'UTC'
+        self.assertEqual(repo_conf.language_menu_options, ['en', 'fr'])
+        self.assertFalse(repo_conf.launched)
+        self.assertEqual(repo_conf.time_zone_abbreviation, 'UTC')

--- a/tests/views/test_admin_create_repo.py
+++ b/tests/views/test_admin_create_repo.py
@@ -61,9 +61,9 @@ class AdminCreateRepoViewTests(view_tests_base.ViewTestsBase):
         self.assertIsNotNone(repo)
         self.assertEqual(
             repo.activation_status, model.Repo.ActivationStatus.STAGING)
-        self.assertFalse(repo.test_mode)
+        self.assertEqual(repo.test_mode, False)
         # Check a couple of the config fields that are set by default.
         repo_conf = config.Configuration('idaho')
         self.assertEqual(repo_conf.language_menu_options, ['en', 'fr'])
-        self.assertFalse(repo_conf.launched)
+        self.assertEqual(repo_conf.launched, False)
         self.assertEqual(repo_conf.time_zone_abbreviation, 'UTC')


### PR DESCRIPTION
Sequel to PR #627 (motivation explained there). This writes to the new fields when repos are created or edited.