### PR TITLE
Django handler for datastore setup.

### DIFF
--- a/app/app.yaml
+++ b/app/app.yaml
@@ -43,6 +43,8 @@ handlers:
   script: wsgi.application
 - url: /personfinder/?
   script: wsgi.application
+- url: /setup_datastore/?
+  script: wsgi.application
 - url: /global/home.html
   script: wsgi.application
 - url: /personfinder/global/home.html

--- a/app/resources/home-ja.html.template
+++ b/app/resources/home-ja.html.template
@@ -78,7 +78,7 @@
     for instructions on administering this site and customizing its appearance.
 
     {% if not config.initialized %}
-      <p>You can set up the database <a href="/setup_datastore">here</a>.
+      <p>You can <a href="/setup_datastore">set up the database</a>.
     {% endif %}
 
   {% endif %}

--- a/app/resources/home-ja.html.template
+++ b/app/resources/home-ja.html.template
@@ -77,6 +77,10 @@
     <a href="https://github.com/google/personfinder">project page</a>
     for instructions on administering this site and customizing its appearance.
 
+    {% if not config.initialized %}
+      <p>You can set up the database <a href="/setup_datastore">here</a>.
+    {% endif %}
+
   {% endif %}
 
 {% endblock content %}

--- a/app/resources/home.html.template
+++ b/app/resources/home.html.template
@@ -78,6 +78,10 @@
     <a href="https://github.com/google/personfinder">project page</a>
     for instructions on administering this site and customizing its appearance.
 
+    {% if not config.initialized %}
+      <p>You can set up the database <a href="/setup_datastore">here</a>.
+    {% endif %}
+
   {% endif %}
 
 {% endblock content %}

--- a/app/resources/home.html.template
+++ b/app/resources/home.html.template
@@ -79,7 +79,7 @@
     for instructions on administering this site and customizing its appearance.
 
     {% if not config.initialized %}
-      <p>You can set up the database <a href="/setup_datastore">here</a>.
+      <p>You can <a href="/setup_datastore">set up the database</a>.
     {% endif %}
 
   {% endif %}

--- a/app/urls.py
+++ b/app/urls.py
@@ -28,6 +28,7 @@ import views.admin.global_index
 import views.admin.repo_index
 import views.admin.review
 import views.admin.statistics
+import views.meta.setup_datastore
 import views.meta.sitemap
 import views.meta.static_files
 import views.meta.static_pages
@@ -56,6 +57,8 @@ _BASE_URL_PATTERNS = [
      views.admin.review.AdminReviewView.as_view),
     ('admin_statistics', r'global/admin/statistics/?',
      views.admin.statistics.AdminStatisticsView.as_view),
+    ('meta_setup-datastore', r'setup_datastore/?',
+     views.meta.setup_datastore.SetupDatastoreHandler.as_view),
     ('meta_static-home', r'/?', views.meta.static_pages.HomeView.as_view),
     ('meta_static-home-altpath', r'global/home.html',
      views.meta.static_pages.HomeView.as_view),

--- a/app/views/meta/setup_datastore.py
+++ b/app/views/meta/setup_datastore.py
@@ -1,0 +1,34 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The datastore setup handler."""
+
+import django.shortcuts
+
+import setup_pf
+import views.base
+
+
+class SetupDatastoreHandler(views.base.BaseView):
+    """The datastore setup handler."""
+
+    ACTION_ID = 'setup_datastore'
+
+    def get(self, request, *args, **kwargs):
+        """Sets up datastore, if it's not already set up."""
+        del request, args, kwargs  # unused
+        if self.env.config.get('initialized'):
+            raise django.core.exceptions.PermissionDenied()
+        setup_pf.setup_datastore()
+        return django.shortcuts.redirect(self.build_absolute_uri('/'))

--- a/app/views/meta/setup_datastore.py
+++ b/app/views/meta/setup_datastore.py
@@ -29,6 +29,6 @@ class SetupDatastoreHandler(views.base.BaseView):
         """Sets up datastore, if it's not already set up."""
         del request, args, kwargs  # unused
         if self.env.config.get('initialized'):
-            raise django.core.exceptions.PermissionDenied()
+            return self.error(400)
         setup_pf.setup_datastore()
         return django.shortcuts.redirect(self.build_absolute_uri('/'))

--- a/tests/views/test_auto_security.py
+++ b/tests/views/test_auto_security.py
@@ -192,6 +192,42 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
             requires_xsrf=False,
             sample_post_data=None,
             xsrf_action_id=None),
