### PR TITLE
Migrate the repo admin index page to Django.

### DIFF
--- a/app/app.yaml
+++ b/app/app.yaml
@@ -45,6 +45,8 @@ handlers:
   script: wsgi.application
 - url: /global/admin/?
   script: main.py
+- url: /personfinder/global/admin/?
+  script: main.py
 - url: /.*/admin/?
   script: wsgi.application
 - url: /.*/admin/dashboard.*

--- a/app/app.yaml
+++ b/app/app.yaml
@@ -43,6 +43,10 @@ handlers:
   script: wsgi.application
 - url: /.*/admin/create_repo.*
   script: wsgi.application
+- url: /global/admin/?
+  script: main.py
+- url: /.*/admin/?
+  script: wsgi.application
 - url: /.*/admin/dashboard.*
   script: wsgi.application
 - url: /.*/admin/delete_record.*

--- a/app/resources/admin_repo_index.html.template
+++ b/app/resources/admin_repo_index.html.template
@@ -14,8 +14,8 @@
 {% load i18n %}
 
 {% block content %}
-<script src="https://unpkg.com/react@16/umd/react.development.js" nonce="{{ csp_nonce }}" crossorigin></script>
-<script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" nonce="{{ csp_nonce }}" crossorigin></script>
+<script src="https://unpkg.com/react@16/umd/react.production.min.js" nonce="{{ csp_nonce }}" crossorigin></script>
+<script src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js" nonce="{{ csp_nonce }}" crossorigin></script>
 
 <script nonce="{{ csp_nonce }}">
   const LANGUAGE_EXONYMS_ARR = JSON.parse(
@@ -648,7 +648,7 @@
       <div class="option">
         <input type="radio" name="search_auth_key_required" value="false"
             id="search_auth_key_required_false"
-            {{view_config.search_auth_key_required|yesno:",checked"}}>
+            {{api_access_control_config.search_auth_key_required|yesno:",checked"}}>
         <label for="search_auth_key_required_false">
           Allow anyone to use the search API
         </label>
@@ -656,7 +656,7 @@
       <div class="option">
         <input type="radio" name="search_auth_key_required" value="true"
             id="search_auth_key_required_true"
-            {{view_config.search_auth_key_required|yesno:"checked,"}}>
+            {{api_access_control_config.search_auth_key_required|yesno:"checked,"}}>
         <label for="search_auth_key_required_true">
           Require an authorization key to use the search API
         </label>
@@ -667,7 +667,7 @@
       <div class="option">
         <input type="radio" name="read_auth_key_required" value="false"
             id="read_auth_key_required_false"
-            {{view_config.read_auth_key_required|yesno:",checked"}}>
+            {{api_access_control_config.read_auth_key_required|yesno:",checked"}}>
         <label for="read_auth_key_required_false">
           Allow anyone to use the read API and read the feeds
         </label>
@@ -675,7 +675,7 @@
       <div class="option">
         <input type="radio" name="read_auth_key_required" value="true"
                id="read_auth_key_required_true"
-               {{view_config.read_auth_key_required|yesno:"checked,"}}>
+               {{api_access_control_config.read_auth_key_required|yesno:"checked,"}}>
         <label for="read_auth_key_required_true">
           Require an authorization key to use the read API and read the feeds
         </label>
@@ -700,7 +700,7 @@
       <div class="option">
         <input type="radio" name="zero_rating_mode" value="false"
             id="zero_rating_mode_false"
-            {{view_config.zero_rating_mode|yesno:",checked"}}>
+            {{zero_rating_config.zero_rating_mode|yesno:",checked"}}>
         <label for="zero_rating_mode_false">
           Disable zero-rating mode: Enable all features which loads resource from external domains.
         </label>
@@ -708,7 +708,7 @@
       <div class="option">
         <input type="radio" name="zero_rating_mode" value="true"
             id="zero_rating_mode_true"
-            {{view_config.zero_rating_mode|yesno:"checked,"}}>
+            {{zero_rating_config.zero_rating_mode|yesno:"checked,"}}>
         <label for="zero_rating_mode_true">
           Enable zero-rating mode: Disable all features which loads resource from external domains.
         </label>
@@ -725,7 +725,7 @@
       </label>
       <div class="response">
         <textarea name="bad_words" id="bad_words" rows=4 cols=80
-          >{{view_config.bad_words|default:""}}</textarea>
+          >{{spam_config.bad_words|default:""}}</textarea>
       </div>
     </div>
   </fieldset>

--- a/app/resources/admin_repo_index.html.template
+++ b/app/resources/admin_repo_index.html.template
@@ -391,31 +391,6 @@
     <legend>General</legend>
 
     <div class="config">
-      <div class="option">
-        <input type="radio" name="force_https" value="true"
-          id="force_https_true"
-          {{view_config.force_https|yesno:"checked,"}}>
-        <label for="force_https_true">
-          Force https
-        </label>
-        <div class="note">
-          Force all requests to this repo to be redirected through https.
-        </div>
-      </div>
-      <div class="option">
-        <input type="radio" name="force_https" value="false"
-            id="force_https_false"
-            {{view_config.force_https|yesno:",checked"}}>
-        <label for="force_https_false">
-          Allow http and https traffic
-        </label>
-        <div class="note">
-          Allow requests to this repo over http or https.
-        </div>
-      </div>
-    </div>
-
-    <div class="config">
       <label for="keywords">
         Keywords in all languages (keywords separated by commas):
       </label>

--- a/app/resources/admin_repo_index.html.template
+++ b/app/resources/admin_repo_index.html.template
@@ -216,12 +216,36 @@
     }
   }
 
+  function insert_profile_websites_example(event) {
+    event.preventDefault();
+    $('profile_websites').value = [
+        '[',
+        '    {',
+        '        "name": "Facebook",',
+        '        "icon_filename": "facebook-16x16.png",',
+        '        "url_regexp": "https?://(www\\\\.)?facebook\\\\.com/.*"',
+        '    },',
+        '    {',
+        '        "name": "Twitter",',
+        '        "icon_filename": "twitter-16x16.png",',
+        '        "url_regexp": "https?://(www\\\\.)?twitter\\\\.com/.*"',
+        '    },',
+        '    {',
+        '        "name": "LinkedIn",',
+        '        "icon_filename": "linkedin-16x16.png",',
+        '        "url_regexp": "https?://(www\\\\.)?linkedin\\\\.com/.*"',
+        '    }',
+        ']'].join('\n');
+  }
+
   function init() {
     ReactDOM.render(
         e(
 	    LanguagesFieldsetComponent,
 	    JSON.parse("{{ language_config_json|escapejs }}")),
         document.querySelector('#languages_component_container'));
+    $('profile_websites_example_link').addEventListener(
+        'click', insert_profile_websites_example);
   }
 
   document.addEventListener('DOMContentLoaded', init);
@@ -388,7 +412,7 @@
   </fieldset>
 
   <fieldset>
-    <legend>General</legend>
+    <legend>Keywords</legend>
 
     <div class="config">
       <label for="keywords">
@@ -396,7 +420,7 @@
       </label>
       <div class="response">
         <textarea name="keywords" id="keywords" rows=4 cols=80
-          >{{view_config.keywords|default:""}}</textarea>
+          >{{keywords_config.keywords|default:""}}</textarea>
       </div>
     </div>
 
@@ -409,7 +433,7 @@
       <div class="option">
         <input type="radio" name="use_family_name" value="true"
           id="use_family_name_true"
-          {{view_config.use_family_name|yesno:"checked,"}}>
+          {{forms_config.use_family_name|yesno:"checked,"}}>
         <label for="use_family_name_true">
           Use both given and family name fields
         </label>
@@ -417,7 +441,7 @@
       <div class="option">
         <input type="radio" name="use_family_name" value="false"
             id="use_family_name_false"
-            {{view_config.use_family_name|yesno:",checked"}}>
+            {{forms_config.use_family_name|yesno:",checked"}}>
         <label for="use_family_name_false">
           Use only a single name field
         </label>
@@ -428,7 +452,7 @@
       <div class="option">
         <input type="radio" name="family_name_first" value="false"
             id="family_name_first_false"
-            {{view_config.family_name_first|yesno:",checked"}}>
+            {{forms_config.family_name_first|yesno:",checked"}}>
         <label for="family_name_first_false">
           Show given name first, then family name
         </label>
@@ -436,7 +460,7 @@
       <div class="option">
         <input type="radio" name="family_name_first" value="true"
             id="family_name_first_true"
-            {{view_config.family_name_first|yesno:"checked,"}}>
+            {{forms_config.family_name_first|yesno:"checked,"}}>
         <label for="family_name_first_true">
           Show family name first, then given name
         </label>
@@ -447,7 +471,7 @@
       <div class="option">
         <input type="radio" name="use_alternate_names" value="false"
             id="use_alternate_names_false"
-            {{view_config.use_alternate_names|yesno:",checked"}}>
+            {{forms_config.use_alternate_names|yesno:",checked"}}>
         <label for="use_alternate_names_false">
           Don't use alternate name fields (e.g. readings of Japanese names)
         </label>
@@ -455,7 +479,7 @@
       <div class="option">
         <input type="radio" name="use_alternate_names" value="true"
             id="use_alternate_names_true"
-            {{view_config.use_alternate_names|yesno:"checked,"}}>
+            {{forms_config.use_alternate_names|yesno:"checked,"}}>
         <label for="use_alternate_names_true">
           Use alternate name fields (e.g. readings of Japanese names)
         </label>
@@ -466,7 +490,7 @@
       <div class="option">
         <input type="radio" name="use_postal_code" value="true"
             id="use_postal_code_true"
-            {{view_config.use_postal_code|yesno:"checked,"}}>
+            {{forms_config.use_postal_code|yesno:"checked,"}}>
         <label for="use_postal_code_true">
           Use the postal code field
         </label>
@@ -474,7 +498,7 @@
       <div class="option">
         <input type="radio" name="use_postal_code" value="false"
             id="use_postal_code_false"
-            {{view_config.use_postal_code|yesno:",checked"}}>
+            {{forms_config.use_postal_code|yesno:",checked"}}>
         <label for="use_postal_code_false">
           Hide the postal code field
         </label>
@@ -485,7 +509,7 @@
       <div class="option">
         <input type="radio" name="allow_believed_dead_via_ui" value="true"
             id="allow_believed_dead_via_ui"
-            {{view_config.allow_believed_dead_via_ui|yesno:"checked,"}}>
+            {{forms_config.allow_believed_dead_via_ui|yesno:"checked,"}}>
         <label for="allow_believed_dead_via_ui_true">
           Allow users to post notes with status
           "I have received information that this person is dead".
@@ -494,7 +518,7 @@
       <div class="option">
         <input type="radio" name="allow_believed_dead_via_ui" value="false"
             id="allow_believed_dead_via_ui"
-            {{view_config.allow_believed_dead_via_ui|yesno:",checked"}}>
+            {{forms_config.allow_believed_dead_via_ui|yesno:",checked"}}>
         <label for="allow_believed_dead_via_ui_false">
           Don't allow users to post notes with status
           "I have received information that this person is dead".
@@ -507,7 +531,7 @@
       <div class="option">
         <input type="radio" name="min_query_word_length" value="1"
             id="min_query_word_length_1"
-            {% ifequal view_config.min_query_word_length 1 %}
+            {% ifequal forms_config.min_query_word_length 1 %}
               checked
             {% endifequal %}
         >
@@ -518,7 +542,7 @@
       <div class="option">
         <input type="radio" name="min_query_word_length" value="2"
             id="min_query_word_length_2"
-            {% ifnotequal view_config.min_query_word_length 1 %}
+            {% ifnotequal forms_config.min_query_word_length 1 %}
               checked
             {% endifnotequal %}
         >
@@ -532,7 +556,7 @@
       <div class="option">
         <input type="radio" name="show_profile_entry" value="true"
             id="show_profile_entry_true"
-            {{view_config.show_profile_entry|yesno:"checked,"}}>
+            {{forms_config.show_profile_entry|yesno:"checked,"}}>
         <label for="show_profile_entry_true">
           Show input fields for profile pages
         </label>
@@ -540,7 +564,7 @@
       <div class="option">
         <input type="radio" name="show_profile_entry" value="false"
             id="show_profile_entry_false"
-            {{view_config.show_profile_entry|yesno:",checked"}}>
+            {{forms_config.show_profile_entry|yesno:",checked"}}>
         <label for="show_profile_entry_false">
           Hide input fields for profile pages
         </label>
@@ -550,11 +574,11 @@
     <div class="config">
       <label for="profile_websites">External websites to show as the
       default options for profile pages (JSON list of dictionaries sorted in the
-      order of display) <a href="javascript:insert_profile_websites_example()"
+      order of display) <a id="profile_websites_example_link" href="#"
       >click to insert an example</a>:</label>
       <div class="response">
         <textarea name="profile_websites" id="profile_websites" rows=3 cols=80
-          >{{view_config_json.profile_websites|default:"[]"}}</textarea>
+          >{{forms_config.profile_websites|default:"[]"}}</textarea>
       </div>
     </div>
   </fieldset>
@@ -566,7 +590,7 @@
       <label for="map_default_zoom">Default zoom level (integer):</label>
       <div class="response">
         <input name="map_default_zoom" id="map_default_zoom" size=24
-            value="{{view_config_json.map_default_zoom}}">
+            value="{{map_config.map_default_zoom}}">
       </div>
     </div>
 
@@ -576,17 +600,17 @@
       </label>
       <div class="response">
         <input name="map_default_center" id="map_default_center" size=24
-            value="{{view_config_json.map_default_center}}">
+            value="{{map_config.map_default_center}}">
       </div>
     </div>
 
     <div class="config">
-      <label for="map_default_center">
+      <label for="map_size_pixels">
         Map size in pixels [width, height]:
       </label>
       <div class="response">
         <input name="map_size_pixels" id="map_size_pixels" size=24
-            value="{{view_config_json.map_size_pixels}}">
+            value="{{map_config.map_size_pixels}}">
       </div>
     </div>
   </fieldset>

--- a/app/resources/admin_repo_index.html.template
+++ b/app/resources/admin_repo_index.html.template
@@ -239,13 +239,17 @@
   }
 
   function init() {
-    ReactDOM.render(
-        e(
-	    LanguagesFieldsetComponent,
-	    JSON.parse("{{ language_config_json|escapejs }}")),
-        document.querySelector('#languages_component_container'));
-    $('profile_websites_example_link').addEventListener(
-        'click', insert_profile_websites_example);
+    {% if category_permissions.custom_messages %}
+      ReactDOM.render(
+          e(
+	      LanguagesFieldsetComponent,
+	      JSON.parse("{{ language_config_json|escapejs }}")),
+          document.querySelector('#languages_component_container'));
+    {% endif %}
+    {% if category_permissions.everything_else %}
+      $('profile_websites_example_link').addEventListener(
+          'click', insert_profile_websites_example);
+    {% endif %}
   }
 
   document.addEventListener('DOMContentLoaded', init);
@@ -257,486 +261,496 @@
 
   <input type="hidden" name="xsrf_token" value="{{ xsrf_token }}" />
 
-  <div id="languages_component_container"></div>
+  {% if category_permissions.custom_messages %}
+    <div id="languages_component_container"></div>
+  {% endif %}
 
-  <fieldset>
-    <legend>Activation mode</legend>
+  {% if category_permissions.everything_else %}
 
