### PR TITLE
Enforce new admin ACLs in Django pages.

### DIFF
--- a/app/modelmodule/admin_acls.py
+++ b/app/modelmodule/admin_acls.py
@@ -32,7 +32,7 @@ class AdminPermission(db.Model):
         # An ordered list of the admin access levels, from lowest to highest
         # (i.e., each level has the permissions of everything before it in the
         # list).
-        ORDERED = [MODERATOR, MANAGER, SUPERADMIN]
+        ORDERING = [MODERATOR, MANAGER, SUPERADMIN]
 
     access_level = db.IntegerProperty(required=True)
 
@@ -74,9 +74,9 @@ class AdminPermission(db.Model):
         """
         if self.access_level == other_level:
             return 0
-        level_index = AdminPermission.AccessLevel.ORDERED.index(
+        level_index = AdminPermission.AccessLevel.ORDERING.index(
             self.access_level)
-        other_level_index = AdminPermission.AccessLevel.ORDERED.index(
+        other_level_index = AdminPermission.AccessLevel.ORDERING.index(
             other_level)
         if level_index < other_level_index:
             return -1

--- a/app/modelmodule/admin_acls.py
+++ b/app/modelmodule/admin_acls.py
@@ -29,6 +29,11 @@ class AdminPermission(db.Model):
         # Moderators can moderate user input.
         MODERATOR = 2
 
+        # An ordered list of the admin access levels, from lowest to highest
+        # (i.e., each level has the permissions of everything before it in the
+        # list).
+        ORDERED = [MODERATOR, MANAGER, SUPERADMIN]
+
     access_level = db.IntegerProperty(required=True)
 
     # The expiration date for the permission.
@@ -55,6 +60,28 @@ class AdminPermission(db.Model):
     @staticmethod
     def get_for_repo(repo):
         return AdminPermission.all().filter('repo =', repo)
+
+    def compare_level_to(self, other_level):
+        """Compares the level of this permission to the given level.
+
+        Args:
+            other_level (int): An AccessLevel value to compare to.
+
+        Returns:
+            int: A negative value if this permission has a lower level, a
+            positive value if this permission has a higher level, or 0 if the
+            levels are the same.
+        """
+        if self.access_level == other_level:
+            return 0
+        level_index = AdminPermission.AccessLevel.ORDERED.index(
+            self.access_level)
+        other_level_index = AdminPermission.AccessLevel.ORDERED.index(
+            other_level)
+        if level_index < other_level_index:
+            return -1
+        else:
+            return 1
 
     def permission_state(self):
         """Returns a string representation of the permission's state.

--- a/app/modelmodule/admin_acls.py
+++ b/app/modelmodule/admin_acls.py
@@ -20,11 +20,14 @@ class AdminPermission(db.Model):
     class AccessLevel(object):
         """An enum for the level of access the user has."""
 
-        # Admin access: the admin can edit the repo, add new moderators, etc.
-        ADMINISTRATOR = 0
-        # Moderator access: the admin can moderate user input, but not anything
-        # else.
-        MODERATOR = 1
+        # Superadmins can do anything for a repo, and global superadmins can
+        # create new repos.
+        SUPERADMIN = 0
+        # Managers have limited administrative access: e.g., they can edit
+        # custom messages for their repo, but not the title.
+        MANAGER = 1
+        # Moderators can moderate user input.
+        MODERATOR = 2
 
     access_level = db.IntegerProperty(required=True)
 

--- a/app/resources/admin_acls.html.template
+++ b/app/resources/admin_acls.html.template
@@ -25,7 +25,7 @@
       Access level:
       <select name="level">
         <option value="superadmin">Superadmin</option>
-	<option value="manager">Manager</option>
+        <option value="manager">Manager</option>
         <option value="moderator">Moderator</option>
       </select><br/>
       Expiration date:
@@ -59,7 +59,7 @@
                   {% if acl.access_level == 0 %}selected="selected"{% endif %}>
                 Superadmin
               </option>
-	      <option value="manager"
+              <option value="manager"
                   {% if acl.access_level == 1 %}selected="selected"{% endif %}>
                 Manager
               </option>

--- a/app/resources/admin_acls.html.template
+++ b/app/resources/admin_acls.html.template
@@ -47,7 +47,7 @@
       <th>Edit</th>
       <th>Revoke</th>
     </tr>
-    {% for acl in existing_acls %}
+    {% for acl in editable_acls %}
       <tr>
         <form method="post">
           <input type="hidden" name="xsrf_token" value="{{xsrf_token}}" />
@@ -81,6 +81,38 @@
             <input type="submit" name="revoke_button" value="Revoke" />
           </td>
         </form>
