### PR TITLE
Include built-in ssl library.

### DIFF
--- a/app/app.yaml
+++ b/app/app.yaml
@@ -69,6 +69,8 @@ handlers:
 libraries:
 - name: django
   version: "1.11"
+- name: ssl
+  version: "2.7.11"
 - name: lxml
   version: "3.7.3"
 - name: webapp2


### PR DESCRIPTION
Django imports this from one of the files it uses for handling exceptions. If it's not available, we get an error saying the import failed, and the original stack trace doesn't make it into the logs.