### PR TITLE
Store activation status on repo objects, step 3

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -260,6 +260,7 @@ def setup_env(request):
     that are commonly used by most handlers."""
     env = utils.Struct()
     env.repo, env.action = get_repo_and_action(request)
+    env.repo_entity = model.Repo.get(env.repo) if env.repo else None
     env.config = config.Configuration(env.repo or '*')
 
     env.analytics_id = env.config.get('analytics_id')
@@ -428,7 +429,7 @@ def setup_env(request):
         # If the repository is deactivated, we should not show test mode
         # notification.
         env.repo_test_mode = (
-            env.config.test_mode and not env.config.deactivated)
+            env.config.test_mode and not env.repo_entity.is_deactivated())
         env.force_https = env.config.force_https
 
         env.params_full_name = request.get('full_name', '').strip()

--- a/app/model.py
+++ b/app/model.py
@@ -131,6 +131,10 @@ class Repo(db.Model):
     # Few properties for now; the repository title and other settings are all in
     # ConfigEntry entities (see config.py).
 
+    @staticmethod
+    def get(repo_id):
+        return Repo.get_by_key_name(repo_id)
+
     @classmethod
     def list(cls):
         """Returns a list of all repository names."""
@@ -139,15 +143,20 @@ class Repo(db.Model):
     @classmethod
     def list_active(cls):
         """Returns a list of the active (non-deactivated) repository names."""
-        return [name for name in Repo.list()
-                if not config.get_for_repo(name, 'deactivated')]
+        staging = [repo.key().name() for repo in Repo.all().filter(
+            'activation_status =', Repo.ActivationStatus.STAGING)]
+        active = [repo.key().name() for repo in Repo.all().filter(
+            'activation_status =', Repo.ActivationStatus.ACTIVE)]
+        return staging + active
 
     @classmethod
     def list_launched(cls):
         """Returns a list of the launched (listed in menu) repository names."""
-        return [name for name in Repo.list()
-                if config.get_for_repo(name, 'launched') and
-                        not config.get_for_repo(name, 'deactivated')]
+        return [repo.key().name() for repo in Repo.all().filter(
+            'activation_status =', Repo.ActivationStatus.ACTIVE)]
+
+    def is_deactivated(self):
+        return self.activation_status == Repo.ActivationStatus.DEACTIVATED
 
 
 class Base(db.Model):

--- a/app/setup_pf.py
+++ b/app/setup_pf.py
@@ -47,12 +47,11 @@ def reset_datastore():
     setup_datastore()
 
 def setup_repos():
-    db.put([Repo(key_name='haiti'),
-            Repo(key_name='japan'),
+    db.put([Repo(key_name='haiti',
+                 activation_status=Repo.ActivationStatus.ACTIVE),
+            Repo(key_name='japan',
+                 activation_status=Repo.ActivationStatus.ACTIVE),
             Repo(key_name='pakistan')])
-    # Set some repositories active so they show on the main page.
-    config.set_for_repo('japan', launched=True)
-    config.set_for_repo('haiti', launched=True)
 
 def setup_configs():
     """Installs configuration settings used for testing by server_tests."""

--- a/app/utils.py
+++ b/app/utils.py
@@ -1198,7 +1198,8 @@ class BaseHandler(webapp.RequestHandler):
 
         # If this repository has been deactivated, terminate with a message.
         # The ignore_deactivation flag is for admin pages that bypass this.
-        if self.config.deactivated and not self.ignore_deactivation:
+        if (self.env.repo_entity.is_deactivated() and
+            not self.ignore_deactivation):
             self.env.language_menu = []
             self.env.robots_ok = True
             self.render('message.html', cls='deactivation',

--- a/tests/server_test_cases/feed_tests.py
+++ b/tests/server_test_cases/feed_tests.py
@@ -96,14 +96,17 @@ class FeedTests(ServerTestsBase):
         self.verify_api_log(ApiActionLog.REPO, api_key='')
 
     def test_repo_feed_all_launched_repos(self):
-        config.set_for_repo('haiti',
-                deactivated=True, launched=True, test_mode=False)
-        config.set_for_repo('japan',
-                deactivated=False, launched=True, test_mode=True,
+        haiti_repo = Repo.get('haiti')
+        haiti_repo.activation_status = Repo.ActivationStatus.DEACTIVATED
+        haiti_repo.put()
+        japan_repo = Repo.get('japan')
+        japan_repo.activation_status = Repo.ActivationStatus.ACTIVE
+        japan_repo.put()
+        config.set_for_repo(
+                'japan', test_mode=True,
                 updated_date=utils.get_timestamp(
                         datetime.datetime(2012, 03, 11)))
-        config.set_for_repo('pakistan',
-                deactivated=False, launched=False, test_mode=False)
+        config.set_for_repo('pakistan', test_mode=False)
 
         # 'haiti', 'japan', and 'pakistan' exist in the datastore. Only those
         # which are 'launched' and not 'deactivated' i.e., only 'japan' should

--- a/tests/server_test_cases/import_tests.py
+++ b/tests/server_test_cases/import_tests.py
@@ -28,6 +28,9 @@ class ImportTests(ServerTestsBase):
     """Tests for CSV import page at /api/import."""
     def setUp(self):
         ServerTestsBase.setUp(self)
+        Repo(
+            key_name='haiti',
+            activation_status=Repo.ActivationStatus.ACTIVE).put()
         config.set_for_repo(
             'haiti',
             api_action_logging=True)

--- a/tests/testutils/data_generator.py
+++ b/tests/testutils/data_generator.py
@@ -75,8 +75,10 @@ class TestDataGenerator(object):
         'is_valid': True,
     }
 
-    def repo(self, store=True, repo_id='haiti'):
-        repo = model.Repo(key_name=repo_id)
+    def repo(
+        self, store=True, repo_id='haiti',
+        activation_status=model.Repo.ActivationStatus.ACTIVE):
+        repo = model.Repo(key_name=repo_id, activation_status=activation_status)
         if store:
             repo.put()
         return repo

--- a/tests/testutils/data_generator.py
+++ b/tests/testutils/data_generator.py
@@ -77,7 +77,7 @@ class TestDataGenerator(object):
 
     def repo(
         self, store=True, repo_id='haiti',
-        activation_status=model.Repo.ActivationStatus.ACTIVE):
+            activation_status=model.Repo.ActivationStatus.ACTIVE):
         repo = model.Repo(key_name=repo_id, activation_status=activation_status)
         if store:
             repo.put()

--- a/tests/views/test_meta_sitemap.py
+++ b/tests/views/test_meta_sitemap.py
@@ -15,13 +15,7 @@
 
 import re
 
-# pylint: disable=wrong-import-order
-# pylint sometimes thinks config is a standard import that belongs before the
-# django import. It's mistaken; config is our own module (if you run
-# python -c "import config", it produces an error saying config doesn't exist).
-# Filed issue #626 to move us out of the global namespace someday, which would
-# prevent stuff like this.
-import config
+import model
 
 import view_tests_base
 

--- a/tests/views/test_meta_sitemap.py
+++ b/tests/views/test_meta_sitemap.py
@@ -36,11 +36,10 @@ class SitemapViewTests(view_tests_base.ViewTestsBase):
         super(SitemapViewTests, self).setUp()
         self.data_generator.repo(repo_id='haiti')
         self.data_generator.repo(repo_id='japan')
-        self.data_generator.repo(repo_id='minnesota')
-        # Set two of the repos as launched; the unlaunched one shouldn't appear
-        # in the sitemap.
-        config.set_for_repo('haiti', launched=True)
-        config.set_for_repo('japan', launched=True)
+        # The unlaunched repo shouldn't appear in the sitemap.
+        self.data_generator.repo(
+            repo_id='minnesota',
+            activation_status=model.Repo.ActivationStatus.STAGING)
 
     def test_get(self):
         """Tests GET requests."""


### PR DESCRIPTION
Read statuses from the Repo entities instead of the config.