+      </tr>
+    {% endfor %}
+  </table>
+
+  <br/>
+
+  <h3>Other users with {{ self.env.repo }} permissions</h3>
+
+  <table class="admin-acls">
+    <tr>
+      <th>Email address</th>
+      <th>Level</th>
+      <th>Expiration date</th>
+    </tr>
+    {% for acl in fixed_acls %}
+      <tr>
+        <td>{{ acl.email_address }}</td>
+	<td>
+          {# Technically, this is guaranteed to always be "Superadmin", since #}
+          {# managers can edit the access of moderators and other managers,   #}
+          {# and moderators can't access this page (i.e., only superadmins    #}
+          {# will ever be un-editable), but relying on that just feels like   #}
+          {# asking for trouble if we change something someday.               #}
+          {% if acl.access_level == 0 %}
+            Superadmin
+          {% elif acl.access_level == 1 %}
+            Manager
+          {% else %}
+            Moderator
+          {% endif %}
+        </td>
+        <td>{{ acl.expiration_date|date:'Y-m-d' }}</td>
       </tr>
     {% endfor %}
   </table>

--- a/app/resources/admin_acls.html.template
+++ b/app/resources/admin_acls.html.template
@@ -16,7 +16,7 @@
 {% block content %}
   <h2>Grant or revoke admin access</h2>
 
-  <h3>Add new admin or moderator</h3>
+  <h3>Add new admin</h3>
 
   <form method="post">
     <input type="hidden" name="xsrf_token" value="{{xsrf_token}}" />
@@ -24,7 +24,8 @@
       Email address: <input type="text" name="email_address" /><br/>
       Access level:
       <select name="level">
-        <option value="administrator">Administrator</option>
+        <option value="superadmin">Superadmin</option>
+	<option value="manager">Manager</option>
         <option value="moderator">Moderator</option>
       </select><br/>
       Expiration date:
@@ -54,12 +55,16 @@
           <td>{{ acl.email_address }}</td>
           <td>
             <select name="level">
-              <option value="administrator"
+              <option value="superadmin"
                   {% if acl.access_level == 0 %}selected="selected"{% endif %}>
-                Administrator
+                Superadmin
+              </option>
+	      <option value="manager"
+                  {% if acl.access_level == 1 %}selected="selected"{% endif %}>
+                Manager
               </option>
               <option value="moderator"
-                  {% if acl.access_level == 1 %}selected="selected"{% endif %}>
+                  {% if acl.access_level == 2 %}selected="selected"{% endif %}>
                 Moderator
               </option>
             </select>

--- a/app/setup_pf.py
+++ b/app/setup_pf.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import const
 from model import *
+import modelmodule.admin_acls as admin_acls_model
+import site_settings
 from utils import *
 
 def setup_datastore():
@@ -24,6 +26,7 @@ def setup_datastore():
     information will not be changed or deleted.)"""
     setup_repos()
     setup_configs()
+    setup_root_admin()
 
 def wipe_datastore(delete=None, keep=None):
     """Deletes everything in the datastore.  If 'delete' is given (a list of
@@ -216,3 +219,19 @@ def setup_lang_test_config():
         view_page_custom_htmls={'en': '', 'fr': ''},
         seek_query_form_custom_htmls={'en': '', 'fr': ''},
     )
+
+def setup_root_admin():
+    if is_dev_app_server():
+        admin_acls_model.AdminPermission.create(
+            repo='global',
+            email_address='test@example.com',
+            access_level=
+            admin_acls_model.AdminPermission.AccessLevel.SUPERADMIN,
+            expiration_date=get_utcnow() + timedelta(days=3)).put()
+    elif site_settings.PROD_ROOT_ADMIN:
+        admin_acls_model.AdminPermission.create(
+            repo='global',
+            email_address=site_settings.PROD_ROOT_ADMIN,
+            access_level=
+            admin_acls_model.AdminPermission.AccessLevel.SUPERADMIN,
+            expiration_date=get_utcnow() + timedelta(days=3)).put()

--- a/app/site_settings.py
+++ b/app/site_settings.py
@@ -37,3 +37,11 @@ OPTIONAL_PATH_PREFIX = 'personfinder'
 # TODO(nworden): Find a way to set this at deploy time. Maybe we could use an
 # environment variable passed through app.yaml.
 PROD_ALLOWED_HOSTS = ['*']
+
+# This should be set to an admin's email address.
+# In production, a global superadmin permission, with a three-day expiration,
+# will be added for this user when the database is set up. That user should
+# adjust their expiration date and add permissions for other users as needed.
+# For development servers, a similar permission is set up for test@example.com
+# instead, regardless of the PROD_ROOT_ADMIN setting.
+PROD_ROOT_ADMIN = None

--- a/app/views/admin/acls.py
+++ b/app/views/admin/acls.py
@@ -29,6 +29,12 @@ class AdminAclsView(views.admin.base.AdminBaseView):
 
     _EXPIRATION_DATE_FORMAT = '%Y-%m-%d'
 
+    _PARAM_VALUES_TO_ADMIN_LEVELS = {
+        'superadmin': admin_acls_model.AdminPermission.AccessLevel.SUPERADMIN,
+        'manager': admin_acls_model.AdminPermission.AccessLevel.MANAGER,
+        'moderator': admin_acls_model.AdminPermission.AccessLevel.MODERATOR,
+    }
+
     def setup(self, request, *args, **kwargs):
         super(AdminAclsView, self).setup(request, *args, **kwargs)
 
@@ -74,10 +80,7 @@ class AdminAclsView(views.admin.base.AdminBaseView):
         del request, args, kwargs  # unused
         self.enforce_xsrf(self.ACTION_ID)
         email_address = self.params.email_address
-        if self.params.level == 'administrator':
-            level = admin_acls_model.AdminPermission.AccessLevel.ADMINISTRATOR
-        elif self.params.level == 'moderator':
-            level = admin_acls_model.AdminPermission.AccessLevel.MODERATOR
+        level = AdminAclsView._PARAM_VALUES_TO_ADMIN_LEVELS[self.params.level]
         expiration_date = datetime.datetime.strptime(
             self.params.expiration_date, AdminAclsView._EXPIRATION_DATE_FORMAT)
         # TODO(nworden): add logging for this

--- a/app/views/admin/acls.py
+++ b/app/views/admin/acls.py
@@ -71,6 +71,7 @@ class AdminAclsView(views.admin.base.AdminBaseView):
             xsrf_token=self.xsrf_tool.generate_token(self.env.user.user_id(),
                                                      self.ACTION_ID))
 
+    @views.admin.base.enforce_manager_admin_level
     def get(self, request, *args, **kwargs):
         """Serves GET requests with a form and list of existing ACLs.
 
@@ -78,9 +79,9 @@ class AdminAclsView(views.admin.base.AdminBaseView):
         (with an option to edit or revoke them) and a form to add a new admin.
         """
         del request, args, kwargs  # unused
-        self.enforce_manager_admin_level()
         return self._render_form()
 
+    @views.admin.base.enforce_manager_admin_level
     def post(self, request, *args, **kwargs):
         """Serves POST requests, making the requested changes.
 
@@ -88,7 +89,6 @@ class AdminAclsView(views.admin.base.AdminBaseView):
         return the same page used for GET requests.
         """
         del request, args, kwargs  # unused
-        self.enforce_manager_admin_level()
         self.enforce_xsrf(self.ACTION_ID)
         email_address = self.params.email_address
         level = AdminAclsView._PARAM_VALUES_TO_ADMIN_LEVELS[self.params.level]

--- a/app/views/admin/api_keys.py
+++ b/app/views/admin/api_keys.py
@@ -51,10 +51,10 @@ class ApiKeyListView(views.admin.base.AdminBaseView):
 
     ACTION_ID = 'admin/api_keys/list'
 
+    @views.admin.base.enforce_superadmin_admin_level
     def get(self, request, *args, **kwargs):
         """Serves a view with a list of API keys."""
         del request, args, kwargs  # unused
-        self.enforce_superadmin_admin_level()
         auths = model.Authorization.all().filter(
             'repo = ', self.env.repo or '*')
         return self.render(
@@ -98,8 +98,8 @@ class ApiKeyManagementView(views.admin.base.AdminBaseView):
                 'subscribe_permission': utils.validate_checkbox_as_bool,
             })
 
+    @views.admin.base.enforce_superadmin_admin_level
     def get(self, request, *args, **kwargs):
-        self.enforce_superadmin_admin_level()
         if self.params.get('log_key'):
             management_log_key = self.params.log_key
             management_log = db.get(management_log_key)
@@ -143,8 +143,8 @@ class ApiKeyManagementView(views.admin.base.AdminBaseView):
         authorization.put()
         return authorization
 
+    @views.admin.base.enforce_superadmin_admin_level
     def post(self, request, *args, **kwargs):
-        self.enforce_superadmin_admin_level()
         self.enforce_xsrf('admin_api_keys')
 
         # Navigation to an individual key's management page is handled by making

--- a/app/views/admin/api_keys.py
+++ b/app/views/admin/api_keys.py
@@ -54,6 +54,7 @@ class ApiKeyListView(views.admin.base.AdminBaseView):
     def get(self, request, *args, **kwargs):
         """Serves a view with a list of API keys."""
         del request, args, kwargs  # unused
+        self.enforce_superadmin_admin_level()
         auths = model.Authorization.all().filter(
             'repo = ', self.env.repo or '*')
         return self.render(
@@ -98,6 +99,7 @@ class ApiKeyManagementView(views.admin.base.AdminBaseView):
             })
 
     def get(self, request, *args, **kwargs):
+        self.enforce_superadmin_admin_level()
         if self.params.get('log_key'):
             management_log_key = self.params.log_key
             management_log = db.get(management_log_key)
@@ -142,6 +144,7 @@ class ApiKeyManagementView(views.admin.base.AdminBaseView):
         return authorization
 
     def post(self, request, *args, **kwargs):
+        self.enforce_superadmin_admin_level()
         self.enforce_xsrf('admin_api_keys')
 
         # Navigation to an individual key's management page is handled by making

--- a/app/views/admin/base.py
+++ b/app/views/admin/base.py
@@ -166,6 +166,7 @@ def _enforce_admin_level(user_admin_permission, min_level):
 def enforce_moderator_admin_level(func):
     """Require that the user be a moderator (or return a 403)."""
     def inner(self, *args, **kwargs):
+        """Implementation of the enforce_moderator_admin_level decorator."""
         _enforce_admin_level(
             self.env.user_admin_permission,
             admin_acls_model.AdminPermission.AccessLevel.MODERATOR)
@@ -175,6 +176,7 @@ def enforce_moderator_admin_level(func):
 def enforce_manager_admin_level(func):
     """Require that the user be a manager (or return a 403)."""
     def inner(self, *args, **kwargs):
+        """Implementation of the enforce_manager_admin_level decorator."""
         _enforce_admin_level(
             self.env.user_admin_permission,
             admin_acls_model.AdminPermission.AccessLevel.MANAGER)
@@ -184,6 +186,7 @@ def enforce_manager_admin_level(func):
 def enforce_superadmin_admin_level(func):
     """Require that the user be a superadmin (or return a 403)."""
     def inner(self, *args, **kwargs):
+        """Implementation of the enforce_superadmin_admin_level decorator."""
         _enforce_admin_level(
             self.env.user_admin_permission,
             admin_acls_model.AdminPermission.AccessLevel.SUPERADMIN)

--- a/app/views/admin/base.py
+++ b/app/views/admin/base.py
@@ -153,11 +153,4 @@ class AdminBaseView(views.base.BaseView):
         if not self.env.user:
             return django.shortcuts.redirect(
                 users.create_login_url(self.build_absolute_uri()))
-        if not users.is_current_user_admin():
-            logout_url = users.create_logout_url(self.build_absolute_uri())
-            return self.render(
-                'not_admin_error.html',
-                status_code=403,
-                logout_url=logout_url,
-                user=self.env.user)
         return super(AdminBaseView, self).dispatch(request, args, kwargs)

--- a/app/views/admin/base.py
+++ b/app/views/admin/base.py
@@ -62,26 +62,25 @@ class AdminBaseView(views.base.BaseView):
         def user(self, value):
             self._user = value
 
-    def _get_user_admin_permission(self, user):
+    def _get_user_admin_permission(self):
         user_repo_admin_object = admin_acls_model.AdminPermission.get(
             self.env.repo, self.env.user.email())
         if (user_repo_admin_object and
-            user_repo_admin_object.expiration_date < utils.get_utcnow()):
+                user_repo_admin_object.expiration_date < utils.get_utcnow()):
             user_repo_admin_object = None
         user_global_admin_object = admin_acls_model.AdminPermission.get(
             'global', self.env.user.email())
         if (user_global_admin_object and
-            user_global_admin_object.expiration_date < utils.get_utcnow()):
+                user_global_admin_object.expiration_date < utils.get_utcnow()):
             user_global_admin_object = None
         if user_repo_admin_object is None:
             return user_global_admin_object