-    <div class="config">
-      <div class="option">
-        <input
-            type="radio" name="activation_status" value="0"
-            id="activation_status_staging"
-            {% if activation_config.activation_status == 0 %}
-              checked
-            {% endif %}>
-        <label for="activation_status_staging">
-          Staging
-        </label>
-        <div class="note">
-          <div>
-            <strong>Use case:</strong> Keep a repository in this mode while
-            testing the repository before public announcement.
+    <fieldset>
+      <legend>Activation mode</legend>
+
+      <div class="config">
+        <div class="option">
+          <input
+              type="radio" name="activation_status" value="0"
+              id="activation_status_staging"
+              {% if activation_config.activation_status == 0 %}
+                checked
+              {% endif %}>
+          <label for="activation_status_staging">
+            Staging
+          </label>
+          <div class="note">
+            <div>
+              <strong>Use case:</strong> Keep a repository in this mode while
+              testing the repository before public announcement.
+            </div>
+            <div>
+              <strong>Effect:</strong> The repository is neither listed on
+              <a href="{{env.global_url}}" target="_blank">the home page</a> nor
+              <a href="{{env.global_url}}/feeds/repo" target="_blank">the
+              repository feed</a>. So only people who know the URL can discover
+              the repository. It is the same as "Activated" except for that.
+            </div>
           </div>
-          <div>
-            <strong>Effect:</strong> The repository is neither listed on
-            <a href="{{env.global_url}}" target="_blank">the home page</a> nor
-            <a href="{{env.global_url}}/feeds/repo" target="_blank">the
-            repository feed</a>. So only people who know the URL can discover
-            the repository. It is the same as "Activated" except for that.
+        </div>
+        <div class="option">
+          <input
+              type="radio" name="activation_status" value="1"
+              id="activation_status_activated"
+              {% if activation_config.activation_status == 1 %}
+                checked
+              {% endif %}>
+          <label for="activation_status_activated">
+            Activated
+          </label>
+          <div class="note">
+            <div>
+              <strong>Use case:</strong> Keep a repository in this mode while the
+              repository is used by end users.
+            </div>
+            <div>
+              <strong>Effect:</strong> The repository is listed on
+              <a href="{{env.global_url}}" target="_blank">the home page</a> and
+              <a href="{{env.global_url}}/feeds/repo" target="_blank">the
+              repository feed</a>. So end users can discover the repository.
+            </div>
+          </div>
+        </div>
+        <div class="option">
+          <input
+              type="radio" name="activation_status" value="2"
+              id="activation_status_deactivated"
+              {% if activation_config.activation_status == 2 %}
+                checked
+              {% endif %}>
+          <label for="activation_status_deactivated">
+            Deactivated
+          </label>
+          <div class="note">
+            <div>
+              <strong>Use case:</strong> Switch to this mode to deactivate the
+              repository.
+            </div>
+            <div>
+              <strong>Effect:</strong> Replaces content of all pages with the
+              deactivation message below. People cannot interact with the
+              repository either via web interface or API. The repository is
+              neither listed on
+              <a href="{{env.global_url}}" target="_blank">the home page</a> nor
+              <a href="{{env.global_url}}/feeds/repo" target="_blank">the
+              repository feed</a>.
+            </div>
           </div>
         </div>
       </div>
-      <div class="option">
-        <input
-            type="radio" name="activation_status" value="1"
-            id="activation_status_activated"
-            {% if activation_config.activation_status == 1 %}
-              checked
-            {% endif %}>
-        <label for="activation_status_activated">
-          Activated
-        </label>
-        <div class="note">
-          <div>
-            <strong>Use case:</strong> Keep a repository in this mode while the
-            repository is used by end users.
+
+      <div class="config">
+        <label for="deactivation_message_html">
+          Deactivation message (HTML):</label>
+        <div class="response">
+          <textarea name="deactivation_message_html"
+              id="deactivation_message_html" rows=6 cols=80
+              >{{activation_config.deactivation_message_html|default:""}}</textarea>
+        </div>
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Data retention mode</legend>
+
+      <div class="config">
+        <div class="option">
+          <input type="radio" name="test_mode" value="true"
+            id="test_mode_true"
+            {{data_retention_config.test_mode|yesno:"checked,"}}>
+          <label for="test_mode_true">
+            Test mode
+          </label>
+          <div class="note">
+            <div>
+              <strong>Use case:</strong> This mode is usually used for always-on
+              repository such as "japan" repository, while no crisis is
+              on-going.
+            </div>
+            <div>
+              <strong>Effect:</strong> In this mode, all records are deleted
+              about {{test_mode_min_age_hours}} hours after they are created,
+              regardless of their specified expiry date. We do this to clean up
+              spams, because it's not feasible to perform manual spam monitoring
+              all the time for always-on repositories.
+            </div>
+            <div>
+              <strong>Note:</strong> If you switch from real mode to
+              test mode, existing records that are more than
+              {{test_mode_min_age_hours}} old will soon be deleted.
+              Also note that (unlike regular deletions or expirations)
+              these deletions do not generate expiry notices
+              in the outgoing PFIF feeds,
+              so any clients that import test records into their own
+              repositories cannot be expected to delete them on the same short
+              schedule.
+            </div>
           </div>
-          <div>
-            <strong>Effect:</strong> The repository is listed on
-            <a href="{{env.global_url}}" target="_blank">the home page</a> and
-            <a href="{{env.global_url}}/feeds/repo" target="_blank">the
-            repository feed</a>. So end users can discover the repository.
+        </div>
+        <div class="option">
+          <input type="radio" name="test_mode" value="false"
+              id="test_mode_false"
+              {{data_retention_config.test_mode|yesno:",checked"}}>
+          <label for="test_mode_false">
+            Real mode
+          </label>
+          <div class="note">
+            <div>
+              <strong>Use case:</strong> Use this mode while the repository is
+              actively used for a real crisis.
+            </div>
+            <div>
+              <strong>Effect:</strong> In this mode, records last until their
+              specified expiry date.
+            </div>
+            <div>
+              <strong>Note:</strong> If you switch from test mode to real mode,
+              any existing records are retained and will be treated as normal.
+            </div>
           </div>
         </div>
       </div>
-      <div class="option">
-        <input
-            type="radio" name="activation_status" value="2"
-            id="activation_status_deactivated"
-            {% if activation_config.activation_status == 2 %}
-              checked
-            {% endif %}>
-        <label for="activation_status_deactivated">
-          Deactivated
+
+    </fieldset>
+
+    <fieldset>
+      <legend>Keywords</legend>
+
+      <div class="config">
+        <label for="keywords">
+          Keywords in all languages (keywords separated by commas):
         </label>
-        <div class="note">
-          <div>
-            <strong>Use case:</strong> Switch to this mode to deactivate the
-            repository.
-          </div>
-          <div>
-            <strong>Effect:</strong> Replaces content of all pages with the
-            deactivation message below. People cannot interact with the
-            repository either via web interface or API. The repository is
-            neither listed on
-            <a href="{{env.global_url}}" target="_blank">the home page</a> nor
-            <a href="{{env.global_url}}/feeds/repo" target="_blank">the
-            repository feed</a>.
-          </div>
+        <div class="response">
+          <textarea name="keywords" id="keywords" rows=4 cols=80
+            >{{keywords_config.keywords|default:""}}</textarea>
         </div>
       </div>
-    </div>
 
-    <div class="config">
-      <label for="deactivation_message_html">
-        Deactivation message (HTML):</label>
-      <div class="response">
-        <textarea name="deactivation_message_html"
-            id="deactivation_message_html" rows=6 cols=80
-            >{{activation_config.deactivation_message_html|default:""}}</textarea>
-      </div>
-    </div>
-  </fieldset>
+    </fieldset>
 
-  <fieldset>
-    <legend>Data retention mode</legend>
+    <fieldset>
+      <legend>Forms</legend>
 
-    <div class="config">
-      <div class="option">
-        <input type="radio" name="test_mode" value="true"
-          id="test_mode_true"
-          {{data_retention_config.test_mode|yesno:"checked,"}}>
-        <label for="test_mode_true">
-          Test mode
-        </label>
-        <div class="note">
-          <div>
-            <strong>Use case:</strong> This mode is usually used for always-on
-            repository such as "japan" repository, while no crisis is
-            on-going.
-          </div>
-          <div>
-            <strong>Effect:</strong> In this mode, all records are deleted
-            about {{test_mode_min_age_hours}} hours after they are created,
-            regardless of their specified expiry date. We do this to clean up
-            spams, because it's not feasible to perform manual spam monitoring
-            all the time for always-on repositories.
-          </div>
-          <div>
-            <strong>Note:</strong> If you switch from real mode to
-            test mode, existing records that are more than
-            {{test_mode_min_age_hours}} old will soon be deleted.
-            Also note that (unlike regular deletions or expirations)
-            these deletions do not generate expiry notices
-            in the outgoing PFIF feeds,
-            so any clients that import test records into their own repositories
-            cannot be expected to delete them on the same short schedule.
-          </div>
+      <div class="config">
+        <div class="option">
+          <input type="radio" name="use_family_name" value="true"
+            id="use_family_name_true"
+            {{forms_config.use_family_name|yesno:"checked,"}}>
+          <label for="use_family_name_true">
+            Use both given and family name fields
+          </label>
+        </div>
+        <div class="option">
+          <input type="radio" name="use_family_name" value="false"
+              id="use_family_name_false"
+              {{forms_config.use_family_name|yesno:",checked"}}>
+          <label for="use_family_name_false">
+            Use only a single name field
+          </label>
         </div>
       </div>
-      <div class="option">
-        <input type="radio" name="test_mode" value="false"
-            id="test_mode_false"
-            {{data_retention_config.test_mode|yesno:",checked"}}>
-        <label for="test_mode_false">
-          Real mode
-        </label>
-        <div class="note">
-          <div>
-            <strong>Use case:</strong> Use this mode while the repository is
-            actively used for a real crisis.
-          </div>
-          <div>
-            <strong>Effect:</strong> In this mode, records last until their
-            specified expiry date.
-          </div>
-          <div>
-            <strong>Note:</strong> If you switch from test mode to real mode,
-            any existing records are retained and will be treated as normal.
-          </div>
+
+      <div class="config">
+        <div class="option">
+          <input type="radio" name="family_name_first" value="false"
+              id="family_name_first_false"
+              {{forms_config.family_name_first|yesno:",checked"}}>
+          <label for="family_name_first_false">
+            Show given name first, then family name
+          </label>
+        </div>
+        <div class="option">
+          <input type="radio" name="family_name_first" value="true"
+              id="family_name_first_true"
+              {{forms_config.family_name_first|yesno:"checked,"}}>
+          <label for="family_name_first_true">
+            Show family name first, then given name
+          </label>
         </div>
       </div>
-    </div>
 
-  </fieldset>
-
-  <fieldset>
-    <legend>Keywords</legend>
-
-    <div class="config">
-      <label for="keywords">
-        Keywords in all languages (keywords separated by commas):
-      </label>
-      <div class="response">
-        <textarea name="keywords" id="keywords" rows=4 cols=80
-          >{{keywords_config.keywords|default:""}}</textarea>
+      <div class="config">
+        <div class="option">
+          <input type="radio" name="use_alternate_names" value="false"
+              id="use_alternate_names_false"
+              {{forms_config.use_alternate_names|yesno:",checked"}}>
+          <label for="use_alternate_names_false">
+            Don't use alternate name fields (e.g. readings of Japanese names)
+          </label>
+        </div>
+        <div class="option">
+          <input type="radio" name="use_alternate_names" value="true"
+              id="use_alternate_names_true"
+              {{forms_config.use_alternate_names|yesno:"checked,"}}>
+          <label for="use_alternate_names_true">
+            Use alternate name fields (e.g. readings of Japanese names)
+          </label>
+        </div>
       </div>
-    </div>
 
-  </fieldset>
+      <div class="config">
+        <div class="option">
+          <input type="radio" name="use_postal_code" value="true"
+              id="use_postal_code_true"
+              {{forms_config.use_postal_code|yesno:"checked,"}}>
+          <label for="use_postal_code_true">
+            Use the postal code field
+          </label>
+        </div>
+        <div class="option">
+          <input type="radio" name="use_postal_code" value="false"
+              id="use_postal_code_false"
+              {{forms_config.use_postal_code|yesno:",checked"}}>
+          <label for="use_postal_code_false">
+            Hide the postal code field
+          </label>
+        </div>
+      </div>
 
-  <fieldset>
-    <legend>Forms</legend>
+      <div class="config">
+        <div class="option">
+          <input type="radio" name="allow_believed_dead_via_ui" value="true"
+              id="allow_believed_dead_via_ui"
+              {{forms_config.allow_believed_dead_via_ui|yesno:"checked,"}}>
+          <label for="allow_believed_dead_via_ui_true">
+            Allow users to post notes with status
+            "I have received information that this person is dead".
+          </label>
+        </div>
+        <div class="option">
+          <input type="radio" name="allow_believed_dead_via_ui" value="false"
+              id="allow_believed_dead_via_ui"
+              {{forms_config.allow_believed_dead_via_ui|yesno:",checked"}}>
+          <label for="allow_believed_dead_via_ui_false">
+            Don't allow users to post notes with status
+            "I have received information that this person is dead".
+          </label>
+        </div>
+      </div>
 
-    <div class="config">
-      <div class="option">
-        <input type="radio" name="use_family_name" value="true"
-          id="use_family_name_true"
-          {{forms_config.use_family_name|yesno:"checked,"}}>
-        <label for="use_family_name_true">
-          Use both given and family name fields
+
+      <div class="config">
+        <div class="option">
+          <input type="radio" name="min_query_word_length" value="1"
+              id="min_query_word_length_1"
+              {% ifequal forms_config.min_query_word_length 1 %}
+                checked
+              {% endifequal %}
+          >
+          <label for="min_query_word_length_1">
+            Accept queries with only 1 character
+          </label>
+        </div>
+        <div class="option">
+          <input type="radio" name="min_query_word_length" value="2"
+              id="min_query_word_length_2"
+              {% ifnotequal forms_config.min_query_word_length 1 %}
+                checked
+              {% endifnotequal %}
+          >
+          <label for="min_query_word_length_2">
+            Require query words to have at least 2 characters
+          </label>
+        </div>
+      </div>
+
+      <div class="config">
+        <div class="option">
+          <input type="radio" name="show_profile_entry" value="true"
+              id="show_profile_entry_true"
+              {{forms_config.show_profile_entry|yesno:"checked,"}}>
+          <label for="show_profile_entry_true">
+            Show input fields for profile pages
+          </label>
+        </div>
+        <div class="option">
+          <input type="radio" name="show_profile_entry" value="false"
+              id="show_profile_entry_false"
+              {{forms_config.show_profile_entry|yesno:",checked"}}>
+          <label for="show_profile_entry_false">
+            Hide input fields for profile pages
+          </label>
+        </div>
+      </div>
+
+      <div class="config">
+        <label for="profile_websites">External websites to show as the
+        default options for profile pages (JSON list of dictionaries sorted in
+        the order of display) <a id="profile_websites_example_link" href="#"
+        >click to insert an example</a>:</label>
+        <div class="response">
+          <textarea name="profile_websites" id="profile_websites" rows=3 cols=80
+            >{{forms_config.profile_websites|default:"[]"}}</textarea>
+        </div>
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Map options</legend>
+
+      <div class="config">
+        <label for="map_default_zoom">Default zoom level (integer):</label>
+        <div class="response">
+          <input name="map_default_zoom" id="map_default_zoom" size=24
+              value="{{map_config.map_default_zoom}}">
+        </div>
+      </div>
+
+      <div class="config">
+        <label for="map_default_center">
+          Default center [latitude north, longitude east]:
         </label>
+        <div class="response">
+          <input name="map_default_center" id="map_default_center" size=24
+              value="{{map_config.map_default_center}}">
+        </div>
       </div>
-      <div class="option">
-        <input type="radio" name="use_family_name" value="false"
-            id="use_family_name_false"
-            {{forms_config.use_family_name|yesno:",checked"}}>
-        <label for="use_family_name_false">
-          Use only a single name field
+
+      <div class="config">
+        <label for="map_size_pixels">
+          Map size in pixels [width, height]:
         </label>
