### PR TITLE
Allow non-integer timezone offsets.

### DIFF
--- a/app/resources/admin.html.template
+++ b/app/resources/admin.html.template
@@ -708,7 +708,8 @@
       <label for="time_zone_offset">Time zone offset (-12 to 14):</label>
       <div class="response">
         UTC +
-        <input type="number" name="time_zone_offset" id="time_zone_offset"
+        <input type="number" step="any"
+            name="time_zone_offset" id="time_zone_offset"
             value="{{view_config_json.time_zone_offset}}">
       </div>
     </div>


### PR DESCRIPTION
The field in the admin page is marked as a number; by default, the
step size is considered to be 1, and this can cause browsers to
prohibit non-integer values. Setting the step to "any" allows any
numeric value.

We could set the step to 0.25 (anything more granular than that is
probably errorneous input), but that would cause the stepper buttons
to increment/decrement by 0.25, which could be annoying. Setting step
to "any" allows any numeric value but leaves the stepper buttons at
the default step of 1 (at least in Firefox and Chrome):
https://stackoverflow.com/questions/19011861/is-there-a-float-input-type-in-html5