-        elif user_global_admin_object is None:
+        if user_global_admin_object is None:
             return user_repo_admin_object
-        elif user_repo_admin_object.compare_level_to(
-            user_global_admin_object.access_level) > 0:
+        if user_repo_admin_object.compare_level_to(
+                user_global_admin_object.access_level) > 0:
             return user_repo_admin_object
-        else:
-            return user_global_admin_object
+        return user_global_admin_object
 
     def setup(self, request, *args, **kwargs):
         """See docs on BaseView.setup."""
@@ -90,8 +89,7 @@ class AdminBaseView(views.base.BaseView):
         self.env.show_logo = True
         self.env.enable_javascript = True
         self.env.user = users.get_current_user()
-        self.env.user_admin_permission = self._get_user_admin_permission(
-            self.env.user)
+        self.env.user_admin_permission = self._get_user_admin_permission()
         self.env.logout_url = users.create_logout_url(self.build_absolute_uri())
         self.env.all_repo_options = [
             utils.Struct(
@@ -113,14 +111,17 @@ class AdminBaseView(views.base.BaseView):
             raise django.core.exceptions.PermissionDenied
 
     def enforce_moderator_admin_level(self):
+        """Require that the user be a moderator (or return a 403)."""
         self._enforce_admin_level(
             admin_acls_model.AdminPermission.AccessLevel.MODERATOR)
 
     def enforce_manager_admin_level(self):
+        """Require that the user be a manager (or return a 403)."""
         self._enforce_admin_level(
             admin_acls_model.AdminPermission.AccessLevel.MANAGER)
 
     def enforce_superadmin_admin_level(self):
+        """Require that the user be a superadmin (or return a 403)."""
         self._enforce_admin_level(
             admin_acls_model.AdminPermission.AccessLevel.SUPERADMIN)
 

--- a/app/views/admin/create_repo.py
+++ b/app/views/admin/create_repo.py
@@ -36,6 +36,7 @@ class AdminCreateRepoView(views.admin.base.AdminBaseView):
             self.request,
             post_params={'new_repo': utils.strip})
 
+    @views.admin.base.enforce_superadmin_admin_level
     def get(self, request, *args, **kwargs):
         """Serves GET requests.
 
@@ -48,12 +49,12 @@ class AdminCreateRepoView(views.admin.base.AdminBaseView):
             HttpResponse: A HTTP response with the admin create-repo page.
         """
         del request, args, kwargs  # unused
-        self.enforce_superadmin_admin_level()
         return self.render(
             'admin_create_repo.html',
             xsrf_token=self.xsrf_tool.generate_token(self.env.user.user_id(),
                                                      self.ACTION_ID))
 
+    @views.admin.base.enforce_superadmin_admin_level
     def post(self, request, *args, **kwargs):
         """Serves POST requests, creating a new repo.
 
@@ -69,7 +70,6 @@ class AdminCreateRepoView(views.admin.base.AdminBaseView):
             HttpResponse: A redirect to the new repo's admin page.
         """
         del request, args, kwargs  # unused
-        self.enforce_superadmin_admin_level()
         self.enforce_xsrf(self.ACTION_ID)
         new_repo = self.params.new_repo
         model.Repo(

--- a/app/views/admin/create_repo.py
+++ b/app/views/admin/create_repo.py
@@ -48,6 +48,7 @@ class AdminCreateRepoView(views.admin.base.AdminBaseView):
             HttpResponse: A HTTP response with the admin create-repo page.
         """
         del request, args, kwargs  # unused
+        self.enforce_superadmin_admin_level()
         return self.render(
             'admin_create_repo.html',
             xsrf_token=self.xsrf_tool.generate_token(self.env.user.user_id(),
@@ -68,6 +69,7 @@ class AdminCreateRepoView(views.admin.base.AdminBaseView):
             HttpResponse: A redirect to the new repo's admin page.
         """
         del request, args, kwargs  # unused
+        self.enforce_superadmin_admin_level()
         self.enforce_xsrf(self.ACTION_ID)
         new_repo = self.params.new_repo
         model.Repo(

--- a/app/views/admin/delete_record.py
+++ b/app/views/admin/delete_record.py
@@ -42,6 +42,7 @@ class AdminDeleteRecordView(views.admin.base.AdminBaseView):
     def get(self, request, *args, **kwargs):
         """Serves GET requests with the deletion form."""
         del request, args, kwargs  # unused
+        self.enforce_moderator_admin_level()
         return self.render(
             'admin_delete_record.html',
             id='%s/person.' % const.HOME_DOMAIN,
@@ -51,6 +52,7 @@ class AdminDeleteRecordView(views.admin.base.AdminBaseView):
     def post(self, request, *args, **kwargs):
         """Sends the user to the deletion page with a valid signature."""
         del request, args, kwargs  # unused
+        self.enforce_moderator_admin_level()
         self.enforce_xsrf(self.ACTION_ID)
         action = ('delete', self.params.id)
         path = '/delete?' + utils.urlencode(

--- a/app/views/admin/delete_record.py
+++ b/app/views/admin/delete_record.py
@@ -39,20 +39,20 @@ class AdminDeleteRecordView(views.admin.base.AdminBaseView):
             self.request,
             post_params={'id': utils.strip})
 
+    @views.admin.base.enforce_moderator_admin_level
     def get(self, request, *args, **kwargs):
         """Serves GET requests with the deletion form."""
         del request, args, kwargs  # unused
-        self.enforce_moderator_admin_level()
         return self.render(
             'admin_delete_record.html',
             id='%s/person.' % const.HOME_DOMAIN,
             xsrf_token=self.xsrf_tool.generate_token(self.env.user.user_id(),
                                                      self.ACTION_ID))
 
+    @views.admin.base.enforce_moderator_admin_level
     def post(self, request, *args, **kwargs):
         """Sends the user to the deletion page with a valid signature."""
         del request, args, kwargs  # unused
-        self.enforce_moderator_admin_level()
         self.enforce_xsrf(self.ACTION_ID)
         action = ('delete', self.params.id)
         path = '/delete?' + utils.urlencode(

--- a/app/views/admin/statistics.py
+++ b/app/views/admin/statistics.py
@@ -24,6 +24,7 @@ class AdminStatisticsView(views.admin.base.AdminBaseView):
 
     ACTION_ID = 'admin/statistics'
 
+    @views.admin.base.enforce_manager_admin_level
     def get(self, request, *args, **kwargs):
         """Serves get requests.
 
@@ -36,7 +37,6 @@ class AdminStatisticsView(views.admin.base.AdminBaseView):
             HttpResponse: A HTTP response with the admin statistics page.
         """
         del request, args, kwargs  # unused
-        self.enforce_manager_admin_level()
         repos = sorted(model.Repo.list())
         all_usage = [_get_repo_usage(repo) for repo in repos]
         note_status_list = []

--- a/app/views/admin/statistics.py
+++ b/app/views/admin/statistics.py
@@ -36,6 +36,7 @@ class AdminStatisticsView(views.admin.base.AdminBaseView):
             HttpResponse: A HTTP response with the admin statistics page.
         """
         del request, args, kwargs  # unused
+        self.enforce_manager_admin_level()
         repos = sorted(model.Repo.list())
         all_usage = [_get_repo_usage(repo) for repo in repos]
         note_status_list = []

--- a/tests/server_test_cases/config_tests.py
+++ b/tests/server_test_cases/config_tests.py
@@ -120,16 +120,8 @@ class ConfigTests(ServerTestsBase):
         assert cfg.get('unknown_key', 'default_value') == 'default_value'
 
     def test_repo_admin_page(self):
-        # Load the page to create a repository.
-        doc = self.go_as_admin('/global/admin/create_repo')
-        self.assertEquals(self.s.status, 200)
-
-        # Activate a new repository.
-        assert not Repo.get_by_key_name('xyz')
-        create_form = doc.cssselect_one('form#create_repo')
-        doc = self.s.submit(create_form, new_repo='xyz')
-        assert Repo.get_by_key_name('xyz')
-
+        Repo(key_name='xyz').put()
+        doc = self.go_as_admin('/xyz/admin')
         # Change some settings for the new repository.
         settings_form = doc.cssselect_one('form#save_repo')
         doc = self.s.submit(settings_form,
@@ -156,7 +148,8 @@ class ConfigTests(ServerTestsBase):
             seek_query_form_custom_htmls='{"no": "query form message"}',
             footer_custom_htmls='{"no": "footer message"}',
             bad_words = 'bad, word',
-            force_https = 'false'
+            force_https = 'false',
+            time_zone_offset = '9'
         )
         self.assertEquals(self.s.status, 200)
         repo = Repo.get_by_key_name('xyz')

--- a/tests/testutils/data_generator.py
+++ b/tests/testutils/data_generator.py
@@ -139,7 +139,7 @@ class TestDataGenerator(object):
         return subscription
 
     def admin_permission(
-        self, store=True, repo_id='haiti', email_address='j@mib.gov',
+        self, store=True, repo_id='haiti', email_address='l@mib.gov',
         access_level=admin_acls_model.AdminPermission.AccessLevel.MODERATOR,
         expiration_date=datetime.datetime(2011, 1, 20)):
         admin_permission = admin_acls_model.AdminPermission.create(

--- a/tests/views/test_admin_acls.py
+++ b/tests/views/test_admin_acls.py
@@ -79,8 +79,8 @@ class AdminAclsViewTests(view_tests_base.ViewTestsBase):
         self.assertEqual(
             res.context['existing_acls'][0].email_address, 'l@mib.gov')
 
-    def test_add_administrator(self):
-        """Tests adding a full administrator."""
+    def test_add_manager(self):
+        """Tests adding a manager."""
         get_doc = self.to_doc(self.client.get(
             '/haiti/admin/acls/', secure=True))
         xsrf_token = get_doc.cssselect_one('input[name="xsrf_token"]').get(
@@ -89,7 +89,7 @@ class AdminAclsViewTests(view_tests_base.ViewTestsBase):
             'xsrf_token': xsrf_token,
             'email_address': 'l@mib.gov',
             'expiration_date': '2019-04-25',
-            'level': 'administrator',
+            'level': 'manager',
         }, secure=True)
         acls = admin_acls_model.AdminPermission.all()
         self.assertEqual(acls.count(), 1)
@@ -98,7 +98,31 @@ class AdminAclsViewTests(view_tests_base.ViewTestsBase):
         self.assertEqual(acl.expiration_date, datetime.datetime(2019, 4, 25))
         self.assertEqual(
             acl.access_level,
-            admin_acls_model.AdminPermission.AccessLevel.ADMINISTRATOR)
+            admin_acls_model.AdminPermission.AccessLevel.MANAGER)
+        res = self.client.get('/haiti/admin/acls/', secure=True)
+        self.assertEqual(
+            res.context['existing_acls'][0].email_address, 'l@mib.gov')
+
+    def test_add_superadmin(self):
+        """Tests adding a superadmin."""
+        get_doc = self.to_doc(self.client.get(
+            '/haiti/admin/acls/', secure=True))
+        xsrf_token = get_doc.cssselect_one('input[name="xsrf_token"]').get(
+            'value')
+        post_resp = self.client.post('/haiti/admin/acls', {
+            'xsrf_token': xsrf_token,
+            'email_address': 'l@mib.gov',
+            'expiration_date': '2019-04-25',
+            'level': 'superadmin',
+        }, secure=True)
+        acls = admin_acls_model.AdminPermission.all()
+        self.assertEqual(acls.count(), 1)
+        acl = acls[0]
+        self.assertEqual(acl.email_address, 'l@mib.gov')
+        self.assertEqual(acl.expiration_date, datetime.datetime(2019, 4, 25))
+        self.assertEqual(
+            acl.access_level,
+            admin_acls_model.AdminPermission.AccessLevel.SUPERADMIN)
         res = self.client.get('/haiti/admin/acls/', secure=True)
         self.assertEqual(
             res.context['existing_acls'][0].email_address, 'l@mib.gov')
@@ -117,7 +141,7 @@ class AdminAclsViewTests(view_tests_base.ViewTestsBase):
             'xsrf_token': xsrf_token,
             'email_address': 'j@mib.gov',
             'expiration_date': '2019-04-25',
-            'level': 'administrator',
+            'level': 'superadmin',
         }, secure=True)
         acls = admin_acls_model.AdminPermission.all()
         self.assertEqual(acls.count(), 1)
@@ -126,7 +150,7 @@ class AdminAclsViewTests(view_tests_base.ViewTestsBase):
         self.assertEqual(acl.expiration_date, datetime.datetime(2019, 4, 25))
         self.assertEqual(
             acl.access_level,
-            admin_acls_model.AdminPermission.AccessLevel.ADMINISTRATOR)
+            admin_acls_model.AdminPermission.AccessLevel.SUPERADMIN)
 
     def test_edit_expiration_date(self):
         """Tests editing the expiration date for a permission."""

--- a/tests/views/test_admin_acls.py
+++ b/tests/views/test_admin_acls.py
@@ -33,22 +33,53 @@ class AdminAclsViewTests(view_tests_base.ViewTestsBase):
     def setUp(self):
         super(AdminAclsViewTests, self).setUp()
         self.data_generator.repo()
-        self.login(is_admin=True)
 
     def test_get_with_no_existing_users(self):
         """Tests GET requests when there's no users with permissions yet."""
+        self.login_as_manager()
         res = self.client.get('/haiti/admin/acls/', secure=True)
-        self.assertEqual(res.context['existing_acls'].count(), 0)
+        self.assertEqual(len(res.context['editable_acls']), 0)
+        self.assertEqual(len(res.context['fixed_acls']), 0)
 
-    def test_get_with_existing_users(self):
-        """Tests GET requests when there are users with permissions."""
+    def test_get_with_none_editable(self):
+        """Tests GET requests where the user can't edit any of the permissions.
+        """
+        self.login_as_manager()
+        self.data_generator.admin_permission(
+            access_level=
+            admin_acls_model.AdminPermission.AccessLevel.SUPERADMIN)
+        self.data_generator.admin_permission(
+            email_address='m@mib.gov',
+            access_level=
+            admin_acls_model.AdminPermission.AccessLevel.SUPERADMIN)
+        res = self.client.get('/haiti/admin/acls/', secure=True)
+        self.assertEqual(len(res.context['editable_acls']), 0)
+        self.assertEqual(len(res.context['fixed_acls']), 2)
+
+    def test_get_with_some_editable(self):
+        """Tests GET requests when the user can edit some of the permissions."""
+        self.login_as_manager()
+        self.data_generator.admin_permission()
+        self.data_generator.admin_permission(
+            email_address='m@mib.gov',
+            access_level=
+            admin_acls_model.AdminPermission.AccessLevel.SUPERADMIN)
+        res = self.client.get('/haiti/admin/acls/', secure=True)
+        self.assertEqual(len(res.context['editable_acls']), 1)
+        self.assertEqual(len(res.context['fixed_acls']), 1)
+
+    def test_get_with_all_editable(self):
+        """Tests GET requests when the user can edit all of the permissions."""
+        self.login_as_manager()
         self.data_generator.admin_permission()
         self.data_generator.admin_permission(email_address='m@mib.gov')
         res = self.client.get('/haiti/admin/acls/', secure=True)
-        self.assertEqual(res.context['existing_acls'].count(), 2)
+        self.assertEqual(len(res.context['editable_acls']), 2)
+        self.assertEqual(len(res.context['fixed_acls']), 0)
 
     def test_get_default_expiration_date(self):
         """Tests that the expected default expiration date is correctly."""
+        self.login_as_manager()
         utils.set_utcnow_for_test(datetime.datetime(2010, 1, 5))
         res = self.client.get('/haiti/admin/acls/', secure=True)
         self.assertEqual(
@@ -57,6 +88,7 @@ class AdminAclsViewTests(view_tests_base.ViewTestsBase):
 
     def test_add_moderator(self):
         """Tests adding a moderator."""
+        self.login_as_manager()
         get_doc = self.to_doc(self.client.get(
             '/haiti/admin/acls/', secure=True))
         xsrf_token = get_doc.cssselect_one('input[name="xsrf_token"]').get(
@@ -67,7 +99,7 @@ class AdminAclsViewTests(view_tests_base.ViewTestsBase):
             'expiration_date': '2019-04-25',
             'level': 'moderator',
         }, secure=True)
-        acls = admin_acls_model.AdminPermission.all()
+        acls = admin_acls_model.AdminPermission.all().filter('repo =', 'haiti')
         self.assertEqual(acls.count(), 1)
         acl = acls[0]
         self.assertEqual(acl.email_address, 'l@mib.gov')
@@ -77,10 +109,11 @@ class AdminAclsViewTests(view_tests_base.ViewTestsBase):
             admin_acls_model.AdminPermission.AccessLevel.MODERATOR)
         res = self.client.get('/haiti/admin/acls/', secure=True)
         self.assertEqual(
-            res.context['existing_acls'][0].email_address, 'l@mib.gov')
+            res.context['editable_acls'][0].email_address, 'l@mib.gov')
 
     def test_add_manager(self):
         """Tests adding a manager."""
+        self.login_as_manager()
         get_doc = self.to_doc(self.client.get(
             '/haiti/admin/acls/', secure=True))
         xsrf_token = get_doc.cssselect_one('input[name="xsrf_token"]').get(
@@ -91,7 +124,7 @@ class AdminAclsViewTests(view_tests_base.ViewTestsBase):
             'expiration_date': '2019-04-25',
             'level': 'manager',
         }, secure=True)
-        acls = admin_acls_model.AdminPermission.all()
+        acls = admin_acls_model.AdminPermission.all().filter('repo =', 'haiti')
         self.assertEqual(acls.count(), 1)
         acl = acls[0]
         self.assertEqual(acl.email_address, 'l@mib.gov')
@@ -101,10 +134,11 @@ class AdminAclsViewTests(view_tests_base.ViewTestsBase):
             admin_acls_model.AdminPermission.AccessLevel.MANAGER)
         res = self.client.get('/haiti/admin/acls/', secure=True)
         self.assertEqual(
-            res.context['existing_acls'][0].email_address, 'l@mib.gov')
+            res.context['editable_acls'][0].email_address, 'l@mib.gov')
 
     def test_add_superadmin(self):
         """Tests adding a superadmin."""