+        <div class="response">
+          <input name="map_size_pixels" id="map_size_pixels" size=24
+              value="{{map_config.map_size_pixels}}">
+        </div>
       </div>
-    </div>
+    </fieldset>
 
-    <div class="config">
-      <div class="option">
-        <input type="radio" name="family_name_first" value="false"
-            id="family_name_first_false"
-            {{forms_config.family_name_first|yesno:",checked"}}>
-        <label for="family_name_first_false">
-          Show given name first, then family name
+    <fieldset>
+      <legend>Time zones</legend>
+
+      <p>These are used to display timestamps of person records and notes.</p>
+
+      <div class="config">
+        <label for="time_zone_offset">Time zone offset (-12 to 14):</label>
+        <div class="response">
+          UTC +
+          <input type="number" step="any"
+              name="time_zone_offset" id="time_zone_offset"
+              value="{{timezone_config.time_zone_offset}}">
+        </div>
+      </div>
+
+      <div class="config">
+        <label for="time_zone_abbreviation">
+          Time zone name (in 3 letters e.g., JST):
         </label>
+        <div class="response">
+          <input
+              name="time_zone_abbreviation"
+              id="time_zone_abbreviation"
+              size=3
+              value="{{timezone_config.time_zone_abbreviation}}">
+        </div>
       </div>
-      <div class="option">
-        <input type="radio" name="family_name_first" value="true"
-            id="family_name_first_true"
-            {{forms_config.family_name_first|yesno:"checked,"}}>
-        <label for="family_name_first_true">
-          Show family name first, then given name
+    </fieldset>
+
+    <fieldset>
+      <legend>Access control</legend>
+
+      <div class="config">
+        <div class="option">
+          <input type="radio" name="search_auth_key_required" value="false"
+              id="search_auth_key_required_false"
+              {{api_access_control_config.search_auth_key_required|yesno:",checked"}}>
+          <label for="search_auth_key_required_false">
+            Allow anyone to use the search API
+          </label>
+        </div>
+        <div class="option">
+          <input type="radio" name="search_auth_key_required" value="true"
+              id="search_auth_key_required_true"
+              {{api_access_control_config.search_auth_key_required|yesno:"checked,"}}>
+          <label for="search_auth_key_required_true">
+            Require an authorization key to use the search API
+          </label>
+        </div>
+      </div>
+
+      <div class="config">
+        <div class="option">
+          <input type="radio" name="read_auth_key_required" value="false"
+              id="read_auth_key_required_false"
+              {{api_access_control_config.read_auth_key_required|yesno:",checked"}}>
+          <label for="read_auth_key_required_false">
+            Allow anyone to use the read API and read the feeds
+          </label>
+        </div>
+        <div class="option">
+          <input type="radio" name="read_auth_key_required" value="true"
+                 id="read_auth_key_required_true"
+                 {{api_access_control_config.read_auth_key_required|yesno:"checked,"}}>
+          <label for="read_auth_key_required_true">
+            Require an authorization key to use the read API and read the feeds
+          </label>
+        </div>
+      </div>
+
+    </fieldset>
+
+    <fieldset>
+      <legend>Zero-rating</legend>
+
+      <div class="config">
+        <p>Sometimes mobile carriers "zero-rate" our site so that users can see our site without normal data access fee. It is often applied per domain name. But when users access Person Finder, it also loads resource from other domains e.g., Google Maps, Google Analytics, Google Translate by default.</p>
+
+        <p>If you enable zero-rating mode, it disables all those features which loads resource from external domains, so that the users from the carriers can access Person Finder completely for free.</p>
+
+        <p><b>CAVEAT:</b> This mode has not been implemented completely, and it still loads some resource from other domains even in zero-rating mode:</p>
+        <ul>
+          <li><a href="https://github.com/google/personfinder/issues/239">reCAPTCHA</a></li>
+        </ul>
+
+        <div class="option">
+          <input type="radio" name="zero_rating_mode" value="false"
+              id="zero_rating_mode_false"
+              {{zero_rating_config.zero_rating_mode|yesno:",checked"}}>
+          <label for="zero_rating_mode_false">
+            Disable zero-rating mode: Enable all features which loads resource from external domains.
+          </label>
+        </div>
+        <div class="option">
+          <input type="radio" name="zero_rating_mode" value="true"
+              id="zero_rating_mode_true"
+              {{zero_rating_config.zero_rating_mode|yesno:"checked,"}}>
+          <label for="zero_rating_mode_true">
+            Enable zero-rating mode: Disable all features which loads resource from external domains.
+          </label>
+        </div>
+      </div>
+
+    </fieldset>
+
+    <fieldset>
+      <legend> Spam detection </legend>
+      <div class="config">
+        <label for="bad_words">
+          Bad words in all languages (words separated by commas):
         </label>
+        <div class="response">
+          <textarea name="bad_words" id="bad_words" rows=4 cols=80
+            >{{spam_config.bad_words|default:""}}</textarea>
+        </div>
       </div>
-    </div>
+    </fieldset>
 
-    <div class="config">
-      <div class="option">
-        <input type="radio" name="use_alternate_names" value="false"
-            id="use_alternate_names_false"
-            {{forms_config.use_alternate_names|yesno:",checked"}}>
-        <label for="use_alternate_names_false">
-          Don't use alternate name fields (e.g. readings of Japanese names)
-        </label>
+    <fieldset>
+      <legend>SMS</legend>
+      <div class="config">
+        Go to <a href="../global/admin">Global settings</a> to configure SMS
+        numbers mapping.
       </div>
-      <div class="option">
-        <input type="radio" name="use_alternate_names" value="true"
-            id="use_alternate_names_true"
-            {{forms_config.use_alternate_names|yesno:"checked,"}}>
-        <label for="use_alternate_names_true">
-          Use alternate name fields (e.g. readings of Japanese names)
-        </label>
-      </div>
-    </div>
+    </fieldset>
 
-    <div class="config">
-      <div class="option">
-        <input type="radio" name="use_postal_code" value="true"
-            id="use_postal_code_true"
-            {{forms_config.use_postal_code|yesno:"checked,"}}>
-        <label for="use_postal_code_true">
-          Use the postal code field
-        </label>
-      </div>
-      <div class="option">
-        <input type="radio" name="use_postal_code" value="false"
-            id="use_postal_code_false"
-            {{forms_config.use_postal_code|yesno:",checked"}}>
-        <label for="use_postal_code_false">
-          Hide the postal code field
-        </label>
-      </div>
-    </div>
-
-    <div class="config">
-      <div class="option">
-        <input type="radio" name="allow_believed_dead_via_ui" value="true"
-            id="allow_believed_dead_via_ui"
-            {{forms_config.allow_believed_dead_via_ui|yesno:"checked,"}}>
-        <label for="allow_believed_dead_via_ui_true">
-          Allow users to post notes with status
-          "I have received information that this person is dead".
-        </label>
-      </div>
-      <div class="option">
-        <input type="radio" name="allow_believed_dead_via_ui" value="false"
-            id="allow_believed_dead_via_ui"
-            {{forms_config.allow_believed_dead_via_ui|yesno:",checked"}}>
-        <label for="allow_believed_dead_via_ui_false">
-          Don't allow users to post notes with status
-          "I have received information that this person is dead".
-        </label>
-      </div>
-    </div>
-
-
-    <div class="config">
-      <div class="option">
-        <input type="radio" name="min_query_word_length" value="1"
-            id="min_query_word_length_1"
-            {% ifequal forms_config.min_query_word_length 1 %}
-              checked
-            {% endifequal %}
-        >
-        <label for="min_query_word_length_1">
-          Accept queries with only 1 character
-        </label>
-      </div>
-      <div class="option">
-        <input type="radio" name="min_query_word_length" value="2"
-            id="min_query_word_length_2"
-            {% ifnotequal forms_config.min_query_word_length 1 %}
-              checked
-            {% endifnotequal %}
-        >
-        <label for="min_query_word_length_2">
-          Require query words to have at least 2 characters
-        </label>
-      </div>
-    </div>
-
-    <div class="config">
-      <div class="option">
-        <input type="radio" name="show_profile_entry" value="true"
-            id="show_profile_entry_true"
-            {{forms_config.show_profile_entry|yesno:"checked,"}}>
-        <label for="show_profile_entry_true">
-          Show input fields for profile pages
-        </label>
-      </div>
-      <div class="option">
-        <input type="radio" name="show_profile_entry" value="false"
-            id="show_profile_entry_false"
-            {{forms_config.show_profile_entry|yesno:",checked"}}>
-        <label for="show_profile_entry_false">
-          Hide input fields for profile pages
-        </label>
-      </div>
-    </div>
-
-    <div class="config">
-      <label for="profile_websites">External websites to show as the
-      default options for profile pages (JSON list of dictionaries sorted in the
-      order of display) <a id="profile_websites_example_link" href="#"
-      >click to insert an example</a>:</label>
-      <div class="response">
-        <textarea name="profile_websites" id="profile_websites" rows=3 cols=80
-          >{{forms_config.profile_websites|default:"[]"}}</textarea>
-      </div>
-    </div>
-  </fieldset>
-
-  <fieldset>
-    <legend>Map options</legend>
-
-    <div class="config">
-      <label for="map_default_zoom">Default zoom level (integer):</label>
-      <div class="response">
-        <input name="map_default_zoom" id="map_default_zoom" size=24
-            value="{{map_config.map_default_zoom}}">
-      </div>
-    </div>
-
-    <div class="config">
-      <label for="map_default_center">
-        Default center [latitude north, longitude east]:
-      </label>
-      <div class="response">
-        <input name="map_default_center" id="map_default_center" size=24
-            value="{{map_config.map_default_center}}">
-      </div>
-    </div>
-
-    <div class="config">
-      <label for="map_size_pixels">
-        Map size in pixels [width, height]:
-      </label>
-      <div class="response">
-        <input name="map_size_pixels" id="map_size_pixels" size=24
-            value="{{map_config.map_size_pixels}}">
-      </div>
-    </div>
-  </fieldset>
-
-  <fieldset>
-    <legend>Time zones</legend>
-
-    <p>These are used to display timestamps of person records and notes.</p>
-
-    <div class="config">
-      <label for="time_zone_offset">Time zone offset (-12 to 14):</label>
-      <div class="response">
-        UTC +
-        <input type="number" step="any"
-            name="time_zone_offset" id="time_zone_offset"
-            value="{{timezone_config.time_zone_offset}}">
-      </div>
-    </div>
-
-    <div class="config">
-      <label for="time_zone_abbreviation">
-        Time zone name (in 3 letters e.g., JST):
-      </label>
-      <div class="response">
-        <input name="time_zone_abbreviation" id="time_zone_abbreviation" size=3
-            value="{{timezone_config.time_zone_abbreviation}}">
-      </div>
-    </div>
-  </fieldset>
-
-  <fieldset>
-    <legend>Access control</legend>
-
-    <div class="config">
-      <div class="option">
-        <input type="radio" name="search_auth_key_required" value="false"
-            id="search_auth_key_required_false"
-            {{api_access_control_config.search_auth_key_required|yesno:",checked"}}>
-        <label for="search_auth_key_required_false">
-          Allow anyone to use the search API
-        </label>
-      </div>
-      <div class="option">
-        <input type="radio" name="search_auth_key_required" value="true"
-            id="search_auth_key_required_true"
-            {{api_access_control_config.search_auth_key_required|yesno:"checked,"}}>
-        <label for="search_auth_key_required_true">
-          Require an authorization key to use the search API
-        </label>
-      </div>
-    </div>
-
-    <div class="config">
-      <div class="option">
-        <input type="radio" name="read_auth_key_required" value="false"
-            id="read_auth_key_required_false"
-            {{api_access_control_config.read_auth_key_required|yesno:",checked"}}>
-        <label for="read_auth_key_required_false">
-          Allow anyone to use the read API and read the feeds
-        </label>
-      </div>
-      <div class="option">
-        <input type="radio" name="read_auth_key_required" value="true"
-               id="read_auth_key_required_true"
-               {{api_access_control_config.read_auth_key_required|yesno:"checked,"}}>
-        <label for="read_auth_key_required_true">
-          Require an authorization key to use the read API and read the feeds
-        </label>
-      </div>
-    </div>
-
-  </fieldset>
-
-  <fieldset>
-    <legend>Zero-rating</legend>
-
-    <div class="config">
-      <p>Sometimes mobile carriers "zero-rate" our site so that users can see our site without normal data access fee. It is often applied per domain name. But when users access Person Finder, it also loads resource from other domains e.g., Google Maps, Google Analytics, Google Translate by default.</p>
-
-      <p>If you enable zero-rating mode, it disables all those features which loads resource from external domains, so that the users from the carriers can access Person Finder completely for free.</p>
-
-      <p><b>CAVEAT:</b> This mode has not been implemented completely, and it still loads some resource from other domains even in zero-rating mode:</p>
-      <ul>
-        <li><a href="https://github.com/google/personfinder/issues/239">reCAPTCHA</a></li>
-      </ul>
-
-      <div class="option">
-        <input type="radio" name="zero_rating_mode" value="false"
-            id="zero_rating_mode_false"
-            {{zero_rating_config.zero_rating_mode|yesno:",checked"}}>
-        <label for="zero_rating_mode_false">
-          Disable zero-rating mode: Enable all features which loads resource from external domains.
-        </label>
-      </div>
-      <div class="option">
-        <input type="radio" name="zero_rating_mode" value="true"
-            id="zero_rating_mode_true"
-            {{zero_rating_config.zero_rating_mode|yesno:"checked,"}}>
-        <label for="zero_rating_mode_true">
-          Enable zero-rating mode: Disable all features which loads resource from external domains.
-        </label>
-      </div>
-    </div>
-
-  </fieldset>
-
-  <fieldset>
-    <legend> Spam detection </legend>
-    <div class="config">
-      <label for="bad_words">
-        Bad words in all languages (words separated by commas):
-      </label>
-      <div class="response">
-        <textarea name="bad_words" id="bad_words" rows=4 cols=80
-          >{{spam_config.bad_words|default:""}}</textarea>
-      </div>
-    </div>
-  </fieldset>
-
-  <fieldset>
-    <legend>SMS</legend>
-    <div class="config">
-      Go to <a href="../global/admin">Global settings</a> to configure SMS
-      numbers mapping.
-    </div>
-  </fieldset>
+  {% endif %}
 
   <p>
     <input type="submit" value="Save these settings">

--- a/app/resources/admin_repo_index.html.template
+++ b/app/resources/admin_repo_index.html.template
@@ -332,7 +332,7 @@
       <div class="option">
         <input type="radio" name="test_mode" value="true"
           id="test_mode_true"
-          {{view_config.test_mode|yesno:"checked,"}}>
+          {{data_retention_config.test_mode|yesno:"checked,"}}>
         <label for="test_mode_true">
           Test mode
         </label>
@@ -364,7 +364,7 @@
       <div class="option">
         <input type="radio" name="test_mode" value="false"
             id="test_mode_false"
-            {{view_config.test_mode|yesno:",checked"}}>
+            {{data_retention_config.test_mode|yesno:",checked"}}>
         <label for="test_mode_false">
           Real mode
         </label>