+        'meta_static-home':
+        PathTestInfo(
+            accepts_get=True,
+            accepts_post=False,
+            sample_path_kwargs={},
+            min_admin_level=None,
+            requires_xsrf=False,
+            sample_post_data=None,
+            xsrf_action_id=None),
+        'meta_static-home-altpath':
+        PathTestInfo(
+            accepts_get=True,
+            accepts_post=False,
+            sample_path_kwargs={},
+            min_admin_level=None,
+            requires_xsrf=False,
+            sample_post_data=None,
+            xsrf_action_id=None),
+        'meta_static-howto':
+        PathTestInfo(
+            accepts_get=True,
+            accepts_post=False,
+            sample_path_kwargs={},
+            min_admin_level=None,
+            requires_xsrf=False,
+            sample_post_data=None,
+            xsrf_action_id=None),
+        'meta_static-responders':
+        PathTestInfo(
+            accepts_get=True,
+            accepts_post=False,
+            sample_path_kwargs={},
+            min_admin_level=None,
+            requires_xsrf=False,
+            sample_post_data=None,
+            xsrf_action_id=None),
         'tasks_check-expired-person-records':
         PathTestInfo(
             accepts_get=True,
@@ -255,43 +291,14 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
             requires_xsrf=False,
             sample_post_data=None,
             xsrf_action_id=None),
-        'meta_static-home':
-        PathTestInfo(
-            accepts_get=True,
-            accepts_post=False,
-            sample_path_kwargs={},
-            min_admin_level=None,
-            requires_xsrf=False,
-            sample_post_data=None,
-            xsrf_action_id=None),
-        'meta_static-home-altpath':
-        PathTestInfo(
-            accepts_get=True,
-            accepts_post=False,
-            sample_path_kwargs={},
-            min_admin_level=None,
-            requires_xsrf=False,
-            sample_post_data=None,
-            xsrf_action_id=None),
-        'meta_static-howto':
-        PathTestInfo(
-            accepts_get=True,
-            accepts_post=False,
-            sample_path_kwargs={},
-            min_admin_level=None,
-            requires_xsrf=False,
-            sample_post_data=None,
-            xsrf_action_id=None),
-        'meta_static-responders':
-        PathTestInfo(
-            accepts_get=True,
-            accepts_post=False,
-            sample_path_kwargs={},
-            min_admin_level=None,
-            requires_xsrf=False,
-            sample_post_data=None,
-            xsrf_action_id=None),
     }
+
+    EXEMPT_PATHS = [
+        # We exempt this from the auto-tests because it should normally (if
+        # datastore is already set up) return an error, regardless of whether
+        # the requester is an admin.
+        'meta_setup-datastore',
+    ]
 
     def init_testbed_stubs(self):
         """Initializes the App Engine testbed stubs.
@@ -489,6 +496,8 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
         so we require that each URL path is included in the dictionary above.
         """
         for pattern in urls.urlpatterns:
+            if pattern.name in AutoSecurityTests.EXEMPT_PATHS:
+                continue
             if pattern.name.startswith('prefixed__'):
                 # Skip these; they're the same views as the non-prefixed
                 # versions.

--- a/tests/views/test_setup_datastore.py
+++ b/tests/views/test_setup_datastore.py
@@ -1,0 +1,56 @@
+# Copyright 2019 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Tests for the datastore setup handler."""
+
+import os
+import unittest
+
+import django
+import django.test
+from google.appengine.ext import testbed
+
+import config
+
+
+class MetaSetupDatastoreHandlerTests(unittest.TestCase):
+    """Tests the datastore setup handler."""
+
+    def setUp(self):
+        super(MetaSetupDatastoreHandlerTests, self).setUp()
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_user_stub()
+        self.testbed.init_datastore_v3_stub()
+        os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings')
+        django.setup()
+        django.test.utils.setup_test_environment()
+        self.client = django.test.Client()
+
+    def tearDown(self):
+        self.testbed.deactivate()
+        django.test.utils.teardown_test_environment()
+
+    def test_setup(self):
+        self.assertFalse(config.get('initialized'))
+        resp = self.client.get('/setup_datastore/', secure=True)
+        self.assertTrue(config.get('initialized'))
+        self.assertIsInstance(resp, django.http.HttpResponseRedirect)
+        self.assertEqual(resp.url, 'https://testserver/')
+
+    def test_already_setup(self):
+        config.set(initialized=True)
+        resp = self.client.get('/setup_datastore', secure=True)
+        self.assertEqual(resp.status_code, 400)


### PR DESCRIPTION
There used to be a button for this on the homepage, but then I moved the homepage to Django and broke it :/
This also fixes the alphabetization the auto security test list, which I imagine got messed up in a merge.