+        self.login_as_superadmin()
         get_doc = self.to_doc(self.client.get(
             '/haiti/admin/acls/', secure=True))
         xsrf_token = get_doc.cssselect_one('input[name="xsrf_token"]').get(
@@ -115,7 +149,7 @@ class AdminAclsViewTests(view_tests_base.ViewTestsBase):
             'expiration_date': '2019-04-25',
             'level': 'superadmin',
         }, secure=True)
-        acls = admin_acls_model.AdminPermission.all()
+        acls = admin_acls_model.AdminPermission.all().filter('repo =', 'haiti')
         self.assertEqual(acls.count(), 1)
         acl = acls[0]
         self.assertEqual(acl.email_address, 'l@mib.gov')
@@ -125,12 +159,28 @@ class AdminAclsViewTests(view_tests_base.ViewTestsBase):
             admin_acls_model.AdminPermission.AccessLevel.SUPERADMIN)
         res = self.client.get('/haiti/admin/acls/', secure=True)
         self.assertEqual(
-            res.context['existing_acls'][0].email_address, 'l@mib.gov')
+            res.context['editable_acls'][0].email_address, 'l@mib.gov')
+
+    def test_managers_cant_add_superadmins(self):
+        """Tests that managers can't add superadmins."""
+        self.login_as_manager()
+        get_doc = self.to_doc(self.client.get(
+            '/haiti/admin/acls/', secure=True))
+        xsrf_token = get_doc.cssselect_one('input[name="xsrf_token"]').get(
+            'value')
+        post_resp = self.client.post('/haiti/admin/acls', {
+            'xsrf_token': xsrf_token,
+            'email_address': 'l@mib.gov',
+            'expiration_date': '2019-04-25',
+            'level': 'superadmin',
+        }, secure=True)
+        self.assertEqual(post_resp.status_code, 403)
 
     def test_edit_access_level(self):
         """Tests editing the access level for a user."""