--- a/app/resources/admin_repo_index.html.template
+++ b/app/resources/admin_repo_index.html.template
@@ -47,14 +47,16 @@
   class LanguagesFieldsetComponent extends React.Component {
     constructor(props) {
       super(props);
-      const repo_titles_map = new Map(
-          Object.keys(this.props.repo_titles).map(
-              k => [k, this.props.repo_titles[k]]));
-      const custom_messages_map = new Map(
-          Object.keys(this.props.custom_messages).map(
+      const repo_titles_map = props.hasOwnProperty('repo_titles') ?
+          new Map(Object.keys(props.repo_titles).map(
+              k => [k, props.repo_titles[k]]))
+          : {};
+      const custom_messages_map = props.hasOwnProperty('custom_messages') ?
+          new Map(Object.keys(props.custom_messages).map(
               ck => [ck, new Map(Object.keys(
                   this.props.custom_messages[ck]).map(
-                      lk => [lk, this.props.custom_messages[ck][lk]]))]));
+                      lk => [lk, props.custom_messages[ck][lk]]))]))
+          : {};
       this.state = {
         lang_list: props.lang_list,
         repo_titles: repo_titles_map,

--- a/app/resources/admin_repo_index.html.template
+++ b/app/resources/admin_repo_index.html.template
@@ -626,7 +626,7 @@
         UTC +
         <input type="number" step="any"
             name="time_zone_offset" id="time_zone_offset"
-            value="{{view_config_json.time_zone_offset}}">
+            value="{{timezone_config.time_zone_offset}}">
       </div>
     </div>
 
@@ -636,7 +636,7 @@
       </label>
       <div class="response">
         <input name="time_zone_abbreviation" id="time_zone_abbreviation" size=3
-            value="{{view_config.time_zone_abbreviation}}">
+            value="{{timezone_config.time_zone_abbreviation}}">
       </div>
     </div>
   </fieldset>

--- a/app/resources/admin_repo_index.html.template
+++ b/app/resources/admin_repo_index.html.template
@@ -241,12 +241,12 @@
     <div class="config">
       <div class="option">
         <input
-            type="radio" name="launch_status" value="staging"
-            id="launch_status_staging"
-            {% if view_config.launch_status == "staging" %}
+            type="radio" name="activation_status" value="0"
+            id="activation_status_staging"
+            {% if activation_config.activation_status == 0 %}
               checked
             {% endif %}>
-        <label for="launch_status_staging">
+        <label for="activation_status_staging">
           Staging
         </label>
         <div class="note">
@@ -265,12 +265,12 @@
       </div>
       <div class="option">
         <input
-            type="radio" name="launch_status" value="activated"
-            id="launch_status_activated"
-            {% if view_config.launch_status == "activated" %}
+            type="radio" name="activation_status" value="1"
+            id="activation_status_activated"
+            {% if activation_config.activation_status == 1 %}
               checked
             {% endif %}>
-        <label for="launch_status_activated">
+        <label for="activation_status_activated">
           Activated
         </label>
         <div class="note">
@@ -288,12 +288,12 @@
       </div>
       <div class="option">
         <input
-            type="radio" name="launch_status" value="deactivated"
-            id="launch_status_deactivated"
-            {% if view_config.launch_status == "deactivated" %}
+            type="radio" name="activation_status" value="2"
+            id="activation_status_deactivated"
+            {% if activation_config.activation_status == 2 %}
               checked
             {% endif %}>
-        <label for="launch_status_deactivated">
+        <label for="activation_status_deactivated">
           Deactivated
         </label>
         <div class="note">
@@ -320,7 +320,7 @@
       <div class="response">
         <textarea name="deactivation_message_html"
             id="deactivation_message_html" rows=6 cols=80
-            >{{view_config.deactivation_message_html|default:""}}</textarea>
+            >{{activation_config.deactivation_message_html|default:""}}</textarea>
       </div>
     </div>
   </fieldset>

--- a/app/resources/admin_repo_index.html.template
+++ b/app/resources/admin_repo_index.html.template
@@ -1,0 +1,745 @@
+{# Copyright 2010 Google Inc.  Licensed under the Apache License, Version   #}
+{# 2.0 (the "License"); you may not use this file except in compliance with #}
+{# the License.  You may obtain a copy of the License at:                   #}
+{#     http://www.apache.org/licenses/LICENSE-2.0                           #}
+{# Unless required by applicable law or agreed to in writing, software      #}
+{# distributed under the License is distributed on an "AS IS" BASIS,        #}
+{# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. #}
+{# See the License for the specific language governing permissions and      #}
+{# limitations under the License.                                           #}
+
+{# Template for the repository settings page (see admin/repo_index.py).     #}
+
+{% extends "admin-base.html.template" %}
+{% load i18n %}
+
+{% block content %}
+<script src="https://unpkg.com/react@16/umd/react.development.js" nonce="{{ csp_nonce }}" crossorigin></script>
+<script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" nonce="{{ csp_nonce }}" crossorigin></script>
+
+<script nonce="{{ csp_nonce }}">
+  const LANGUAGE_EXONYMS_ARR = JSON.parse(
+      "{{ language_exonyms_json|escapejs }}");
+  const LANGUAGE_EXONYMS_MAP = new Map(LANGUAGE_EXONYMS_ARR);
+
+  const CUSTOM_MESSAGES_CONFIG_KEYS = [
+      'start_page_custom_htmls',
+      'results_page_custom_htmls',
+      'view_page_custom_htmls',
+      'seek_query_form_custom_htmls',
+      'footer_custom_htmls',
+  ];
+  const CUSTOM_MESSAGES_LABELS = {
+      'start_page_custom_htmls':
+      'Custom message for start page in each language',
+      'results_page_custom_htmls':
+      'Custom message for search results page in each language',
+      'view_page_custom_htmls':
+      'Custom message for person record view page in each language',
+      'seek_query_form_custom_htmls':
+      'Custom message for the query form when role=seek in each language',
+      'footer_custom_htmls':
+      'Custom message for the footer in all pages in each language',
+  };
+
+  const e = React.createElement;
+
+  class LanguagesFieldsetComponent extends React.Component {
+    constructor(props) {
+      super(props);
+      const repo_titles_map = new Map(
+          Object.keys(this.props.repo_titles).map(
+              k => [k, this.props.repo_titles[k]]));
+      const custom_messages_map = new Map(
+          Object.keys(this.props.custom_messages).map(
+              ck => [ck, new Map(Object.keys(
+                  this.props.custom_messages[ck]).map(
+                      lk => [lk, this.props.custom_messages[ck][lk]]))]));
+      this.state = {
+        lang_list: props.lang_list,
+        repo_titles: repo_titles_map,
+	custom_messages: custom_messages_map,
+      };
+      this.addLanguage = this.addLanguage.bind(this);
+      this.removeLanguage = this.removeLanguage.bind(this);
+      this.updateRepoTitle = this.updateRepoTitle.bind(this);
+      this.updateLanguageSelection = this.updateLanguageSelection.bind(this);
+      this.updateCustomMessage = this.updateCustomMessage.bind(this);
+    }
+
+    addLanguage() {
+      if (this.state.lang_list.indexOf(null) >= 0) {
+        alert('There is already an unselected language in the list!');
+        return;
+      }
+      const new_lang_list = Array.from(this.state.lang_list);
+      new_lang_list.push(null);
+      this.setState({lang_list: new_lang_list});
+    }
+
+    removeLanguage(index) {
+      const arr_length = this.state.lang_list.length;
+      if (index == 0) {
+        this.setState({
+	  lang_list: this.state.lang_list.slice(1, arr_length),
+	});
+      } else if (index == arr_length - 1) {
+        this.setState({
+	  lang_list: this.state.lang_list.slice(0, index),
+	});
+      } else {
+        this.setState({
+	  lang_list: this.state.lang_list.slice(0, index).concat(
+	      this.state.lang_list.slice(index + 1, arr_length)),
+	});
+      }
+    }
+
+    updateRepoTitle(lang, value) {
+      const new_titles = new Map(this.state.repo_titles);
+      new_titles.set(lang, value);
+      this.setState({repo_titles: new_titles});
+    }
+
+    updateLanguageSelection(index, event) {
+      if (this.state.lang_list.indexOf(event.target.value) >= 0) {
+        alert('That language is already in the list!');
+        return;
+      }
+      const new_lang_list = Array.from(this.state.lang_list);
+      new_lang_list[index] = event.target.value;
+      this.setState({lang_list: new_lang_list});
+    }
+
+    updateCustomMessage(config_key, lang, value) {
+      const new_messages = new Map(this.state.custom_messages);
+      new_messages.set(config_key, new Map(new_messages.get(config_key)));
+      new_messages.get(config_key).set(lang, value);
+      this.setState({custom_messages: new_messages});
+    }
+
+    getRepoTitleRow(index, lang) {
+      var deleteButton = e(
+          'button', {
+              onClick: () => this.removeLanguage(index),
+              type: 'button',
+          }, 'X');
+      var deleteCell = e('td', {key: 'deletecell'}, deleteButton);
+      const langSelectOptions =
+          [e('option', {key: 'none'}, 'Select a language')].concat(
+              LANGUAGE_EXONYMS_ARR.map(lang_opt => e(
+                  'option',
+                  {key: lang_opt[0], value: lang_opt[0]},
+                  lang_opt[1])));
+      var langSelect = e('select', {
+          name: "langlist__" + index,
+          value: lang == null ? "" : lang,
+          onChange: (e) => this.updateLanguageSelection(index, e),
+      }, langSelectOptions);
+      var langCell = e('td', {key: 'langcell'}, langSelect);
+      var titleField = e('input', {
+          type: 'text',
+          name: "repotitle__" + lang,
+	  onChange: (e) => this.updateRepoTitle(lang, e.target.value),
+          value: this.state.repo_titles.get(lang) == null ?
+              "" : this.state.repo_titles.get(lang),
+      }, null);
+      var titleCell = e('td', {key: 'titlecell'}, titleField);
+      return e('tr', {key: lang}, [
+        deleteCell,
+        langCell,
+        titleCell,
+      ]);
+    }
+
+    getRepoTitleTable() {
+      const rows = this.state.lang_list.map(
+          (lang, index) => this.getRepoTitleRow(index, lang));
+      return e('table', {key: 'repotitletable'}, e('tbody', null, rows));
+    }
+
+    getAddLanguageButton() {
+      return e('button', {
+          key: 'addlangbutton',
+          onClick: this.addLanguage,
+          type: 'button',
+      }, 'Add language');
+    }
+
+    getCustomMessageTableRow(config_key, lang, index) {
+      var langLabel = 'unselected';
+      if (lang != undefined) {
+        langLabel = LANGUAGE_EXONYMS_MAP.get(lang) + ' (' + lang + ')';
+      }
+      const messages = this.state.custom_messages.get(config_key);
+      return e('tr', {key: lang}, [
+        e('td', {key: 'label'}, langLabel),
+        e('td', {key: 'field'}, e('textarea', {
+          cols: 72,
+          name: "custommsg__" + config_key + "__" + lang,
+          value: messages.get(lang) == null ? "" : messages.get(lang),
+          onChange: (e) => this.updateCustomMessage(
+              config_key, lang, e.target.value),
+        })),
+      ]);
+    }
+
+    getCustomMessagesTable(config_key) {
+      const rows = this.state.lang_list.map(
+        (lang) => this.getCustomMessageTableRow(config_key, lang)
+      );
+      return e('div', {key: config_key}, [
+          e('p', {key: 'label'}, CUSTOM_MESSAGES_LABELS[config_key] + ':'),
+          e('table', {key: 'table'}, e('tbody', null, rows)),
+      ]);
+    }
+
+    getCustomMessagesTables() {
+      const tables = CUSTOM_MESSAGES_CONFIG_KEYS.map(
+	  config_key => this.getCustomMessagesTable(config_key));
+      return e('div', {key: 'custommsgstables'}, tables);
+    }
+
+    render() {
+      return e('fieldset', null, [
+          e('legend', {key: 'legend'}, 'Languages and text'),
+	  {% if category_permissions.everything_else %}
+	    this.getRepoTitleTable(),
+	    this.getAddLanguageButton(),
+          {% endif %}
+	  {% if category_permissions.custom_messages %}
+	    this.getCustomMessagesTables(),
+	  {% endif %}
+      ]);
+    }
+  }
+
+  function init() {
+    ReactDOM.render(
+        e(
+	    LanguagesFieldsetComponent,
+	    JSON.parse("{{ language_config_json|escapejs }}")),
+        document.querySelector('#languages_component_container'));
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+</script>
+
+<h2>Repository settings for {{ env.repo }}</h2>
+
+<form id="save_repo" method="post" class="admin">
+
+  <input type="hidden" name="xsrf_token" value="{{ xsrf_token }}" />
+
+  <div id="languages_component_container"></div>
+
+  <fieldset>
+    <legend>Activation mode</legend>
+
+    <div class="config">
+      <div class="option">
+        <input
+            type="radio" name="launch_status" value="staging"
+            id="launch_status_staging"
+            {% if view_config.launch_status == "staging" %}
+              checked
+            {% endif %}>
+        <label for="launch_status_staging">
+          Staging
+        </label>
+        <div class="note">
+          <div>
+            <strong>Use case:</strong> Keep a repository in this mode while
+            testing the repository before public announcement.
+          </div>
+          <div>
+            <strong>Effect:</strong> The repository is neither listed on
+            <a href="{{env.global_url}}" target="_blank">the home page</a> nor
+            <a href="{{env.global_url}}/feeds/repo" target="_blank">the
+            repository feed</a>. So only people who know the URL can discover
+            the repository. It is the same as "Activated" except for that.
+          </div>
+        </div>
+      </div>
+      <div class="option">
+        <input
+            type="radio" name="launch_status" value="activated"
+            id="launch_status_activated"
+            {% if view_config.launch_status == "activated" %}
+              checked
+            {% endif %}>
+        <label for="launch_status_activated">
+          Activated
+        </label>
+        <div class="note">
+          <div>
+            <strong>Use case:</strong> Keep a repository in this mode while the
+            repository is used by end users.
+          </div>
+          <div>
+            <strong>Effect:</strong> The repository is listed on
+            <a href="{{env.global_url}}" target="_blank">the home page</a> and
+            <a href="{{env.global_url}}/feeds/repo" target="_blank">the
+            repository feed</a>. So end users can discover the repository.
+          </div>
+        </div>
+      </div>
+      <div class="option">
+        <input
+            type="radio" name="launch_status" value="deactivated"
+            id="launch_status_deactivated"
+            {% if view_config.launch_status == "deactivated" %}
+              checked
+            {% endif %}>
+        <label for="launch_status_deactivated">
+          Deactivated
+        </label>
+        <div class="note">
+          <div>
+            <strong>Use case:</strong> Switch to this mode to deactivate the
+            repository.
+          </div>
+          <div>
+            <strong>Effect:</strong> Replaces content of all pages with the
+            deactivation message below. People cannot interact with the
+            repository either via web interface or API. The repository is
+            neither listed on
+            <a href="{{env.global_url}}" target="_blank">the home page</a> nor
+            <a href="{{env.global_url}}/feeds/repo" target="_blank">the
+            repository feed</a>.
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="config">
+      <label for="deactivation_message_html">
+        Deactivation message (HTML):</label>
+      <div class="response">
+        <textarea name="deactivation_message_html"
+            id="deactivation_message_html" rows=6 cols=80
+            >{{view_config.deactivation_message_html|default:""}}</textarea>
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>Data retention mode</legend>
+
+    <div class="config">
+      <div class="option">
+        <input type="radio" name="test_mode" value="true"
+          id="test_mode_true"
+          {{view_config.test_mode|yesno:"checked,"}}>
+        <label for="test_mode_true">
+          Test mode
+        </label>
+        <div class="note">
+          <div>
+            <strong>Use case:</strong> This mode is usually used for always-on
+            repository such as "japan" repository, while no crisis is
+            on-going.
+          </div>
+          <div>
+            <strong>Effect:</strong> In this mode, all records are deleted
+            about {{test_mode_min_age_hours}} hours after they are created,
+            regardless of their specified expiry date. We do this to clean up
+            spams, because it's not feasible to perform manual spam monitoring
+            all the time for always-on repositories.
+          </div>
+          <div>
+            <strong>Note:</strong> If you switch from real mode to
+            test mode, existing records that are more than
+            {{test_mode_min_age_hours}} old will soon be deleted.
+            Also note that (unlike regular deletions or expirations)
+            these deletions do not generate expiry notices
+            in the outgoing PFIF feeds,
+            so any clients that import test records into their own repositories
+            cannot be expected to delete them on the same short schedule.
+          </div>
+        </div>
+      </div>
+      <div class="option">
+        <input type="radio" name="test_mode" value="false"
+            id="test_mode_false"
+            {{view_config.test_mode|yesno:",checked"}}>
+        <label for="test_mode_false">
+          Real mode
+        </label>
+        <div class="note">
+          <div>
+            <strong>Use case:</strong> Use this mode while the repository is
+            actively used for a real crisis.
+          </div>
+          <div>
+            <strong>Effect:</strong> In this mode, records last until their
+            specified expiry date.
+          </div>
+          <div>
+            <strong>Note:</strong> If you switch from test mode to real mode,
+            any existing records are retained and will be treated as normal.
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </fieldset>
+
+  <fieldset>
+    <legend>General</legend>
+
+    <div class="config">
+      <div class="option">
+        <input type="radio" name="force_https" value="true"
+          id="force_https_true"
+          {{view_config.force_https|yesno:"checked,"}}>
+        <label for="force_https_true">
+          Force https
+        </label>
+        <div class="note">
+          Force all requests to this repo to be redirected through https.
+        </div>
+      </div>
+      <div class="option">
+        <input type="radio" name="force_https" value="false"
+            id="force_https_false"
+            {{view_config.force_https|yesno:",checked"}}>
+        <label for="force_https_false">
+          Allow http and https traffic
+        </label>
+        <div class="note">
+          Allow requests to this repo over http or https.
+        </div>
+      </div>
+    </div>
+
+    <div class="config">
+      <label for="keywords">
+        Keywords in all languages (keywords separated by commas):
+      </label>
+      <div class="response">
+        <textarea name="keywords" id="keywords" rows=4 cols=80
+          >{{view_config.keywords|default:""}}</textarea>
+      </div>
+    </div>
+
+  </fieldset>
+
+  <fieldset>
+    <legend>Forms</legend>
+
+    <div class="config">
+      <div class="option">
+        <input type="radio" name="use_family_name" value="true"
+          id="use_family_name_true"
+          {{view_config.use_family_name|yesno:"checked,"}}>
+        <label for="use_family_name_true">
+          Use both given and family name fields
+        </label>
+      </div>
+      <div class="option">
+        <input type="radio" name="use_family_name" value="false"
+            id="use_family_name_false"
+            {{view_config.use_family_name|yesno:",checked"}}>
+        <label for="use_family_name_false">
+          Use only a single name field
+        </label>
+      </div>
+    </div>
+
+    <div class="config">
+      <div class="option">
+        <input type="radio" name="family_name_first" value="false"
+            id="family_name_first_false"
+            {{view_config.family_name_first|yesno:",checked"}}>
+        <label for="family_name_first_false">
+          Show given name first, then family name
+        </label>
+      </div>
+      <div class="option">
+        <input type="radio" name="family_name_first" value="true"
+            id="family_name_first_true"
+            {{view_config.family_name_first|yesno:"checked,"}}>
+        <label for="family_name_first_true">
+          Show family name first, then given name
+        </label>
+      </div>
+    </div>
+
+    <div class="config">
+      <div class="option">
+        <input type="radio" name="use_alternate_names" value="false"
+            id="use_alternate_names_false"
+            {{view_config.use_alternate_names|yesno:",checked"}}>
+        <label for="use_alternate_names_false">
+          Don't use alternate name fields (e.g. readings of Japanese names)
+        </label>
+      </div>
+      <div class="option">
+        <input type="radio" name="use_alternate_names" value="true"
+            id="use_alternate_names_true"
+            {{view_config.use_alternate_names|yesno:"checked,"}}>
+        <label for="use_alternate_names_true">
+          Use alternate name fields (e.g. readings of Japanese names)
+        </label>
+      </div>
+    </div>
+
+    <div class="config">
+      <div class="option">
+        <input type="radio" name="use_postal_code" value="true"
+            id="use_postal_code_true"
+            {{view_config.use_postal_code|yesno:"checked,"}}>
+        <label for="use_postal_code_true">
+          Use the postal code field
+        </label>
+      </div>
+      <div class="option">
+        <input type="radio" name="use_postal_code" value="false"
+            id="use_postal_code_false"
+            {{view_config.use_postal_code|yesno:",checked"}}>
+        <label for="use_postal_code_false">
+          Hide the postal code field
+        </label>
+      </div>
+    </div>
+
+    <div class="config">
+      <div class="option">
+        <input type="radio" name="allow_believed_dead_via_ui" value="true"
+            id="allow_believed_dead_via_ui"
+            {{view_config.allow_believed_dead_via_ui|yesno:"checked,"}}>
+        <label for="allow_believed_dead_via_ui_true">
+          Allow users to post notes with status
+          "I have received information that this person is dead".
+        </label>
+      </div>
+      <div class="option">
+        <input type="radio" name="allow_believed_dead_via_ui" value="false"
+            id="allow_believed_dead_via_ui"
+            {{view_config.allow_believed_dead_via_ui|yesno:",checked"}}>
+        <label for="allow_believed_dead_via_ui_false">
+          Don't allow users to post notes with status
+          "I have received information that this person is dead".
+        </label>
+      </div>
+    </div>
+
+
+    <div class="config">
+      <div class="option">
+        <input type="radio" name="min_query_word_length" value="1"
+            id="min_query_word_length_1"
+            {% ifequal view_config.min_query_word_length 1 %}
+              checked
+            {% endifequal %}
+        >
+        <label for="min_query_word_length_1">
+          Accept queries with only 1 character
+        </label>
+      </div>
+      <div class="option">
+        <input type="radio" name="min_query_word_length" value="2"
+            id="min_query_word_length_2"
+            {% ifnotequal view_config.min_query_word_length 1 %}
+              checked
+            {% endifnotequal %}
+        >
+        <label for="min_query_word_length_2">
+          Require query words to have at least 2 characters
+        </label>
+      </div>
+    </div>
+
+    <div class="config">
+      <div class="option">
+        <input type="radio" name="show_profile_entry" value="true"
+            id="show_profile_entry_true"
+            {{view_config.show_profile_entry|yesno:"checked,"}}>
+        <label for="show_profile_entry_true">
+          Show input fields for profile pages
+        </label>
+      </div>
+      <div class="option">
+        <input type="radio" name="show_profile_entry" value="false"
+            id="show_profile_entry_false"
+            {{view_config.show_profile_entry|yesno:",checked"}}>
+        <label for="show_profile_entry_false">
+          Hide input fields for profile pages
+        </label>
+      </div>
+    </div>
+
+    <div class="config">
+      <label for="profile_websites">External websites to show as the
+      default options for profile pages (JSON list of dictionaries sorted in the
+      order of display) <a href="javascript:insert_profile_websites_example()"
+      >click to insert an example</a>:</label>
+      <div class="response">
+        <textarea name="profile_websites" id="profile_websites" rows=3 cols=80
+          >{{view_config_json.profile_websites|default:"[]"}}</textarea>
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>Map options</legend>
+
+    <div class="config">
+      <label for="map_default_zoom">Default zoom level (integer):</label>
+      <div class="response">
+        <input name="map_default_zoom" id="map_default_zoom" size=24
+            value="{{view_config_json.map_default_zoom}}">
+      </div>
+    </div>
+
+    <div class="config">
+      <label for="map_default_center">
+        Default center [latitude north, longitude east]:
+      </label>
+      <div class="response">
+        <input name="map_default_center" id="map_default_center" size=24
+            value="{{view_config_json.map_default_center}}">
+      </div>
+    </div>
+
+    <div class="config">
+      <label for="map_default_center">
+        Map size in pixels [width, height]:
+      </label>
+      <div class="response">
+        <input name="map_size_pixels" id="map_size_pixels" size=24
+            value="{{view_config_json.map_size_pixels}}">
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>Time zones</legend>
+
+    <p>These are used to display timestamps of person records and notes.</p>
+
+    <div class="config">
+      <label for="time_zone_offset">Time zone offset (-12 to 14):</label>
+      <div class="response">
+        UTC +
+        <input type="number" step="any"
+            name="time_zone_offset" id="time_zone_offset"
+            value="{{view_config_json.time_zone_offset}}">
+      </div>
+    </div>
+
+    <div class="config">
+      <label for="time_zone_abbreviation">
+        Time zone name (in 3 letters e.g., JST):
+      </label>
+      <div class="response">
+        <input name="time_zone_abbreviation" id="time_zone_abbreviation" size=3
+            value="{{view_config.time_zone_abbreviation}}">
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>Access control</legend>
+
+    <div class="config">
+      <div class="option">
+        <input type="radio" name="search_auth_key_required" value="false"
+            id="search_auth_key_required_false"
+            {{view_config.search_auth_key_required|yesno:",checked"}}>
+        <label for="search_auth_key_required_false">
+          Allow anyone to use the search API
+        </label>
+      </div>
+      <div class="option">
+        <input type="radio" name="search_auth_key_required" value="true"
+            id="search_auth_key_required_true"
+            {{view_config.search_auth_key_required|yesno:"checked,"}}>
+        <label for="search_auth_key_required_true">
+          Require an authorization key to use the search API
+        </label>
+      </div>
+    </div>
+
+    <div class="config">
+      <div class="option">
+        <input type="radio" name="read_auth_key_required" value="false"
+            id="read_auth_key_required_false"
+            {{view_config.read_auth_key_required|yesno:",checked"}}>
+        <label for="read_auth_key_required_false">
+          Allow anyone to use the read API and read the feeds
+        </label>
+      </div>
+      <div class="option">
+        <input type="radio" name="read_auth_key_required" value="true"
+               id="read_auth_key_required_true"
+               {{view_config.read_auth_key_required|yesno:"checked,"}}>
+        <label for="read_auth_key_required_true">
+          Require an authorization key to use the read API and read the feeds
+        </label>
+      </div>
+    </div>
+
+  </fieldset>
+
+  <fieldset>
+    <legend>Zero-rating</legend>
+
+    <div class="config">
+      <p>Sometimes mobile carriers "zero-rate" our site so that users can see our site without normal data access fee. It is often applied per domain name. But when users access Person Finder, it also loads resource from other domains e.g., Google Maps, Google Analytics, Google Translate by default.</p>
+
+      <p>If you enable zero-rating mode, it disables all those features which loads resource from external domains, so that the users from the carriers can access Person Finder completely for free.</p>
+
+      <p><b>CAVEAT:</b> This mode has not been implemented completely, and it still loads some resource from other domains even in zero-rating mode:</p>
+      <ul>
+        <li><a href="https://github.com/google/personfinder/issues/239">reCAPTCHA</a></li>
+      </ul>
+
+      <div class="option">
+        <input type="radio" name="zero_rating_mode" value="false"
+            id="zero_rating_mode_false"
+            {{view_config.zero_rating_mode|yesno:",checked"}}>
+        <label for="zero_rating_mode_false">
+          Disable zero-rating mode: Enable all features which loads resource from external domains.
+        </label>
+      </div>
+      <div class="option">
+        <input type="radio" name="zero_rating_mode" value="true"
+            id="zero_rating_mode_true"
+            {{view_config.zero_rating_mode|yesno:"checked,"}}>
+        <label for="zero_rating_mode_true">
+          Enable zero-rating mode: Disable all features which loads resource from external domains.
+        </label>
+      </div>
+    </div>
+
+  </fieldset>
+
+  <fieldset>
+    <legend> Spam detection </legend>
+    <div class="config">
+      <label for="bad_words">
+        Bad words in all languages (words separated by commas):
+      </label>
+      <div class="response">
+        <textarea name="bad_words" id="bad_words" rows=4 cols=80
+          >{{view_config.bad_words|default:""}}</textarea>
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <legend>SMS</legend>
+    <div class="config">
+      Go to <a href="../global/admin">Global settings</a> to configure SMS
+      numbers mapping.
+    </div>
+  </fieldset>
+
+  <p>
+    <input type="submit" value="Save these settings">
+  </p>
+</form>
+
+{% endblock %}

--- a/app/resources/css-default.template
+++ b/app/resources/css-default.template
@@ -1088,6 +1088,10 @@ form.admin .config .note {
   color: #f00;
 }
 
+#save_repo table td {
+  vertical-align: top;
+}
+
 /* Review page */
 
 table.review {

--- a/app/urls.py
+++ b/app/urls.py
@@ -24,6 +24,7 @@ import views.admin.api_keys
 import views.admin.create_repo
 import views.admin.dashboard
 import views.admin.delete_record
+import views.admin.repo_index
 import views.admin.review
 import views.admin.statistics
 import views.meta.sitemap
@@ -44,6 +45,8 @@ _BASE_URL_PATTERNS = [
      views.admin.dashboard.AdminDashboardView.as_view),
     ('admin_delete-record', r'(?P<repo>[^\/]+)/admin/delete_record/?',
      views.admin.delete_record.AdminDeleteRecordView.as_view),
+    ('admin_repo_index', r'(?P<repo>[^\/]+)/admin/?',
+     views.admin.repo_index.AdminRepoIndexView.as_view),
     ('admin_review', r'(?P<repo>[^\/]+)/admin/review/?',
      views.admin.review.AdminReviewView.as_view),
     ('admin_statistics', r'global/admin/statistics/?',

--- a/app/utils.py
+++ b/app/utils.py
@@ -203,6 +203,10 @@ def validate_int(string):
     return string and int(strip(string))
 
 
+def validate_float(string):
+    return string and float(strip(string))
+
+
 def validate_sex(string):
     """Validates the 'sex' parameter, returning a canonical value or ''."""
     if string:

--- a/app/views/admin/repo_index.py
+++ b/app/views/admin/repo_index.py
@@ -296,10 +296,13 @@ class AdminRepoIndexView(views.admin.base.AdminBaseView):
     def _set_data_retention_config(self):
         if self._category_permissions['everything_else']:
             if self._repo_obj.test_mode != self.params.test_mode:
+                # TODO(nworden): stop setting test_mode in the config once we've
+                # switched to using the field on the Repo object exclusively.
                 self._repo_obj.test_mode = self.params.test_mode
                 self._repo_obj.put()
                 config.set_for_repo(
                     self.env.repo,
+                    test_mode=self.params.test_mode,
                     updated_date=utils.get_utcnow_timestamp())
 
     def _set_keywords_config(self):

--- a/app/views/admin/repo_index.py
+++ b/app/views/admin/repo_index.py
@@ -101,6 +101,8 @@ class AdminRepoIndexView(views.admin.base.AdminBaseView):
         self._category_permissions = self._get_category_permissions()
 
     def _get_category_permissions(self):
+        if not self.env.user_admin_permission:
+            return {}
         return {
             key: self.env.user_admin_permission.compare_level_to(min_level) >= 0
             for key, min_level in

--- a/app/views/admin/repo_index.py
+++ b/app/views/admin/repo_index.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """The admin custom messages page."""
 
-import django.shortcuts
 import simplejson
 
 import config
@@ -52,45 +51,46 @@ class AdminRepoIndexView(views.admin.base.AdminBaseView):
 
     def _read_params(self, request):
         if request.method == 'POST':
-          lang_list = []
-          self.params.repo_titles = {}
-          self.params.custom_messages = {}
-          for key, value in request.POST.items():
-              key_parts = key.split('__')
-              if key_parts[0] == 'langlist':
-                  lang_list.append((int(key_parts[1]), value))
-              elif key_parts[0] == 'repotitle':
-                  self.params.repo_titles[key_parts[1]] = value
-              elif key_parts[0] == 'custommsg':
-                  messages = self.params.custom_messages.setdefault(
-                      key_parts[1], {})
-                  messages[key_parts[2]] = value
-          self.params.lang_list = [
-              value for _, value in sorted(lang_list, key=lambda kv : kv[0])]
-          self.params.read_values(
-              post_params={
-                  'activation_status': utils.validate_int,
-                  'allow_believed_dead_via_ui': utils.validate_checkbox_as_bool,
-                  'bad_words': utils.strip,
-                  'deactivation_message_html': utils.strip,
-                  'family_name_first': utils.validate_checkbox_as_bool,
-                  'keywords': utils.strip,
-                  'map_default_center': utils.strip,
-                  'map_default_zoom': utils.validate_int,
-                  'map_size_pixels': utils.strip,
-                  'min_query_word_length': utils.validate_int,
-                  'profile_websites': utils.strip,
-                  'read_auth_key_required': utils.validate_checkbox_as_bool,
-                  'search_auth_key_required': utils.validate_checkbox_as_bool,
-                  'show_profile_entry': utils.validate_checkbox_as_bool,
-                  'test_mode': utils.validate_checkbox_as_bool,
-                  'time_zone_offset': utils.validate_float,
-                  'time_zone_abbreviation': utils.strip,
-                  'use_alternate_names': utils.validate_checkbox_as_bool,
-                  'use_family_name': utils.validate_checkbox_as_bool,
-                  'use_postal_code': utils.validate_checkbox_as_bool,
-                  'zero_rating_mode': utils.validate_checkbox_as_bool,
-              })
+            lang_list = []
+            self.params.repo_titles = {}
+            self.params.custom_messages = {}
+            for key, value in request.POST.items():
+                key_parts = key.split('__')
+                if key_parts[0] == 'langlist':
+                    lang_list.append((int(key_parts[1]), value))
+                elif key_parts[0] == 'repotitle':
+                    self.params.repo_titles[key_parts[1]] = value
+                elif key_parts[0] == 'custommsg':
+                    messages = self.params.custom_messages.setdefault(
+                        key_parts[1], {})
+                    messages[key_parts[2]] = value
+            self.params.lang_list = [
+                value for _, value in sorted(lang_list, key=lambda kv: kv[0])]
+            self.params.read_values(
+                post_params={
+                    'activation_status': utils.validate_int,
+                    'allow_believed_dead_via_ui':
+                    utils.validate_checkbox_as_bool,
+                    'bad_words': utils.strip,
+                    'deactivation_message_html': utils.strip,
+                    'family_name_first': utils.validate_checkbox_as_bool,
+                    'keywords': utils.strip,
+                    'map_default_center': utils.strip,
+                    'map_default_zoom': utils.validate_int,
+                    'map_size_pixels': utils.strip,
+                    'min_query_word_length': utils.validate_int,
+                    'profile_websites': utils.strip,
+                    'read_auth_key_required': utils.validate_checkbox_as_bool,
+                    'search_auth_key_required': utils.validate_checkbox_as_bool,
+                    'show_profile_entry': utils.validate_checkbox_as_bool,
+                    'test_mode': utils.validate_checkbox_as_bool,
+                    'time_zone_offset': utils.validate_float,
+                    'time_zone_abbreviation': utils.strip,
+                    'use_alternate_names': utils.validate_checkbox_as_bool,
+                    'use_family_name': utils.validate_checkbox_as_bool,
+                    'use_postal_code': utils.validate_checkbox_as_bool,
+                    'zero_rating_mode': utils.validate_checkbox_as_bool,
+                })
 
     def setup(self, request, *args, **kwargs):
         """See docs on BaseView.setup."""
@@ -111,7 +111,7 @@ class AdminRepoIndexView(views.admin.base.AdminBaseView):
 
     def _render_form(self):
         language_exonyms = sorted(list(const.LANGUAGE_EXONYMS.items()),
-                                  key= lambda lang: lang[1])
+                                  key=lambda lang: lang[1])
         encoder = simplejson.encoder.JSONEncoder(ensure_ascii=False)
         return self.render(
             'admin_repo_index.html',
@@ -268,7 +268,7 @@ class AdminRepoIndexView(views.admin.base.AdminBaseView):
             try:
                 for field_name in AdminRepoIndexView._JSON_FIELDS:
                     simplejson.loads(self.params.get(field_name))
-            except:
+            except simplejson.JSONDecodeError:
                 return self.error(400, 'Invalid JSON value.')
 
     def _set_language_config(self):
@@ -283,7 +283,8 @@ class AdminRepoIndexView(views.admin.base.AdminBaseView):
 
     def _set_activation_config(self):
         if self._category_permissions['everything_else']:
-            if self._repo_obj.activation_status != self.params.activation_status:
+            if (self._repo_obj.activation_status !=
+                    self.params.activation_status):
                 self._repo_obj.activation_status = self.params.activation_status
                 self._repo_obj.put()
                 config.set_for_repo(

--- a/app/views/admin/repo_index.py
+++ b/app/views/admin/repo_index.py
@@ -283,16 +283,24 @@ class AdminRepoIndexView(views.admin.base.AdminBaseView):
 
     def _set_activation_config(self):
         if self._category_permissions['everything_else']:
-            self._repo_obj.activation_status = self.params.activation_status
-            self._repo_obj.put()
+            if self._repo_obj.activation_status != self.params.activation_status:
+                self._repo_obj.activation_status = self.params.activation_status
+                self._repo_obj.put()
+                config.set_for_repo(
+                    self.env.repo,
+                    updated_date=utils.get_utcnow_timestamp())
             config.set_for_repo(
                 self.env.repo,
                 deactivation_message_html=self.params.deactivation_message_html)
 
     def _set_data_retention_config(self):
         if self._category_permissions['everything_else']:
-            self._repo_obj.test_mode = self.params.test_mode
-            self._repo_obj.put()
+            if self._repo_obj.test_mode != self.params.test_mode:
+                self._repo_obj.test_mode = self.params.test_mode
+                self._repo_obj.put()
+                config.set_for_repo(
+                    self.env.repo,
+                    updated_date=utils.get_utcnow_timestamp())
 
     def _set_keywords_config(self):
         if self._category_permissions['everything_else']:

--- a/app/views/admin/repo_index.py
+++ b/app/views/admin/repo_index.py
@@ -267,6 +267,8 @@ class AdminRepoIndexView(views.admin.base.AdminBaseView):
             # category.
             try:
                 for field_name in AdminRepoIndexView._JSON_FIELDS:
+                    if not self.params.get(field_name):
+                        return self.error(400, 'Missing JSON value.')
                     simplejson.loads(self.params.get(field_name))
             except simplejson.JSONDecodeError:
                 return self.error(400, 'Invalid JSON value.')

--- a/app/views/admin/repo_index.py
+++ b/app/views/admin/repo_index.py
@@ -1,0 +1,91 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The admin custom messages page."""
+
+import django.shortcuts
+import simplejson
+
+import config
+import const
+import model
+import modelmodule.admin_acls as admin_acls_model
+import utils
+import views.admin.base
+
+
+class AdminRepoIndexView(views.admin.base.AdminBaseView):
+    """The admin repo index view."""
+
+    ACTION_ID = 'admin/repo-index'
+
+    _CATEGORY_PERMISSION_LEVELS = {
+        'custom_messages':
+        admin_acls_model.AdminPermission.AccessLevel.MANAGER,
+        'everything_else':
+        admin_acls_model.AdminPermission.AccessLevel.SUPERADMIN,
+    }
+
+    _CUSTOM_MESSAGES_CONFIG_KEYS = [
+        'start_page_custom_htmls',
+        'results_page_custom_htmls',
+        'view_page_custom_htmls',
+        'seek_query_form_custom_htmls',
+        'footer_custom_htmls',
+    ]
+
+    def _get_category_permissions(self):
+        return {
+            key: self.env.user_admin_permission.compare_level_to(min_level) >= 0
+            for key, min_level in
+            AdminRepoIndexView._CATEGORY_PERMISSION_LEVELS.items()
+        }
+
+    @views.admin.base.enforce_manager_admin_level
+    def get(self, request, *args, **kwargs):
+        """Serves GET requests."""
+        del request, args, kwargs  # Unused.
+        language_exonyms = sorted(list(const.LANGUAGE_EXONYMS.items()),
+                                  key= lambda lang: lang[1])
+        category_permissions = self._get_category_permissions()
+        language_config = self._get_language_config(category_permissions)
+        encoder = simplejson.encoder.JSONEncoder(ensure_ascii=False)
+        return self.render(
+            'admin_repo_index.html',
+            category_permissions=category_permissions,
+            language_exonyms_json=encoder.encode(language_exonyms),
+            language_config_json=encoder.encode(language_config),
+            xsrf_token=self.xsrf_tool.generate_token(
+                self.env.user.user_id(), self.ACTION_ID))
+
+    def _get_language_config(self, category_permissions):
+        language_config = {}
+        language_config['lang_list'] = self.env.config.get(
+            'language_menu_options', [])
+        if category_permissions['everything_else']:
+            language_config['repo_titles'] = self.env.config.get(
+                'repo_titles', {})
+        if category_permissions['custom_messages']:
+            custom_messages = {}
+            for config_key in AdminRepoIndexView._CUSTOM_MESSAGES_CONFIG_KEYS:
+                custom_messages[config_key] = self.env.config.get(
+                    config_key, {})
+            language_config['custom_messages'] = custom_messages
+        return language_config
+
+    @views.admin.base.enforce_manager_admin_level
+    def post(self, request, *args, **kwargs):
+        """Serves POST requests, updating the repo's configuration."""
+        del request, args, kwargs  # Unused.
+        self.enforce_xsrf(self.ACTION_ID)
+        category_permissions = self._get_category_permissions()

--- a/app/views/admin/repo_index.py
+++ b/app/views/admin/repo_index.py
@@ -269,7 +269,7 @@ class AdminRepoIndexView(views.admin.base.AdminBaseView):
                 for field_name in AdminRepoIndexView._JSON_FIELDS:
                     simplejson.loads(self.params.get(field_name))
             except:
-                return self.error(400, 'Invalid profile_websites value.')
+                return self.error(400, 'Invalid JSON value.')
 
     def _set_language_config(self):
         values = {}

--- a/tests/server_test_cases/config_tests.py
+++ b/tests/server_test_cases/config_tests.py
@@ -178,7 +178,7 @@ class ConfigTests(ServerTestsBase):
             assert not doc.cssselect('table')
             assert not doc.cssselect('td')
 
-    def test_the_test_mode(self):
+    def test_non_test_mode(self):
         HTML_PATHS = ['', '/query', '/results', '/create', '/view',
                       '/multiview', '/reveal', '/photo', '/embed', '/delete']
 
@@ -187,6 +187,10 @@ class ConfigTests(ServerTestsBase):
             doc = self.go('/haiti%s' % path)
             assert 'currently in test mode' not in doc.content, \
                 'path: %s, content: %s' % (path, doc.content)
+
+    def test_the_test_mode(self):
+        HTML_PATHS = ['', '/query', '/results', '/create', '/view',
+                      '/multiview', '/reveal', '/photo', '/embed', '/delete']
 
         # Enable test-mode for an existing repository.
         config.set_for_repo('haiti', test_mode=True)

--- a/tests/server_test_cases/config_tests.py
+++ b/tests/server_test_cases/config_tests.py
@@ -157,18 +157,13 @@ class ConfigTests(ServerTestsBase):
         assert config.get('unreviewed_notes_threshold') == 100
 
     def test_deactivation(self):
-        cfg = config.Configuration('haiti')
-        old_updated_date = cfg.updated_date
-        self.advance_utcnow(seconds=1)
-
         # Deactivate an existing repository.
+        repo_obj = Repo.get('haiti')
+        repo_obj.activation_status=Repo.ActivationStatus.DEACTIVATED
+        repo_obj.put()
         config.set_for_repo(
             'haiti',
-            activation_status=Repo.ActivationStatus.DEACTIVATED,
             deactivation_message_html='de<i>acti</i>vated')
-
-        # Changing 'launch_status' renews updated_date.
-        assert config.get_for_repo('haiti', 'updated_date') != old_updated_date
 
         # Ensure all paths listed in app.yaml are inaccessible, except /admin.
         for path in ['', '/query', '/results', '/create', '/view',
@@ -193,17 +188,8 @@ class ConfigTests(ServerTestsBase):
             assert 'currently in test mode' not in doc.content, \
                 'path: %s, content: %s' % (path, doc.content)
 
-        cfg = config.Configuration('haiti')
-        old_updated_date = cfg.updated_date
-        self.advance_utcnow(seconds=1)
-
         # Enable test-mode for an existing repository.
         config.set_for_repo('haiti', test_mode=True)
-
-        cfg = config.Configuration('haiti')
-        assert cfg.test_mode
-        # Changing 'test_mode' renews updated_date.
-        assert cfg.updated_date != old_updated_date
 
         # Ensure all HTML pages show the test mode message.
         for path in HTML_PATHS:

--- a/tests/server_test_cases/config_tests.py
+++ b/tests/server_test_cases/config_tests.py
@@ -119,124 +119,6 @@ class ConfigTests(ServerTestsBase):
         cfg = config.Configuration('foo')
         assert cfg.get('unknown_key', 'default_value') == 'default_value'
 
-    def test_repo_admin_page(self):
-        Repo(key_name='xyz').put()
-        doc = self.go_as_admin('/xyz/admin')
-        # Change some settings for the new repository.
-        settings_form = doc.cssselect_one('form#save_repo')
-        doc = self.s.submit(settings_form,
-            launch_status='activated',
-            test_mode='true',
-            language_menu_options='["no"]',
-            repo_titles='{"no": "Jordskjelv"}',
-            keywords='foo, bar',
-            use_family_name='false',
-            family_name_first='false',
-            use_alternate_names='false',
-            use_postal_code='false',
-            allow_believed_dead_via_ui='false',
-            min_query_word_length='1',
-            show_profile_entry='false',
-            profile_websites='["http://abc"]',
-            map_default_zoom='6',
-            map_default_center='[4, 5]',
-            map_size_pixels='[300, 300]',
-            read_auth_key_required='false',
-            start_page_custom_htmls='{"no": "start page message"}',
-            results_page_custom_htmls='{"no": "results page message"}',
-            view_page_custom_htmls='{"no": "view page message"}',
-            seek_query_form_custom_htmls='{"no": "query form message"}',
-            footer_custom_htmls='{"no": "footer message"}',
-            bad_words = 'bad, word',
-            force_https = 'false',
-            time_zone_offset = '9'
-        )
-        self.assertEquals(self.s.status, 200)
-        repo = Repo.get_by_key_name('xyz')
-        assert repo.activation_status == Repo.ActivationStatus.ACTIVE
-        assert repo.test_mode
-        cfg = config.Configuration('xyz')
-        self.assertEquals(cfg.language_menu_options, ['no'])
-        assert cfg.repo_titles == {'no': 'Jordskjelv'}
-        assert cfg.keywords == 'foo, bar'
-        assert not cfg.use_family_name
-        assert not cfg.family_name_first
-        assert not cfg.use_alternate_names
-        assert not cfg.use_postal_code
-        assert not cfg.allow_believed_dead_via_ui
-        assert cfg.min_query_word_length == 1
-        assert not cfg.show_profile_entry
-        assert cfg.profile_websites == ['http://abc']
-        assert cfg.map_default_zoom == 6
-        assert cfg.map_default_center == [4, 5]
-        assert cfg.map_size_pixels == [300, 300]
-        assert not cfg.read_auth_key_required
-        assert cfg.bad_words == 'bad, word'
-        assert not cfg.force_https
-
-        old_updated_date = cfg.updated_date
-        self.advance_utcnow(seconds=1)
-
-        # Change settings again and make sure they took effect.
-        settings_form = doc.cssselect_one('form#save_repo')
-        doc = self.s.submit(settings_form,
-            language_menu_options='["nl"]',
-            repo_titles='{"nl": "Aardbeving"}',
-            keywords='spam, ham',
-            use_family_name='true',
-            family_name_first='true',
-            use_alternate_names='true',
-            use_postal_code='true',
-            allow_believed_dead_via_ui='true',
-            min_query_word_length='2',
-            show_profile_entry='true',
-            profile_websites='["http://xyz"]',
-            map_default_zoom='7',
-            map_default_center='[-3, -7]',
-            map_size_pixels='[123, 456]',
-            read_auth_key_required='true',
-            start_page_custom_htmls='{"nl": "start page message"}',
-            results_page_custom_htmls='{"nl": "results page message"}',
-            view_page_custom_htmls='{"nl": "view page message"}',
-            seek_query_form_custom_htmls='{"nl": "query form message"}',
-            footer_custom_htmls='{"no": "footer message"}',
-            bad_words = 'foo, bar',
-            force_https = 'true'
-        )
-
-        cfg = config.Configuration('xyz')
-        assert cfg.language_menu_options == ['nl']
-        assert cfg.repo_titles == {'nl': 'Aardbeving'}
-        assert cfg.keywords == 'spam, ham'
-        assert cfg.use_family_name
-        assert cfg.family_name_first
-        assert cfg.use_alternate_names
-        assert cfg.use_postal_code
-        assert cfg.allow_believed_dead_via_ui
-        assert cfg.min_query_word_length == 2
-        assert cfg.show_profile_entry
-        assert cfg.profile_websites == ['http://xyz']
-        assert cfg.map_default_zoom == 7
-        assert cfg.map_default_center == [-3, -7]
-        assert cfg.map_size_pixels == [123, 456]
-        assert cfg.read_auth_key_required
-        assert cfg.bad_words == 'foo, bar'
-        assert cfg.force_https
-        # Changing configs other than 'launch_status' or 'test_mode' does not
-        # renew 'updated_date'.
-        assert cfg.updated_date == old_updated_date
-
-        # Verifies that there is a javascript constant with languages in it
-        # (for the dropdown); thus, a language that is NOT used but IS
-        # supported should appear
-        assert 'bg' in doc.content
-        assert 'Bulgarian' in doc.content
-
-        # Verifies that there is a javascript constant with the previously
-        # saved languages and titles in it
-        assert 'nl' in doc.content
-        assert 'Aardbeving' in doc.content
-
     def test_global_admin_page(self):
         # Load the global administration page.
         doc = self.go_as_admin('/global/admin')
@@ -275,35 +157,18 @@ class ConfigTests(ServerTestsBase):
         assert config.get('unreviewed_notes_threshold') == 100
 
     def test_deactivation(self):
-        # Load the administration page.
-        doc = self.go_as_admin('/haiti/admin')
-        assert self.s.status == 200
-
         cfg = config.Configuration('haiti')
         old_updated_date = cfg.updated_date
         self.advance_utcnow(seconds=1)
 
         # Deactivate an existing repository.
-        settings_form = doc.cssselect_one('form#save_repo')
-        doc = self.s.submit(settings_form,
-            language_menu_options='["en"]',
-            repo_titles='{"en": "Foo"}',
-            keywords='foo, bar',
-            profile_websites='[]',
-            launch_status='deactivated',
-            deactivation_message_html='de<i>acti</i>vated',
-            start_page_custom_htmls='{"en": "start page message"}',
-            results_page_custom_htmls='{"en": "results page message"}',
-            view_page_custom_htmls='{"en": "view page message"}',
-            seek_query_form_custom_htmls='{"en": "query form message"}',
-            footer_custom_htmls='{"no": "footer message"}',
-        )
+        config.set_for_repo(
+            'haiti',
+            activation_status=Repo.ActivationStatus.DEACTIVATED,
+            deactivation_message_html='de<i>acti</i>vated')
 
-        cfg = config.Configuration('haiti')
-        assert cfg.deactivated
-        assert cfg.deactivation_message_html == 'de<i>acti</i>vated'
         # Changing 'launch_status' renews updated_date.
-        assert cfg.updated_date != old_updated_date
+        assert config.get_for_repo('haiti', 'updated_date') != old_updated_date
 
         # Ensure all paths listed in app.yaml are inaccessible, except /admin.
         for path in ['', '/query', '/results', '/create', '/view',
@@ -328,26 +193,12 @@ class ConfigTests(ServerTestsBase):
             assert 'currently in test mode' not in doc.content, \
                 'path: %s, content: %s' % (path, doc.content)
 
-        # Load the administration page.
-        doc = self.go_as_admin('/haiti/admin')
-        assert self.s.status == 200
-
         cfg = config.Configuration('haiti')
         old_updated_date = cfg.updated_date
         self.advance_utcnow(seconds=1)
 
         # Enable test-mode for an existing repository.
-        settings_form = doc.cssselect_one('form#save_repo')
-        doc = self.s.submit(settings_form,
-            language_menu_options='["en"]',
-            repo_titles='{"en": "Foo"}',
-            test_mode='true',
-            profile_websites='[]',
-            start_page_custom_htmls='{"en": "start page message"}',
-            results_page_custom_htmls='{"en": "results page message"}',
-            view_page_custom_htmls='{"en": "view page message"}',
-            seek_query_form_custom_htmls='{"en": "query form message"}',
-            footer_custom_htmls='{"en": "footer message"}')
+        config.set_for_repo('haiti', test_mode=True)
 
         cfg = config.Configuration('haiti')
         assert cfg.test_mode
@@ -361,51 +212,28 @@ class ConfigTests(ServerTestsBase):
                 'path: %s, content: %s' % (path, doc.content)
 
     def test_custom_messages(self):
-        # Load the administration page.
-        doc = self.go_as_admin('/haiti/admin')
-        assert self.s.status == 200
-
-        # Edit the custom text fields
-        settings_form = doc.cssselect_one('form#save_repo')
-        doc = self.s.submit(settings_form,
-            language_menu_options='["en"]',
-            repo_titles='{"en": "Foo"}',
+        config.set_for_repo(
+            'haiti',
+            language_menu_options=['en'],
+            repo_titles={'en': 'Foo'},
             keywords='foo, bar',
             profile_websites='[]',
             start_page_custom_htmls=
-                '{"en": "<b>English</b> start page message",'
-                ' "fr": "<b>French</b> start page message"}',
+                {'en': '<b>English</b> start page message',
+                 'fr': '<b>French</b> start page message'},
             results_page_custom_htmls=
-                '{"en": "<b>English</b> results page message",'
-                ' "fr": "<b>French</b> results page message"}',
+                {'en': '<b>English</b> results page message',
+                 'fr': '<b>French</b> results page message'},
             view_page_custom_htmls=
-                '{"en": "<b>English</b> view page message",'
-                ' "fr": "<b>French</b> view page message"}',
+                {'en': '<b>English</b> view page message',
+                 'fr': '<b>French</b> view page message'},
             seek_query_form_custom_htmls=
-                '{"en": "<b>English</b> query form message",'
-                ' "fr": "<b>French</b> query form message"}',
+                {'en': '<b>English</b> query form message',
+                 'fr': '<b>French</b> query form message'},
             footer_custom_htmls=
-                '{"en": "<b>English</b> footer message",'
-                ' "fr": "<b>French</b> footer message"}',
+                {'en': '<b>English</b> footer message',
+                 'fr': '<b>French</b> footer message'},
         )
-        assert self.s.status == 200
-
-        cfg = config.Configuration('haiti')
-        assert cfg.start_page_custom_htmls == \
-            {'en': '<b>English</b> start page message',
-             'fr': '<b>French</b> start page message'}
-        assert cfg.results_page_custom_htmls == \
-            {'en': '<b>English</b> results page message',
-             'fr': '<b>French</b> results page message'}
-        assert cfg.view_page_custom_htmls == \
-            {'en': '<b>English</b> view page message',
-             'fr': '<b>French</b> view page message'}
-        assert cfg.seek_query_form_custom_htmls == \
-            {'en': '<b>English</b> query form message',
-             'fr': '<b>French</b> query form message'}
-        assert cfg.footer_custom_htmls == \
-            {'en': '<b>English</b> footer message',
-             'fr': '<b>French</b> footer message'}
 
         # Add a person record
         db.put(Person(

--- a/tests/views/test_admin_repo_index.py
+++ b/tests/views/test_admin_repo_index.py
@@ -204,6 +204,7 @@ class AdminRepoIndexViewTests(view_tests_base.ViewTestsBase):
         repo = model.Repo.get_by_key_name('haiti')
         self.assertTrue(repo.test_mode)
         repo_conf = config.Configuration('haiti')
+        self.assertIs(repo_conf.test_mode, True)
         self.assertEqual(
             repo_conf.updated_date,
             utils.get_timestamp(datetime.datetime(2019, 5, 10, 12, 15, 0)))

--- a/tests/views/test_admin_repo_index.py
+++ b/tests/views/test_admin_repo_index.py
@@ -1,0 +1,141 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the main repo admin page."""
+
+import copy
+
+import django
+import django.http
+import django.test
+
+# pylint: disable=wrong-import-order
+# pylint sometimes thinks config is a standard import that belongs before the
+# django import. It's mistaken; config is our own module (if you run
+# python -c "import config", it produces an error saying config doesn't exist).
+# Filed issue #626 to move us out of the global namespace someday, which would
+# prevent stuff like this.
+import config
+import model
+
+import view_tests_base
+
+
+class AdminRepoIndexViewTests(view_tests_base.ViewTestsBase):
+    """Tests the admin repo index view."""
+
+    _PRIOR_CONFIG = {
+        'language_menu_options': ['en', 'fr'],
+        'repo_titles': {'en': 'en title', 'fr': 'fr title'},
+        'start_page_custom_htmls': {
+            'en': 'en start msg', 'fr': 'fr start msg'},
+        'results_page_custom_htmls': {
+            'en': 'en results msg', 'fr': 'fr results msg'},
+        'view_page_custom_htmls': {
+            'en': 'en view msg', 'fr': 'fr view msg'},
+        'seek_query_form_custom_htmls': {
+            'en': 'en seek msg', 'fr': 'fr seek msg'},
+        'footer_custom_htmls': {
+            'en': 'en footer msg', 'fr': 'fr footer msg'},
+        'time_zone_abbreviation': 'UTC',
+    }
+
+    _SUPERADMIN_ONLY_CONTEXT_KEYS = [
+        'activation_config',
+        'api_access_control_config',
+        'data_retention_config',
+        'forms_config',
+        'keywords_config',
+        'map_config',
+        'spam_config',
+        'timezone_config',
+        'zero_rating_config',
+    ]
+
+    def setUp(self):
+        super(AdminRepoIndexViewTests, self).setUp()
+        self.data_generator.repo()
+        config.set_for_repo('haiti', **AdminRepoIndexViewTests._PRIOR_CONFIG)
+
+    def test_get_as_manager(self):
+        """Tests GET requests as a manager-level admin."""
+        self.login_as_manager()
+        resp = self.client.get('/haiti/admin/', secure=True)
+        doc = self.to_doc(resp)
+        # Check that a couple of the custom messages appear in the doc content.
+        self.assertTrue('en start msg' in doc.content)
+        self.assertTrue('fr view msg' in doc.content)
+        # I tried doing this test the other way around -- checking that every
+        # key in the context was among the set of keys we expect manager-level
+        # admins to have access to -- but that didn't work out well, because
+        # Django seems to include basic stuff (e.g., "True", "None", etc.) as
+        # part of the context (in other words, there's stuff in the context dict
+        # that didn't come from us, and I don't want to have to keep a list of
+        # them).
+        for key in AdminRepoIndexViewTests._SUPERADMIN_ONLY_CONTEXT_KEYS:
+            self.assertFalse(
+                resp.context.get(key),
+                'Non-empty superadmin-only key: %s' % key)
+
+    def test_get_as_superadmin(self):
+        """Tests GET requests as a superadmin."""
+        self.login_as_superadmin()
+        resp = self.client.get('/haiti/admin/', secure=True)
+        doc = self.to_doc(resp)
+        # Check that a couple of the custom messages appear in the doc content.
+        self.assertTrue('en start msg' in doc.content)
+        self.assertTrue('fr view msg' in doc.content)
+        for key in AdminRepoIndexViewTests._SUPERADMIN_ONLY_CONTEXT_KEYS:
+            self.assertTrue(
+                resp.context[key],
+                'Empty superadmin key for superadmin: %s' % key)
+
+    def test_edit_custom_messages(self):
+        """Tests POST requests to edit custom messages."""
+        self.login_as_manager()
+        get_doc = self.to_doc(self.client.get('/haiti/admin', secure=True))
+        xsrf_token = get_doc.cssselect_one('input[name="xsrf_token"]').get(
+            'value')
+        post_params = copy.deepcopy(AdminRepoIndexViewTests._PRIOR_CONFIG)
+        post_params['activation_status'] = str(
+            model.Repo.ActivationStatus.ACTIVE)
+        post_params['test_mode'] = 'false'
+        post_params['custommsg__start_page_custom_htmls__en'] = 'new en msg'
+        post_params['xsrf_token'] = xsrf_token
+        post_resp = self.client.post('/haiti/admin/', post_params, secure=True)
+        # Check that the repo object wasn't changed.
+        repo = model.Repo.get_by_key_name('haiti')
+        self.assertEqual(
+            repo.activation_status, model.Repo.ActivationStatus.ACTIVE)
+        self.assertIs(repo.test_mode, False)
+        # Check a couple of the config fields that are set by default.
+        repo_conf = config.Configuration('haiti')
+        self.assertEqual(repo_conf.language_menu_options, ['en', 'fr'])
+        self.assertEqual(repo_conf.time_zone_abbreviation, 'UTC')
+        # Check that the custom message was updated.
+        self.assertEqual(repo_conf.start_page_custom_htmls['en'], 'new en msg')
+
+    def test_edit_activation_status(self):
+        self.login_as_superadmin()
+        get_doc = self.to_doc(self.client.get('/haiti/admin', secure=True))
+        xsrf_token = get_doc.cssselect_one('input[name="xsrf_token"]').get(
+            'value')
+        post_params = copy.deepcopy(AdminRepoIndexViewTests._PRIOR_CONFIG)
+        post_params['activation_status'] = str(
+            model.Repo.ActivationStatus.DEACTIVATED)
+        post_params['test_mode'] = 'false'
+        post_params['xsrf_token'] = xsrf_token
+        post_resp = self.client.post('/haiti/admin/', post_params, secure=True)
+        repo = model.Repo.get_by_key_name('haiti')
+        self.assertEqual(
+            repo.activation_status, model.Repo.ActivationStatus.DEACTIVATED)

--- a/tests/views/test_admin_repo_index.py
+++ b/tests/views/test_admin_repo_index.py
@@ -14,6 +14,7 @@
 """Tests for the main repo admin page."""
 
 import copy
+import datetime
 
 import django
 import django.http
@@ -27,6 +28,7 @@ import django.test
 # prevent stuff like this.
 import config
 import model
+import utils
 
 import view_tests_base
 
@@ -65,6 +67,8 @@ class AdminRepoIndexViewTests(view_tests_base.ViewTestsBase):
         'read_auth_key_required': False,
         'zero_rating_mode': False,
         'bad_words': '',
+        'updated_date': utils.get_timestamp(
+            datetime.datetime(2019, 5, 10, 11, 15, 0)),
     }
 
     _BASE_POST_PARAMS = {
@@ -176,6 +180,8 @@ class AdminRepoIndexViewTests(view_tests_base.ViewTestsBase):
         self.assertEqual(repo_conf.start_page_custom_htmls['en'], 'new en msg')
 
     def test_edit_activation_status_config(self):
+        # Set the time to an hour past the original update_date.
+        utils.set_utcnow_for_test(datetime.datetime(2019, 5, 10, 12, 15, 0))
         self.login_as_superadmin()
         self._post_with_params(
             activation_status=str(model.Repo.ActivationStatus.DEACTIVATED),
@@ -186,12 +192,21 @@ class AdminRepoIndexViewTests(view_tests_base.ViewTestsBase):
         repo_conf = config.Configuration('haiti')
         self.assertEqual(
             repo_conf.deactivation_message_html, 'it is deactivated')
+        self.assertEqual(
+            repo_conf.updated_date,
+            utils.get_timestamp(datetime.datetime(2019, 5, 10, 12, 15, 0)))
 
     def test_edit_data_retention_mode_config(self):
+        # Set the time to an hour past the original update_date.
+        utils.set_utcnow_for_test(datetime.datetime(2019, 5, 10, 12, 15, 0))
         self.login_as_superadmin()
         self._post_with_params(test_mode=True)
         repo = model.Repo.get_by_key_name('haiti')
         self.assertTrue(repo.test_mode)
+        repo_conf = config.Configuration('haiti')
+        self.assertEqual(
+            repo_conf.updated_date,
+            utils.get_timestamp(datetime.datetime(2019, 5, 10, 12, 15, 0)))
 
     def test_edit_keywords_config(self):
         self.login_as_superadmin()

--- a/tests/views/test_admin_repo_index.py
+++ b/tests/views/test_admin_repo_index.py
@@ -16,16 +16,6 @@
 import copy
 import datetime
 
-import django
-import django.http
-import django.test
-
-# pylint: disable=wrong-import-order
-# pylint sometimes thinks config is a standard import that belongs before the
-# django import. It's mistaken; config is our own module (if you run
-# python -c "import config", it produces an error saying config doesn't exist).
-# Filed issue #626 to move us out of the global namespace someday, which would
-# prevent stuff like this.
 import config
 import model
 import utils

--- a/tests/views/test_admin_repo_index.py
+++ b/tests/views/test_admin_repo_index.py
@@ -129,6 +129,7 @@ class AdminRepoIndexViewTests(view_tests_base.ViewTestsBase):
         # that didn't come from us, and I don't want to have to keep a list of
         # them).
         for key in AdminRepoIndexViewTests._SUPERADMIN_ONLY_CONTEXT_KEYS:
+            # These can be either None or an empty dictionary.
             self.assertFalse(
                 resp.context.get(key),
                 'Non-empty superadmin-only key: %s' % key)
@@ -221,7 +222,7 @@ class AdminRepoIndexViewTests(view_tests_base.ViewTestsBase):
         self.assertIs(repo_conf.use_alternate_names, True)
         self.assertIs(repo_conf.use_postal_code, True)
         self.assertIs(repo_conf.allow_believed_dead_via_ui, True)
-        self.assertIs(repo_conf.min_query_word_length, 2)
+        self.assertEqual(repo_conf.min_query_word_length, 2)
         self.assertIs(repo_conf.show_profile_entry, True)
 
     def test_edit_map_config(self):

--- a/tests/views/test_admin_repo_index.py
+++ b/tests/views/test_admin_repo_index.py
@@ -47,7 +47,59 @@ class AdminRepoIndexViewTests(view_tests_base.ViewTestsBase):
             'en': 'en seek msg', 'fr': 'fr seek msg'},
         'footer_custom_htmls': {
             'en': 'en footer msg', 'fr': 'fr footer msg'},
+        'map_default_zoom': 5,
+        'map_default_center': '[-43.8, 152.5]',
+        'map_size_pixels': '[200, 400]',
+        'keywords': '',
+        'use_family_name': False,
+        'family_name_first': False,
+        'use_alternate_names': False,
+        'use_postal_code': False,
+        'allow_believed_dead_via_ui': False,
+        'min_query_word_length': 1,
+        'show_profile_entry': False,
+        'profile_websites': '[]',
+        'time_zone_offset': 0,
         'time_zone_abbreviation': 'UTC',
+        'search_auth_key_required': False,
+        'read_auth_key_required': False,
+        'zero_rating_mode': False,
+        'bad_words': '',
+    }
+
+    _BASE_POST_PARAMS = {
+        'langlist__0': 'en',
+        'langlist__1': 'fr',
+        'repotitle__en': 'en title',
+        'repotitle__fr': 'fr title',
+        'custommsg__start_page_custom_htmls__en': 'en start msg',
+        'custommsg__start_page_custom_htmls__fr': 'fr start msg',
+        'custommsg__results_page_custom_htmls__en': 'en results msg',
+        'custommsg__results_page_custom_htmls__fr': 'fr results msg',
+        'custommsg__view_page_custom_htmls__en': 'en view msg',
+        'custommsg__view_page_custom_htmls__fr': 'fr view msg',
+        'custommsg__seek_query_form_custom_htmls__en': 'en seek msg',
+        'custommsg__seek_query_form_custom_htmls__fr': 'fr seek msg',
+        'custommsg__footer_custom_htmls__en': 'en footer msg',
+        'custommsg__footer_custom_htmls__fr': 'fr footer msg',
+        'map_default_center': '[-43.8, 152.5]',
+        'map_default_zoom': '5',
+        'map_size_pixels': '[200, 400]',
+        'keywords': '',
+        'use_family_name': 'false',
+        'family_name_first': 'false',
+        'use_alternate_names': 'false',
+        'use_postal_code': 'false',
+        'allow_believed_dead_via_ui': 'false',
+        'min_query_word_length': '1',
+        'show_profile_entry': 'false',
+        'profile_websites': '[]',
+        'time_zone_offset': '0',
+        'time_zone_abbreviation': 'UTC',
+        'search_auth_key_required': 'false',
+        'read_auth_key_required': 'false',
+        'zero_rating_mode': 'false',
+        'bad_words': '',
     }
 
     _SUPERADMIN_ONLY_CONTEXT_KEYS = [
@@ -100,42 +152,144 @@ class AdminRepoIndexViewTests(view_tests_base.ViewTestsBase):
                 resp.context[key],
                 'Empty superadmin key for superadmin: %s' % key)
 
+    def test_edit_lang_list(self):
+        self.login_as_superadmin()
+        self._post_with_params(
+            langlist__0='en', langlist__1='fr', langlist__2='es')
+        repo_conf = config.Configuration('haiti')
+        self.assertEqual(repo_conf.language_menu_options, ['en', 'fr', 'es'])
+
+    def test_edit_repo_titles(self):
+        self.login_as_superadmin()
+        self._post_with_params(
+            repotitle__en='en title', repotitle__fr='new and improved fr title')
+        repo_conf = config.Configuration('haiti')
+        self.assertEqual(
+            repo_conf.repo_titles['fr'], 'new and improved fr title')
+
     def test_edit_custom_messages(self):
         """Tests POST requests to edit custom messages."""
         self.login_as_manager()
-        get_doc = self.to_doc(self.client.get('/haiti/admin', secure=True))
-        xsrf_token = get_doc.cssselect_one('input[name="xsrf_token"]').get(
-            'value')
-        post_params = copy.deepcopy(AdminRepoIndexViewTests._PRIOR_CONFIG)
-        post_params['activation_status'] = str(
-            model.Repo.ActivationStatus.ACTIVE)
-        post_params['test_mode'] = 'false'
-        post_params['custommsg__start_page_custom_htmls__en'] = 'new en msg'
-        post_params['xsrf_token'] = xsrf_token
-        post_resp = self.client.post('/haiti/admin/', post_params, secure=True)
-        # Check that the repo object wasn't changed.
-        repo = model.Repo.get_by_key_name('haiti')
-        self.assertEqual(
-            repo.activation_status, model.Repo.ActivationStatus.ACTIVE)
-        self.assertIs(repo.test_mode, False)
-        # Check a couple of the config fields that are set by default.
+        self._post_with_params(
+            custommsg__start_page_custom_htmls__en='new en msg')
         repo_conf = config.Configuration('haiti')
-        self.assertEqual(repo_conf.language_menu_options, ['en', 'fr'])
-        self.assertEqual(repo_conf.time_zone_abbreviation, 'UTC')
-        # Check that the custom message was updated.
         self.assertEqual(repo_conf.start_page_custom_htmls['en'], 'new en msg')
 
-    def test_edit_activation_status(self):
+    def test_edit_activation_status_config(self):
         self.login_as_superadmin()
-        get_doc = self.to_doc(self.client.get('/haiti/admin', secure=True))
-        xsrf_token = get_doc.cssselect_one('input[name="xsrf_token"]').get(
-            'value')
-        post_params = copy.deepcopy(AdminRepoIndexViewTests._PRIOR_CONFIG)
-        post_params['activation_status'] = str(
-            model.Repo.ActivationStatus.DEACTIVATED)
-        post_params['test_mode'] = 'false'
-        post_params['xsrf_token'] = xsrf_token
-        post_resp = self.client.post('/haiti/admin/', post_params, secure=True)
+        self._post_with_params(
+            activation_status=str(model.Repo.ActivationStatus.DEACTIVATED),
+            deactivation_message_html='it is deactivated')
         repo = model.Repo.get_by_key_name('haiti')
         self.assertEqual(
             repo.activation_status, model.Repo.ActivationStatus.DEACTIVATED)
+        repo_conf = config.Configuration('haiti')
+        self.assertEqual(
+            repo_conf.deactivation_message_html, 'it is deactivated')
+
+    def test_edit_data_retention_mode_config(self):
+        self.login_as_superadmin()
+        self._post_with_params(test_mode=True)
+        repo = model.Repo.get_by_key_name('haiti')
+        self.assertTrue(repo.test_mode)
+
+    def test_edit_keywords_config(self):
+        self.login_as_superadmin()
+        self._post_with_params(keywords='haiti,earthquake')
+        repo_conf = config.Configuration('haiti')
+        self.assertEqual(repo_conf.keywords, 'haiti,earthquake')
+
+    def test_edit_forms_config(self):
+        self.login_as_superadmin()
+        self._post_with_params(
+            use_family_name='true',
+            family_name_first='true',
+            use_alternate_names='true',
+            use_postal_code='true',
+            allow_believed_dead_via_ui='true',
+            min_query_word_length='2',
+            show_profile_entry='true')
+        repo_conf = config.Configuration('haiti')
+        self.assertIs(repo_conf.use_family_name, True)
+        self.assertIs(repo_conf.family_name_first, True)
+        self.assertIs(repo_conf.use_alternate_names, True)
+        self.assertIs(repo_conf.use_postal_code, True)
+        self.assertIs(repo_conf.allow_believed_dead_via_ui, True)
+        self.assertIs(repo_conf.min_query_word_length, 2)
+        self.assertIs(repo_conf.show_profile_entry, True)
+
+    def test_edit_map_config(self):
+        self.login_as_superadmin()
+        self._post_with_params(
+            map_default_zoom='8',
+            map_default_center='[32.7, 85.6]',
+            map_size_pixels='[300, 450]')
+        repo_conf = config.Configuration('haiti')
+        self.assertEqual(repo_conf.map_default_zoom, 8)
+        self.assertEqual(repo_conf.map_default_center, '[32.7, 85.6]')
+        self.assertEqual(repo_conf.map_size_pixels, '[300, 450]')
+
+    def test_edit_timezone_config(self):
+        self.login_as_superadmin()
+        self._post_with_params(
+            time_zone_offset='5.75',
+            time_zone_abbreviation='NPT')
+        repo_conf = config.Configuration('haiti')
+        self.assertEqual(repo_conf.time_zone_offset, 5.75)
+        self.assertEqual(repo_conf.time_zone_abbreviation, 'NPT')
+
+    def test_api_access_control_config(self):
+        self.login_as_superadmin()
+        self._post_with_params(
+            search_auth_key_required='true',
+            read_auth_key_required='true')
+        repo_conf = config.Configuration('haiti')
+        self.assertIs(repo_conf.search_auth_key_required, True)
+        self.assertIs(repo_conf.read_auth_key_required, True)
+
+    def test_edit_zero_rating_config(self):
+        self.login_as_superadmin()
+        self._post_with_params(zero_rating_mode='true')
+        repo_conf = config.Configuration('haiti')
+        self.assertIs(repo_conf.zero_rating_mode, True)
+
+    def test_edit_spam_config(self):
+        self.login_as_superadmin()
+        self._post_with_params(bad_words='voldemort')
+        repo_conf = config.Configuration('haiti')
+        self.assertEqual(repo_conf.bad_words, 'voldemort')
+
+    def test_manager_edit_restrictions(self):
+        self.login_as_manager()
+        self._post_with_params(
+            use_family_name='true',
+            family_name_first='true',
+            use_alternate_names='true',
+            use_postal_code='true',
+            allow_believed_dead_via_ui='true',
+            min_query_word_length='2',
+            show_profile_entry='true',
+            map_default_zoom='8',
+            map_default_center='[32.7, 85.6]',
+            map_size_pixels='[300, 450]',
+            time_zone_offset='5.75',
+            time_zone_abbreviation='NPT',
+            search_auth_key_required='true',
+            read_auth_key_required='true',
+            zero_rating_mode='true',
+            bad_words='voldemort')
+        repo_conf = config.Configuration('haiti')
+        for key, value in AdminRepoIndexViewTests._PRIOR_CONFIG.items():
+            self.assertEqual(repo_conf.get(key), value)
+
+    def _post_with_params(self, **kwargs):
+        get_doc = self.to_doc(self.client.get('/haiti/admin', secure=True))
+        xsrf_token = get_doc.cssselect_one('input[name="xsrf_token"]').get(
+            'value')
+        post_params = copy.deepcopy(AdminRepoIndexViewTests._BASE_POST_PARAMS)
+        post_params['activation_status'] = str(
+            model.Repo.ActivationStatus.ACTIVE)
+        post_params['test_mode'] = 'false'
+        post_params['xsrf_token'] = xsrf_token
+        post_params.update(kwargs)
+        return self.client.post('/haiti/admin/', post_params, secure=True)

--- a/tests/views/test_auto_security.py
+++ b/tests/views/test_auto_security.py
@@ -170,6 +170,10 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
         self.testbed.init_user_stub()
         self.testbed.init_memcache_stub()
 
+    def setUp(self):
+        super(AutoSecurityTests, self).setUp()
+        self.data_generator.repo()
+
     def get_path(self, path_name):
         """Gets a path to use for the given path name.
 

--- a/tests/views/test_auto_security.py
+++ b/tests/views/test_auto_security.py
@@ -121,6 +121,16 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
                 'id': 'abc123',
             },
             xsrf_action_id='admin/delete_record'),
+        'admin_repo_index':
+        PathTestInfo(
+            accepts_get=True,
+            accepts_post=True,
+            min_admin_level=aa_model.AdminPermission.AccessLevel.MANAGER,
+            requires_xsrf=True,
+            sample_post_data={
+                'custommsg__start_page_custom_htmls__en': 'custom message',
+            },
+            xsrf_action_id='admin/repo-index'),
         'admin_review':
         PathTestInfo(
             accepts_get=True,


### PR DESCRIPTION
Previously the global admin page and the main repo admin page were in the same handler and Django template. This splits it up and moves the repo one to Django to start with.

In this PR I've also added enforcement based on the new ACL system for this page. That's more complex for this page than the others, because manager-level admins and superadmins should both be able to access it, but managers should only be able to change a subset of the fields (I considered splitting those fields off into their own page, but I think it'd be annoying for superadmins to have the language list and the custom messages on separate pages).

Lastly, this rewrites the JS for handling languages and custom messages on that page using React to simplify things. The JS for that page was kinda complex to start with, and it turned into a mess when I tried to handle the manager/superadmin separation (which is why this PR's branch name is adminindex*4*...). This is an isolated use of React (i.e., it's not connected to the new user-facing UI).