### PR TITLE
Fix for /personfinder-prefixed static files.

### DIFF
--- a/app/app.yaml
+++ b/app/app.yaml
@@ -35,6 +35,8 @@ handlers:
 
 - url: /static
   static_dir: resources/static/fixed/
+- url: /personfinder/static
+  static_dir: resources/static/fixed/
 
 # These are the handlers we've migrated to Django.
 - url: /.*/admin/acls.*


### PR DESCRIPTION
In prod, we serve off google.org/personfinder, and the URL prefix isn't
stripped on its way to App Engine. I forgot to account for that when I
set up the fixed static file handling in PR #670.