+        self.login_as_superadmin()
         self.data_generator.admin_permission(
-            email_address='j@mib.gov',
+            email_address='l@mib.gov',
             expiration_date=datetime.datetime(2019, 4, 25),
             access_level=admin_acls_model.AdminPermission.AccessLevel.MODERATOR)
         get_doc = self.to_doc(self.client.get(
@@ -139,23 +189,44 @@ class AdminAclsViewTests(view_tests_base.ViewTestsBase):
             'value')
         post_resp = self.client.post('/haiti/admin/acls', {
             'xsrf_token': xsrf_token,
-            'email_address': 'j@mib.gov',
+            'email_address': 'l@mib.gov',
             'expiration_date': '2019-04-25',
             'level': 'superadmin',
         }, secure=True)
-        acls = admin_acls_model.AdminPermission.all()
+        acls = admin_acls_model.AdminPermission.all().filter('repo =', 'haiti')
         self.assertEqual(acls.count(), 1)
         acl = acls[0]
-        self.assertEqual(acl.email_address, 'j@mib.gov')
+        self.assertEqual(acl.email_address, 'l@mib.gov')
         self.assertEqual(acl.expiration_date, datetime.datetime(2019, 4, 25))
         self.assertEqual(
             acl.access_level,
             admin_acls_model.AdminPermission.AccessLevel.SUPERADMIN)
 
-    def test_edit_expiration_date(self):
-        """Tests editing the expiration date for a permission."""
+    def test_managers_cant_edit_superadmins(self):
+        """Tests that managers can't edit superadmins."""
+        self.login_as_manager()
         self.data_generator.admin_permission(
-            email_address='j@mib.gov',
+            email_address='l@mib.gov',
+            expiration_date=datetime.datetime(2019, 4, 25),
+            access_level=
+            admin_acls_model.AdminPermission.AccessLevel.SUPERADMIN)
+        get_doc = self.to_doc(self.client.get(
+            '/haiti/admin/acls/', secure=True))
+        xsrf_token = get_doc.cssselect('input[name="xsrf_token"]')[0].get(
+            'value')
+        post_resp = self.client.post('/haiti/admin/acls', {
+            'xsrf_token': xsrf_token,
+            'email_address': 'l@mib.gov',
+            'expiration_date': '2019-04-26',  # different expiration date
+            'level': 'superadmin',
+        }, secure=True)
+        self.assertEqual(post_resp.status_code, 403)
+
+    def test_managers_cant_superadminify(self):
+        """Tests that managers can't make a user into a superadmin."""
+        self.login_as_manager()
+        self.data_generator.admin_permission(
+            email_address='l@mib.gov',
             expiration_date=datetime.datetime(2019, 4, 25),
             access_level=admin_acls_model.AdminPermission.AccessLevel.MODERATOR)
         get_doc = self.to_doc(self.client.get(
@@ -164,14 +235,33 @@ class AdminAclsViewTests(view_tests_base.ViewTestsBase):
             'value')
         post_resp = self.client.post('/haiti/admin/acls', {
             'xsrf_token': xsrf_token,
-            'email_address': 'j@mib.gov',
+            'email_address': 'l@mib.gov',
+            'expiration_date': '2019-04-25',
+            'level': 'superadmin',
+        }, secure=True)
+        self.assertEqual(post_resp.status_code, 403)
+
+    def test_edit_expiration_date(self):
+        """Tests editing the expiration date for a permission."""
+        self.login_as_manager()
+        self.data_generator.admin_permission(
+            email_address='l@mib.gov',
+            expiration_date=datetime.datetime(2019, 4, 25),
+            access_level=admin_acls_model.AdminPermission.AccessLevel.MODERATOR)
+        get_doc = self.to_doc(self.client.get(
+            '/haiti/admin/acls/', secure=True))
+        xsrf_token = get_doc.cssselect('input[name="xsrf_token"]')[1].get(
+            'value')
+        post_resp = self.client.post('/haiti/admin/acls', {
+            'xsrf_token': xsrf_token,
+            'email_address': 'l@mib.gov',
             'expiration_date': '2019-05-25',
             'level': 'moderator',
         }, secure=True)
-        acls = admin_acls_model.AdminPermission.all()
+        acls = admin_acls_model.AdminPermission.all().filter('repo =', 'haiti')
         self.assertEqual(acls.count(), 1)
         acl = acls[0]
-        self.assertEqual(acl.email_address, 'j@mib.gov')
+        self.assertEqual(acl.email_address, 'l@mib.gov')
         self.assertEqual(acl.expiration_date, datetime.datetime(2019, 5, 25))
         self.assertEqual(
             acl.access_level,
@@ -179,17 +269,38 @@ class AdminAclsViewTests(view_tests_base.ViewTestsBase):
 
     def test_revoke_access(self):
         """Tests revoking admin access."""
-        self.data_generator.admin_permission(email_address='j@mib.gov')
+        self.login_as_manager()
+        self.data_generator.admin_permission(email_address='l@mib.gov')
         get_doc = self.to_doc(self.client.get(
             '/haiti/admin/acls/', secure=True))
         xsrf_token = get_doc.cssselect('input[name="xsrf_token"]')[1].get(
             'value')
         post_resp = self.client.post('/haiti/admin/acls', {
             'xsrf_token': xsrf_token,
-            'email_address': 'j@mib.gov',
+            'email_address': 'l@mib.gov',
             'expiration_date': '2019-04-25',
             'level': 'moderator',
             'revoke_button': 'Revoke',
         }, secure=True)
-        acls = admin_acls_model.AdminPermission.all()
+        acls = admin_acls_model.AdminPermission.all().filter('repo =', 'haiti')
         self.assertEqual(acls.count(), 0)
+
+    def test_managers_cant_revoke_superadmins(self):
+        """Tests that managers can't revoke the access of superadmins."""
+        self.login_as_manager()
+        self.data_generator.admin_permission(
+            email_address='l@mib.gov',
+            access_level=
+            admin_acls_model.AdminPermission.AccessLevel.SUPERADMIN)
+        get_doc = self.to_doc(self.client.get(
+            '/haiti/admin/acls/', secure=True))
+        xsrf_token = get_doc.cssselect('input[name="xsrf_token"]')[0].get(
+            'value')
+        post_resp = self.client.post('/haiti/admin/acls', {
+            'xsrf_token': xsrf_token,
+            'email_address': 'l@mib.gov',
+            'expiration_date': '2019-04-25',
+            'level': 'moderator',
+            'revoke_button': 'Revoke',
+        }, secure=True)
+        self.assertEqual(post_resp.status_code, 403)

--- a/tests/views/test_admin_api_keys.py
+++ b/tests/views/test_admin_api_keys.py
@@ -27,7 +27,7 @@ class ApiKeyListViewTests(view_tests_base.ViewTestsBase):
         super(ApiKeyListViewTests, self).setUp()
         self.data_generator.repo()
         self.authorization = self.data_generator.authorization()
-        self.login(is_admin=True)
+        self.login_as_superadmin()
 
     def test_get(self):
         """Tests GET requests."""
@@ -53,7 +53,7 @@ class ApiKeyManagementViewTests(view_tests_base.ViewTestsBase):
 
     def setUp(self):
         super(ApiKeyManagementViewTests, self).setUp()
-        self.login(is_admin=True)
+        self.login_as_superadmin()
 
     def test_get_create_form(self):
         """Tests GET requests with no log key (i.e., the creation form)."""

--- a/tests/views/test_admin_create_repo.py
+++ b/tests/views/test_admin_create_repo.py
@@ -35,7 +35,7 @@ class AdminCreateRepoViewTests(view_tests_base.ViewTestsBase):
     def setUp(self):
         super(AdminCreateRepoViewTests, self).setUp()
         self.data_generator.repo()
-        self.login(is_admin=True)
+        self.login_as_superadmin()
 
     def test_get(self):
         """Tests GET requests."""

--- a/tests/views/test_admin_delete_record.py
+++ b/tests/views/test_admin_delete_record.py
@@ -38,7 +38,7 @@ class AdminDeleteRecordViewTests(view_tests_base.ViewTestsBase):
 
     def setUp(self):
         super(AdminDeleteRecordViewTests, self).setUp()
-        self.login(is_admin=True)
+        self.login_as_moderator()
         self.data_generator.repo()
         self.person = self.data_generator.person()
 

--- a/tests/views/test_admin_statistics.py
+++ b/tests/views/test_admin_statistics.py
@@ -12,7 +12,7 @@ class AdminStatisticsViewTests(view_tests_base.ViewTestsBase):
         super(AdminStatisticsViewTests, self).setUp()
         self.data_generator.repo()
         self.counter = model.UsageCounter.create('haiti')
-        self.login(is_admin=True)
+        self.login_as_manager()
 
     def get_page_doc(self):
         return self.to_doc(self.client.get('/global/admin/statistics/',

--- a/tests/views/test_auto_security.py
+++ b/tests/views/test_auto_security.py
@@ -26,6 +26,7 @@ import os
 
 import django.urls
 
+import modelmodule.admin_acls as aa_model
 import urls
 
 import view_tests_base
@@ -39,8 +40,9 @@ PathTestInfo = collections.namedtuple(
         'accepts_get',
         # Whether the past is expected to accept POST requests.
         'accepts_post',
-        # Whether the page is restricted to admins.
-        'restricted_to_admins',
+        # The minimum admin level required to access the page (None if
+        # non-admins are expected to be able to access it).
+        'min_admin_level',
         # Whether POST requests should require an XSRF token.
         'requires_xsrf',
         # A dict with valid POST data, excluding an XSRF token (the tests will
@@ -63,7 +65,7 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
         PathTestInfo(
             accepts_get=True,
             accepts_post=True,
-            restricted_to_admins=True,
+            min_admin_level=aa_model.AdminPermission.AccessLevel.MANAGER,
             requires_xsrf=True,
             sample_post_data={
                 'email_address': 'l@mib.gov',
@@ -75,7 +77,7 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
         PathTestInfo(
             accepts_get=True,
             accepts_post=False,
-            restricted_to_admins=True,
+            min_admin_level=aa_model.AdminPermission.AccessLevel.SUPERADMIN,
             requires_xsrf=False,
             sample_post_data=None,
             xsrf_action_id=None),
@@ -83,7 +85,7 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
         PathTestInfo(
             accepts_get=True,
             accepts_post=True,
-            restricted_to_admins=True,
+            min_admin_level=aa_model.AdminPermission.AccessLevel.SUPERADMIN,
             requires_xsrf=True,
             sample_post_data={
                 'contact_name': 'Bob',
@@ -95,7 +97,7 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
         PathTestInfo(
             accepts_get=True,
             accepts_post=True,
-            restricted_to_admins=True,
+            min_admin_level=aa_model.AdminPermission.AccessLevel.SUPERADMIN,
             requires_xsrf=True,
             sample_post_data={
                 'new_repo': 'new-hampshire',
@@ -105,7 +107,7 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
         PathTestInfo(
             accepts_get=True,
             accepts_post=True,
-            restricted_to_admins=True,
+            min_admin_level=aa_model.AdminPermission.AccessLevel.MODERATOR,
             requires_xsrf=True,
             sample_post_data={
                 'id': 'abc123',
@@ -115,7 +117,7 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
         PathTestInfo(
             accepts_get=True,
             accepts_post=False,
-            restricted_to_admins=True,
+            min_admin_level=aa_model.AdminPermission.AccessLevel.MANAGER,
             requires_xsrf=False,
             sample_post_data=None,
             xsrf_action_id=None),
@@ -123,7 +125,7 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
         PathTestInfo(
             accepts_get=True,
             accepts_post=False,
-            restricted_to_admins=False,
+            min_admin_level=None,
             requires_xsrf=False,
             sample_post_data=None,
             xsrf_action_id=None),
@@ -163,9 +165,7 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
         if path_info.requires_xsrf:
             # Copy the data dict to avoid mutating the original.
             data = copy.deepcopy(path_info.sample_post_data)
-            data['xsrf_token'] = self._xsrf_tool.generate_token(
-                view_tests_base.ViewTestsBase.TEST_USER_ID,
-                path_info.xsrf_action_id)
+            data['xsrf_token'] = self.xsrf_token(path_info.xsrf_action_id)
             return data
         return path_info.sample_post_data
 
@@ -186,9 +186,9 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
 
     def test_blocked_to_non_admins(self):
         """Tests that admin-only pages aren't available to non-admins."""
-        self.login(is_admin=False)
+        self.login_as_nonadmin()
         for (path_name, path_info) in self.get_paths_to_test(
-                lambda path_info: path_info.restricted_to_admins):
+                lambda path_info: path_info.min_admin_level is not None):
             path = self.get_path(path_name)
             if path_info.accepts_get:
                 self.assertEqual(
@@ -201,18 +201,39 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
                         secure=True).status_code, 403,
                     'Admin-only page available to non-admin: %s' % path_name)
 
-    def test_available_to_admins(self):
-        """Tests that admin-only pages are available to admins.
-
-        This is a sort of meta-test: I'm not really concerned that we might
-        accidentally lock admins out of the admin pages, but I do want to make
-        sure that the test above actually depends on the user not being an admin
-        (as opposed to access getting denied because the tests are set up wrong
-        somehow).
-        """
-        self.login(is_admin=True)
+    def _check_admin_blocking(self, level):
+        levels = aa_model.AdminPermission.AccessLevel.ORDERING[
+            aa_model.AdminPermission.AccessLevel.ORDERING.index(level)+1:]
         for (path_name, path_info) in self.get_paths_to_test(
-                lambda path_info: path_info.restricted_to_admins):
+                lambda path_info: path_info.min_admin_level in levels):
+            path = self.get_path(path_name)
+            if path_info.accepts_get:
+                self.assertEqual(
+                    self.client.get(path, secure=True).status_code, 403,
+                    'Admin-only page available to non-admin: %s' % path_name)
+            if path_info.accepts_post:
+                self.assertEqual(
+                    self.client.post(
+                        path, self.get_valid_post_data(path_info),
+                        secure=True).status_code, 403,
+                    'Admin-only page available to non-admin: %s' % path_name)
+
+    def test_moderator_blocking(self):
+        """Tests that moderators can't access manager/superadmin pages."""
+        self.login_as_moderator()
+        self._check_admin_blocking(
+            aa_model.AdminPermission.AccessLevel.MODERATOR)
+
+    def test_manager_blocking(self):
+        """Tests that managers can't access superadmin pages."""
+        self.login_as_manager()
+        self._check_admin_blocking(aa_model.AdminPermission.AccessLevel.MANAGER)
+
+    def _check_admin_accessing(self, level):
+        levels = aa_model.AdminPermission.AccessLevel.ORDERING[
+            :aa_model.AdminPermission.AccessLevel.ORDERING.index(level)+1]
+        for (path_name, path_info) in self.get_paths_to_test(
+                lambda path_info: path_info.min_admin_level in levels):
             path = self.get_path(path_name)
             if path_info.accepts_get:
                 self.assertEqual(
@@ -227,11 +248,29 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
                         secure=True).status_code, 403,
                     'POST unavailable to admins for: %s' % path_name)
 
+    def test_moderator_accessing(self):
+        """Tests that moderators can access moderator pages."""
+        self.login_as_moderator()
+        self._check_admin_accessing(
+            aa_model.AdminPermission.AccessLevel.MODERATOR)
+
+    def test_manager_accessing(self):
+        """Tests that managers can access manager/moderator pages."""
+        self.login_as_manager()
+        self._check_admin_accessing(
+            aa_model.AdminPermission.AccessLevel.MANAGER)
+
+    def test_superadmin_accessing(self):
+        """Tests that superadmins can access all pages."""
+        self.login_as_superadmin()
+        self._check_admin_accessing(
+            aa_model.AdminPermission.AccessLevel.SUPERADMIN)
+
     def test_other_pages_unrestricted(self):
         """Tests that non-admins can access unrestricted pages."""
-        self.login(is_admin=False)
+        self.login_as_nonadmin()
         for (path_name, path_info) in self.get_paths_to_test(
-                lambda path_info: not path_info.restricted_to_admins):
+                lambda path_info: path_info.min_admin_level is None):
             path = self.get_path(path_name)
             if path_info.accepts_get:
                 self.assertEqual(
@@ -248,7 +287,7 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
     def test_missing_xsrf_token(self):
         """Tests that, if XSRF is required, POSTs without a token are rejected.
         """
-        self.login(is_admin=True)
+        self.login_as_superadmin()
         for (path_name, path_info) in self.get_paths_to_test(
                 lambda path_info: path_info.requires_xsrf):
             # Just in case someone accidentally included an XSRF token in the
@@ -267,7 +306,7 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
 
     def test_invalid_xsrf_token(self):
         """Tests that XSRF tokens are checked for validity."""
-        self.login(is_admin=True)
+        self.login_as_superadmin()
         for (path_name, path_info) in self.get_paths_to_test(
                 lambda path_info: path_info.requires_xsrf):
             path = self.get_path(path_name)


### PR DESCRIPTION
In addition to the enforcement, this makes two changes:
- It rearranges the model to support three levels. We'd originally planned on giving the higher level to access to global admins, but that introduces some implementation complexity and makes the whole thing more rigid. By splitting it up like this instead, I think it'll be more flexible and better able to handle future feature requests.
- Adds a constant to the `site_settings` module for a root admin, so that someone setting up from scratch has a way to get in.