### PR TITLE
Use user's local TZ in React UI.

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -5468,12 +5468,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5488,17 +5490,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5615,7 +5620,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5627,6 +5633,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5641,6 +5648,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5648,12 +5656,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5672,6 +5682,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5752,7 +5763,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5764,6 +5776,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5885,6 +5898,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "webpack-dev-server --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
-    "test": "jest"
+    "test": "TZ=UTC jest"
   },
   "license": "Apache-2.0",
   "jest": {

--- a/ui/src/pages/Results.js
+++ b/ui/src/pages/Results.js
@@ -195,11 +195,6 @@ class SearchResultImpl extends Component {
         month='short'
         hour='numeric'
         minute='numeric'
-        // TODO(nworden): handle timezones. react-intl is supposed to support
-        // passing timezones into the IntlProvider itself, which would be ideal
-        // but which I can't seem to get working. Worst-case scenario we define
-        // it as a global JS var and use it for FormattedDates throughout.
-        timeZone='UTC'
         timeZoneName='short' />
     var timestampLine = '';
     if (this.props.result.timestampType == 'creation') {

--- a/ui/src/pages/__snapshots__/GlobalHome_test.js.snap
+++ b/ui/src/pages/__snapshots__/GlobalHome_test.js.snap
@@ -68,9 +68,11 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
             </span>
           </FormattedMessage>
         </p>
-        <RippledComponent
+        <WithRipple(Button)
           className="pf-button-secondary globalhome-howsitworkbutton"
+          dense={false}
           disabled={false}
+          icon={null}
           initRipple={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
@@ -81,13 +83,17 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
           onMouseUp={[Function]}
           onTouchEnd={[Function]}
           onTouchStart={[Function]}
+          outlined={false}
           raised={true}
           style={Object {}}
           unbounded={false}
+          unelevated={false}
         >
-          <Component
+          <Button
             className="pf-button-secondary globalhome-howsitworkbutton"
+            dense={false}
             disabled={false}
+            icon={null}
             initRipple={[Function]}
             onBlur={[Function]}
             onClick={[Function]}
@@ -98,8 +104,11 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
             onMouseUp={[Function]}
             onTouchEnd={[Function]}
             onTouchStart={[Function]}
+            outlined={false}
             raised={true}
             style={Object {}}
+            unbounded={false}
+            unelevated={false}
           >
             <button
               className="mdc-button pf-button-secondary globalhome-howsitworkbutton mdc-button--raised"
@@ -115,25 +124,30 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
               onTouchStart={[Function]}
               style={Object {}}
             >
-              <span
-                className="mdc-button__label"
-              >
-                How does it work?
-              </span>
+              How does it work?
             </button>
-          </Component>
-        </RippledComponent>
+          </Button>
+        </WithRipple(Button)>
       </div>
-      <Grid>
+      <Grid
+        className=""
+        fixedColumnWidth={false}
+        tag="div"
+      >
         <div
           className="mdc-layout-grid"
         >
-          <Row>
+          <Row
+            className=""
+            tag="div"
+          >
             <div
               className="mdc-layout-grid__inner"
             >
               <Cell
+                className=""
                 key="haiti"
+                tag="div"
               >
                 <div
                   className="mdc-layout-grid__cell"
@@ -187,11 +201,12 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                     >
                       <Card
                         className="repocard"
+                        outlined={false}
                       >
                         <div
                           className="mdc-card repocard"
                         >
-                          <RippledComponent
+                          <WithRipple(PrimaryContentBase)
                             className="repocard-content"
                             disabled={false}
                             onBlur={[Function]}
@@ -206,7 +221,7 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                             style={Object {}}
                             unbounded={false}
                           >
-                            <Component
+                            <PrimaryContentBase
                               className="repocard-content"
                               disabled={false}
                               initRipple={[Function]}
@@ -220,6 +235,7 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                               onTouchEnd={[Function]}
                               onTouchStart={[Function]}
                               style={Object {}}
+                              unbounded={false}
                             >
                               <div
                                 className="mdc-card__primary-action repocard-content"
@@ -271,8 +287,8 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                                   </p>
                                 </div>
                               </div>
-                            </Component>
-                          </RippledComponent>
+                            </PrimaryContentBase>
+                          </WithRipple(PrimaryContentBase)>
                         </div>
                       </Card>
                     </RepoCardImpl>
@@ -280,7 +296,9 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                 </div>
               </Cell>
               <Cell
+                className=""
                 key="japan"
+                tag="div"
               >
                 <div
                   className="mdc-layout-grid__cell"
@@ -334,11 +352,12 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                     >
                       <Card
                         className="repocard"
+                        outlined={false}
                       >
                         <div
                           className="mdc-card repocard"
                         >
-                          <RippledComponent
+                          <WithRipple(PrimaryContentBase)
                             className="repocard-content"
                             disabled={false}
                             onBlur={[Function]}
@@ -353,7 +372,7 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                             style={Object {}}
                             unbounded={false}
                           >
-                            <Component
+                            <PrimaryContentBase
                               className="repocard-content"
                               disabled={false}
                               initRipple={[Function]}
@@ -367,6 +386,7 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                               onTouchEnd={[Function]}
                               onTouchStart={[Function]}
                               style={Object {}}
+                              unbounded={false}
                             >
                               <div
                                 className="mdc-card__primary-action repocard-content"
@@ -418,8 +438,8 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                                   </p>
                                 </div>
                               </div>
-                            </Component>
-                          </RippledComponent>
+                            </PrimaryContentBase>
+                          </WithRipple(PrimaryContentBase)>
                         </div>
                       </Card>
                     </RepoCardImpl>
@@ -427,7 +447,9 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                 </div>
               </Cell>
               <Cell
+                className=""
                 key="albany"
+                tag="div"
               >
                 <div
                   className="mdc-layout-grid__cell"
@@ -481,11 +503,12 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                     >
                       <Card
                         className="repocard"
+                        outlined={false}
                       >
                         <div
                           className="mdc-card repocard"
                         >
-                          <RippledComponent
+                          <WithRipple(PrimaryContentBase)
                             className="repocard-content"
                             disabled={false}
                             onBlur={[Function]}
@@ -500,7 +523,7 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                             style={Object {}}
                             unbounded={false}
                           >
-                            <Component
+                            <PrimaryContentBase
                               className="repocard-content"
                               disabled={false}
                               initRipple={[Function]}
@@ -514,6 +537,7 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                               onTouchEnd={[Function]}
                               onTouchStart={[Function]}
                               style={Object {}}
+                              unbounded={false}
                             >
                               <div
                                 className="mdc-card__primary-action repocard-content"
@@ -565,8 +589,8 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                                   </p>
                                 </div>
                               </div>
-                            </Component>
-                          </RippledComponent>
+                            </PrimaryContentBase>
+                          </WithRipple(PrimaryContentBase)>
                         </div>
                       </Card>
                     </RepoCardImpl>
@@ -574,7 +598,9 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                 </div>
               </Cell>
               <Cell
+                className=""
                 key="seattle"
+                tag="div"
               >
                 <div
                   className="mdc-layout-grid__cell"
@@ -628,11 +654,12 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                     >
                       <Card
                         className="repocard"
+                        outlined={false}
                       >
                         <div
                           className="mdc-card repocard"
                         >
-                          <RippledComponent
+                          <WithRipple(PrimaryContentBase)
                             className="repocard-content"
                             disabled={false}
                             onBlur={[Function]}
@@ -647,7 +674,7 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                             style={Object {}}
                             unbounded={false}
                           >
-                            <Component
+                            <PrimaryContentBase
                               className="repocard-content"
                               disabled={false}
                               initRipple={[Function]}
@@ -661,6 +688,7 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                               onTouchEnd={[Function]}
                               onTouchStart={[Function]}
                               style={Object {}}
+                              unbounded={false}
                             >
                               <div
                                 className="mdc-card__primary-action repocard-content"
@@ -712,8 +740,8 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                                   </p>
                                 </div>
                               </div>
-                            </Component>
-                          </RippledComponent>
+                            </PrimaryContentBase>
+                          </WithRipple(PrimaryContentBase)>
                         </div>
                       </Card>
                     </RepoCardImpl>
@@ -721,7 +749,9 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                 </div>
               </Cell>
               <Cell
+                className=""
                 key="montreal"
+                tag="div"
               >
                 <div
                   className="mdc-layout-grid__cell"
@@ -775,11 +805,12 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                     >
                       <Card
                         className="repocard"
+                        outlined={false}
                       >
                         <div
                           className="mdc-card repocard"
                         >
-                          <RippledComponent
+                          <WithRipple(PrimaryContentBase)
                             className="repocard-content"
                             disabled={false}
                             onBlur={[Function]}
@@ -794,7 +825,7 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                             style={Object {}}
                             unbounded={false}
                           >
-                            <Component
+                            <PrimaryContentBase
                               className="repocard-content"
                               disabled={false}
                               initRipple={[Function]}
@@ -808,6 +839,7 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                               onTouchEnd={[Function]}
                               onTouchStart={[Function]}
                               style={Object {}}
+                              unbounded={false}
                             >
                               <div
                                 className="mdc-card__primary-action repocard-content"
@@ -859,8 +891,8 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                                   </p>
                                 </div>
                               </div>
-                            </Component>
-                          </RippledComponent>
+                            </PrimaryContentBase>
+                          </WithRipple(PrimaryContentBase)>
                         </div>
                       </Card>
                     </RepoCardImpl>
@@ -868,7 +900,9 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                 </div>
               </Cell>
               <Cell
+                className=""
                 key="belgium"
+                tag="div"
               >
                 <div
                   className="mdc-layout-grid__cell"
@@ -922,11 +956,12 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                     >
                       <Card
                         className="repocard"
+                        outlined={false}
                       >
                         <div
                           className="mdc-card repocard"
                         >
-                          <RippledComponent
+                          <WithRipple(PrimaryContentBase)
                             className="repocard-content"
                             disabled={false}
                             onBlur={[Function]}
@@ -941,7 +976,7 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                             style={Object {}}
                             unbounded={false}
                           >
-                            <Component
+                            <PrimaryContentBase
                               className="repocard-content"
                               disabled={false}
                               initRipple={[Function]}
@@ -955,6 +990,7 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                               onTouchEnd={[Function]}
                               onTouchStart={[Function]}
                               style={Object {}}
+                              unbounded={false}
                             >
                               <div
                                 className="mdc-card__primary-action repocard-content"
@@ -1006,8 +1042,8 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                                   </p>
                                 </div>
                               </div>
-                            </Component>
-                          </RippledComponent>
+                            </PrimaryContentBase>
+                          </WithRipple(PrimaryContentBase)>
                         </div>
                       </Card>
                     </RepoCardImpl>
@@ -1015,7 +1051,9 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                 </div>
               </Cell>
               <Cell
+                className=""
                 key="boise"
+                tag="div"
               >
                 <div
                   className="mdc-layout-grid__cell"
@@ -1069,11 +1107,12 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                     >
                       <Card
                         className="repocard"
+                        outlined={false}
                       >
                         <div
                           className="mdc-card repocard"
                         >
-                          <RippledComponent
+                          <WithRipple(PrimaryContentBase)
                             className="repocard-content"
                             disabled={false}
                             onBlur={[Function]}
@@ -1088,7 +1127,7 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                             style={Object {}}
                             unbounded={false}
                           >
-                            <Component
+                            <PrimaryContentBase
                               className="repocard-content"
                               disabled={false}
                               initRipple={[Function]}
@@ -1102,6 +1141,7 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                               onTouchEnd={[Function]}
                               onTouchStart={[Function]}
                               style={Object {}}
+                              unbounded={false}
                             >
                               <div
                                 className="mdc-card__primary-action repocard-content"
@@ -1153,8 +1193,8 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                                   </p>
                                 </div>
                               </div>
-                            </Component>
-                          </RippledComponent>
+                            </PrimaryContentBase>
+                          </WithRipple(PrimaryContentBase)>
                         </div>
                       </Card>
                     </RepoCardImpl>
@@ -1188,22 +1228,32 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
             </span>
           </div>
         </EndBarHeader>
-        <Grid>
+        <Grid
+          className=""
+          fixedColumnWidth={false}
+          tag="div"
+        >
           <div
             className="mdc-layout-grid"
           >
-            <Row>
+            <Row
+              className=""
+              tag="div"
+            >
               <div
                 className="mdc-layout-grid__inner"
               >
                 <Cell
+                  className=""
                   desktopColumns={6}
+                  tag="div"
                 >
                   <div
                     className="mdc-layout-grid__cell mdc-layout-grid__cell--span-6-desktop"
                   >
                     <Card
                       className="globalhome-thirdpartycard"
+                      outlined={false}
                     >
                       <div
                         className="mdc-card globalhome-thirdpartycard"
@@ -1240,17 +1290,24 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                             </FormattedHTMLMessage>
                           </p>
                         </div>
-                        <Actions>
+                        <Actions
+                          className=""
+                          fullBleed={false}
+                        >
                           <div
                             className="mdc-card__actions"
                           >
-                            <ActionButtons>
+                            <ActionButtons
+                              className=""
+                            >
                               <div
                                 className="mdc-card__action-buttons"
                               >
-                                <RippledComponent
+                                <WithRipple(Button)
                                   className="pf-button-secondary mdc-card__action mdc-card__action--button"
+                                  dense={false}
                                   disabled={false}
+                                  icon={null}
                                   initRipple={[Function]}
                                   key=".0"
                                   onBlur={[Function]}
@@ -1262,13 +1319,17 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                                   onMouseUp={[Function]}
                                   onTouchEnd={[Function]}
                                   onTouchStart={[Function]}
+                                  outlined={false}
                                   raised={true}
                                   style={Object {}}
                                   unbounded={false}
+                                  unelevated={false}
                                 >
-                                  <Component
+                                  <Button
                                     className="pf-button-secondary mdc-card__action mdc-card__action--button"
+                                    dense={false}
                                     disabled={false}
+                                    icon={null}
                                     initRipple={[Function]}
                                     onBlur={[Function]}
                                     onClick={[Function]}
@@ -1279,8 +1340,11 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                                     onMouseUp={[Function]}
                                     onTouchEnd={[Function]}
                                     onTouchStart={[Function]}
+                                    outlined={false}
                                     raised={true}
                                     style={Object {}}
+                                    unbounded={false}
+                                    unelevated={false}
                                   >
                                     <button
                                       className="mdc-button pf-button-secondary mdc-card__action mdc-card__action--button mdc-button--raised"
@@ -1296,14 +1360,10 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                                       onTouchStart={[Function]}
                                       style={Object {}}
                                     >
-                                      <span
-                                        className="mdc-button__label"
-                                      >
-                                        Learn how
-                                      </span>
+                                      Learn how
                                     </button>
-                                  </Component>
-                                </RippledComponent>
+                                  </Button>
+                                </WithRipple(Button)>
                               </div>
                             </ActionButtons>
                           </div>
@@ -1313,13 +1373,16 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                   </div>
                 </Cell>
                 <Cell
+                  className=""
                   desktopColumns={6}
+                  tag="div"
                 >
                   <div
                     className="mdc-layout-grid__cell mdc-layout-grid__cell--span-6-desktop"
                   >
                     <Card
                       className="globalhome-thirdpartycard"
+                      outlined={false}
                     >
                       <div
                         className="mdc-card globalhome-thirdpartycard"
@@ -1356,17 +1419,24 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                             </FormattedHTMLMessage>
                           </p>
                         </div>
-                        <Actions>
+                        <Actions
+                          className=""
+                          fullBleed={false}
+                        >
                           <div
                             className="mdc-card__actions"
                           >
-                            <ActionButtons>
+                            <ActionButtons
+                              className=""
+                            >
                               <div
                                 className="mdc-card__action-buttons"
                               >
-                                <RippledComponent
+                                <WithRipple(Button)
                                   className="pf-button-secondary mdc-card__action mdc-card__action--button"
+                                  dense={false}
                                   disabled={false}
+                                  icon={null}
                                   initRipple={[Function]}
                                   key=".0"
                                   onBlur={[Function]}
@@ -1378,13 +1448,17 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                                   onMouseUp={[Function]}
                                   onTouchEnd={[Function]}
                                   onTouchStart={[Function]}
+                                  outlined={false}
                                   raised={true}
                                   style={Object {}}
                                   unbounded={false}
+                                  unelevated={false}
                                 >
-                                  <Component
+                                  <Button
                                     className="pf-button-secondary mdc-card__action mdc-card__action--button"
+                                    dense={false}
                                     disabled={false}
+                                    icon={null}
                                     initRipple={[Function]}
                                     onBlur={[Function]}
                                     onClick={[Function]}
@@ -1395,8 +1469,11 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                                     onMouseUp={[Function]}
                                     onTouchEnd={[Function]}
                                     onTouchStart={[Function]}
+                                    outlined={false}
                                     raised={true}
                                     style={Object {}}
+                                    unbounded={false}
+                                    unelevated={false}
                                   >
                                     <button
                                       className="mdc-button pf-button-secondary mdc-card__action mdc-card__action--button mdc-button--raised"
@@ -1412,14 +1489,10 @@ exports[`testing GlobalHome snapshot test for GlobalHome 1`] = `
                                       onTouchStart={[Function]}
                                       style={Object {}}
                                     >
-                                      <span
-                                        className="mdc-button__label"
-                                      >
-                                        Get started
-                                      </span>
+                                      Get started
                                     </button>
-                                  </Component>
-                                </RippledComponent>
+                                  </Button>
+                                </WithRipple(Button)>
                               </div>
                             </ActionButtons>
                           </div>

--- a/ui/src/pages/__snapshots__/RepoHome_test.js.snap
+++ b/ui/src/pages/__snapshots__/RepoHome_test.js.snap
@@ -186,11 +186,15 @@ exports[`testing RepoHome snapshot test for RepoHome 1`] = `
               dense={false}
               floatingLabelClassName=""
               fullWidth={false}
+              helperText={null}
+              isRtl={false}
               label="Search for a person"
+              leadingIcon={null}
               lineRippleClassName=""
               notchedOutlineClassName=""
               outlined={true}
               textarea={false}
+              trailingIcon={null}
             >
               <div
                 className="mdc-text-field searchbar mdc-text-field--outlined"
@@ -218,6 +222,7 @@ exports[`testing RepoHome snapshot test for RepoHome 1`] = `
                         "hasLabel": [Function],
                         "hasOutline": [Function],
                         "isFocused": [Function],
+                        "isRtl": [Function],
                         "notchOutline": [Function],
                         "registerInputInteractionHandler": [Function],
                         "registerTextFieldInteractionHandler": [Function],
@@ -226,8 +231,10 @@ exports[`testing RepoHome snapshot test for RepoHome 1`] = `
                         "setLineRippleTransformOrigin": [Function],
                         "shakeLabel": [Function],
                       },
-                      "characterCounter_": undefined,
-                      "helperText_": undefined,
+                      "helperText_": Object {
+                        "setValidity": [Function],
+                        "showToScreenReader": [Function],
+                      },
                       "inputBlurHandler_": [Function],
                       "inputFocusHandler_": [Function],
                       "inputInputHandler_": [Function],
@@ -238,6 +245,7 @@ exports[`testing RepoHome snapshot test for RepoHome 1`] = `
                       "setPointerXOffset_": [Function],
                       "textFieldInteractionHandler_": [Function],
                       "trailingIcon_": undefined,
+                      "useCustomValidityChecking_": false,
                       "useNativeValidation_": true,
                       "validationAttributeChangeHandler_": [Function],
                       "validationObserver_": undefined,
@@ -245,19 +253,22 @@ exports[`testing RepoHome snapshot test for RepoHome 1`] = `
                   }
                   handleFocusChange={[Function]}
                   handleValueChange={[Function]}
-                  id=""
+                  id={null}
                   inputType="input"
+                  onBlur={[Function]}
                   onChange={[Function]}
+                  onFocus={[Function]}
                   onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchStart={[Function]}
                   setDisabled={[Function]}
                   setInputId={[Function]}
-                  syncInput={[Function]}
                   value=""
                 >
                   <input
                     className="mdc-text-field__input"
                     disabled={false}
-                    id=""
+                    id={null}
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -267,44 +278,42 @@ exports[`testing RepoHome snapshot test for RepoHome 1`] = `
                     value=""
                   />
                 </Input>
+                <FloatingLabel
+                  className=""
+                  float={false}
+                  handleWidthChange={[Function]}
+                  htmlFor={null}
+                >
+                  <label
+                    className="mdc-floating-label"
+                    htmlFor={null}
+                    onAnimationEnd={[Function]}
+                  >
+                    Search for a person
+                  </label>
+                </FloatingLabel>
                 <NotchedOutline
                   className=""
+                  isRtl={false}
                   notch={false}
                   notchWidth={0}
                 >
                   <div
-                    className="mdc-notched-outline mdc-notched-outline--upgraded"
+                    className="mdc-notched-outline"
+                    key="notched-outline"
                   >
-                    <div
-                      className="mdc-notched-outline__leading"
-                    />
-                    <div
-                      className="mdc-notched-outline__notch"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
+                    <svg
+                      focusable="false"
                     >
-                      <FloatingLabel
-                        className=""
-                        float={false}
-                        handleWidthChange={[Function]}
-                        htmlFor=""
-                      >
-                        <label
-                          className="mdc-floating-label"
-                          htmlFor=""
-                          onAnimationEnd={[Function]}
-                        >
-                          Search for a person
-                        </label>
-                      </FloatingLabel>
-                    </div>
-                    <div
-                      className="mdc-notched-outline__trailing"
-                    />
+                      <path
+                        className="mdc-notched-outline__path"
+                      />
+                    </svg>
                   </div>
+                  <div
+                    className="mdc-notched-outline__idle"
+                    key="notched-outline-idle"
+                  />
                 </NotchedOutline>
               </div>
             </TextField>
@@ -347,9 +356,11 @@ exports[`testing RepoHome snapshot test for RepoHome 1`] = `
             </span>
           </div>
         </EndBarHeader>
-        <RippledComponent
+        <WithRipple(Button)
           className="pf-button-secondary"
+          dense={false}
           disabled={false}
+          icon={null}
           initRipple={[Function]}
           onBlur={[Function]}
           onClick={[Function]}
@@ -360,13 +371,17 @@ exports[`testing RepoHome snapshot test for RepoHome 1`] = `
           onMouseUp={[Function]}
           onTouchEnd={[Function]}
           onTouchStart={[Function]}
+          outlined={false}
           raised={true}
           style={Object {}}
           unbounded={false}
+          unelevated={false}
         >
-          <Component
+          <Button
             className="pf-button-secondary"
+            dense={false}
             disabled={false}
+            icon={null}
             initRipple={[Function]}
             onBlur={[Function]}
             onClick={[Function]}
@@ -377,8 +392,11 @@ exports[`testing RepoHome snapshot test for RepoHome 1`] = `
             onMouseUp={[Function]}
             onTouchEnd={[Function]}
             onTouchStart={[Function]}
+            outlined={false}
             raised={true}
             style={Object {}}
+            unbounded={false}
+            unelevated={false}
           >
             <button
               className="mdc-button pf-button-secondary mdc-button--raised"
@@ -394,14 +412,10 @@ exports[`testing RepoHome snapshot test for RepoHome 1`] = `
               onTouchStart={[Function]}
               style={Object {}}
             >
-              <span
-                className="mdc-button__label"
-              >
-                Provide information about someone
-              </span>
+              Provide information about someone
             </button>
-          </Component>
-        </RippledComponent>
+          </Button>
+        </WithRipple(Button)>
       </div>
       <InjectIntl(Footer)>
         <Footer

--- a/ui/src/pages/__snapshots__/Results_test.js.snap
+++ b/ui/src/pages/__snapshots__/Results_test.js.snap
@@ -198,11 +198,15 @@ exports[`testing Results snapshot test for Results 1`] = `
               dense={false}
               floatingLabelClassName=""
               fullWidth={false}
+              helperText={null}
+              isRtl={false}
               label="Search for a person"
+              leadingIcon={null}
               lineRippleClassName=""
               notchedOutlineClassName=""
               outlined={true}
               textarea={false}
+              trailingIcon={null}
             >
               <div
                 className="mdc-text-field searchbar mdc-text-field--outlined"
@@ -230,6 +234,7 @@ exports[`testing Results snapshot test for Results 1`] = `
                         "hasLabel": [Function],
                         "hasOutline": [Function],
                         "isFocused": [Function],
+                        "isRtl": [Function],
                         "notchOutline": [Function],
                         "registerInputInteractionHandler": [Function],
                         "registerTextFieldInteractionHandler": [Function],
@@ -238,8 +243,10 @@ exports[`testing Results snapshot test for Results 1`] = `
                         "setLineRippleTransformOrigin": [Function],
                         "shakeLabel": [Function],
                       },
-                      "characterCounter_": undefined,
-                      "helperText_": undefined,
+                      "helperText_": Object {
+                        "setValidity": [Function],
+                        "showToScreenReader": [Function],
+                      },
                       "inputBlurHandler_": [Function],
                       "inputFocusHandler_": [Function],
                       "inputInputHandler_": [Function],
@@ -250,6 +257,7 @@ exports[`testing Results snapshot test for Results 1`] = `
                       "setPointerXOffset_": [Function],
                       "textFieldInteractionHandler_": [Function],
                       "trailingIcon_": undefined,
+                      "useCustomValidityChecking_": false,
                       "useNativeValidation_": true,
                       "validationAttributeChangeHandler_": [Function],
                       "validationObserver_": undefined,
@@ -257,19 +265,22 @@ exports[`testing Results snapshot test for Results 1`] = `
                   }
                   handleFocusChange={[Function]}
                   handleValueChange={[Function]}
-                  id=""
+                  id={null}
                   inputType="input"
+                  onBlur={[Function]}
                   onChange={[Function]}
+                  onFocus={[Function]}
                   onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  onTouchStart={[Function]}
                   setDisabled={[Function]}
                   setInputId={[Function]}
-                  syncInput={[Function]}
                   value="thátcher"
                 >
                   <input
                     className="mdc-text-field__input"
                     disabled={false}
-                    id=""
+                    id={null}
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
@@ -279,44 +290,42 @@ exports[`testing Results snapshot test for Results 1`] = `
                     value="thátcher"
                   />
                 </Input>
+                <FloatingLabel
+                  className=""
+                  float={true}
+                  handleWidthChange={[Function]}
+                  htmlFor={null}
+                >
+                  <label
+                    className="mdc-floating-label mdc-floating-label--float-above"
+                    htmlFor={null}
+                    onAnimationEnd={[Function]}
+                  >
+                    Search for a person
+                  </label>
+                </FloatingLabel>
                 <NotchedOutline
                   className=""
+                  isRtl={false}
                   notch={true}
                   notchWidth={0}
                 >
                   <div
-                    className="mdc-notched-outline mdc-notched-outline--upgraded mdc-notched-outline--notched"
+                    className="mdc-notched-outline mdc-notched-outline--notched"
+                    key="notched-outline"
                   >
-                    <div
-                      className="mdc-notched-outline__leading"
-                    />
-                    <div
-                      className="mdc-notched-outline__notch"
-                      style={
-                        Object {
-                          "width": undefined,
-                        }
-                      }
+                    <svg
+                      focusable="false"
                     >
-                      <FloatingLabel
-                        className=""
-                        float={true}
-                        handleWidthChange={[Function]}
-                        htmlFor=""
-                      >
-                        <label
-                          className="mdc-floating-label mdc-floating-label--float-above"
-                          htmlFor=""
-                          onAnimationEnd={[Function]}
-                        >
-                          Search for a person
-                        </label>
-                      </FloatingLabel>
-                    </div>
-                    <div
-                      className="mdc-notched-outline__trailing"
-                    />
+                      <path
+                        className="mdc-notched-outline__path"
+                      />
+                    </svg>
                   </div>
+                  <div
+                    className="mdc-notched-outline__idle"
+                    key="notched-outline-idle"
+                  />
                 </NotchedOutline>
               </div>
             </TextField>
@@ -877,7 +886,7 @@ exports[`testing Results snapshot test for Results 1`] = `
           </Footer>
         </InjectIntl(Footer)>
       </div>
-      <RippledComponent
+      <WithRipple(Fab)
         className="results-addpersonfab"
         disabled={false}
         icon={
@@ -885,6 +894,8 @@ exports[`testing Results snapshot test for Results 1`] = `
             src="/static/icons/maticon_add.svg"
           />
         }
+        initRipple={[Function]}
+        mini={false}
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -898,7 +909,7 @@ exports[`testing Results snapshot test for Results 1`] = `
         textLabel="Create new record"
         unbounded={false}
       >
-        <Component
+        <Fab
           className="results-addpersonfab"
           disabled={false}
           icon={
@@ -907,6 +918,7 @@ exports[`testing Results snapshot test for Results 1`] = `
             />
           }
           initRipple={[Function]}
+          mini={false}
           onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
@@ -918,10 +930,16 @@ exports[`testing Results snapshot test for Results 1`] = `
           onTouchStart={[Function]}
           style={Object {}}
           textLabel="Create new record"
+          unbounded={false}
         >
           <button
             className="mdc-fab results-addpersonfab mdc-fab--extended"
             disabled={false}
+            icon={
+              <img
+                src="/static/icons/maticon_add.svg"
+              />
+            }
             onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
@@ -933,30 +951,18 @@ exports[`testing Results snapshot test for Results 1`] = `
             onTouchStart={[Function]}
             style={Object {}}
           >
-            <Icon
-              icon={
-                <img
-                  src="/static/icons/maticon_add.svg"
-                />
-              }
+            <img
+              className="mdc-fab__icon"
+              src="/static/icons/maticon_add.svg"
+            />
+            <span
+              className="mdc-fab__label"
             >
-              <img
-                className="mdc-fab__icon"
-                src="/static/icons/maticon_add.svg"
-              />
-            </Icon>
-            <TextLabel
-              textLabel="Create new record"
-            >
-              <span
-                className="mdc-fab__label"
-              >
-                Create new record
-              </span>
-            </TextLabel>
+              Create new record
+            </span>
           </button>
-        </Component>
-      </RippledComponent>
+        </Fab>
+      </WithRipple(Fab)>
     </div>
   </Results>
 </InjectIntl(Results)>

--- a/ui/src/pages/__snapshots__/Results_test.js.snap
+++ b/ui/src/pages/__snapshots__/Results_test.js.snap
@@ -547,7 +547,6 @@ exports[`testing Results snapshot test for Results 1`] = `
                                 hour="numeric"
                                 minute="numeric"
                                 month="short"
-                                timeZone="UTC"
                                 timeZoneName="short"
                                 value={2019-05-15T17:12:23.936Z}
                               />,
@@ -561,7 +560,6 @@ exports[`testing Results snapshot test for Results 1`] = `
                               hour="numeric"
                               minute="numeric"
                               month="short"
-                              timeZone="UTC"
                               timeZoneName="short"
                               value={2019-05-15T17:12:23.936Z}
                             >
@@ -798,7 +796,6 @@ exports[`testing Results snapshot test for Results 1`] = `
                                 hour="numeric"
                                 minute="numeric"
                                 month="short"
-                                timeZone="UTC"
                                 timeZoneName="short"
                                 value={2019-05-16T16:35:23.936Z}
                               />,
@@ -812,7 +809,6 @@ exports[`testing Results snapshot test for Results 1`] = `
                               hour="numeric"
                               minute="numeric"
                               month="short"
-                              timeZone="UTC"
                               timeZoneName="short"
                               value={2019-05-16T16:35:23.936Z}
                             >


### PR DESCRIPTION
Turns out it'll use the client's timezone by default, which is great. We just have to set the timezone env variable in tests, so that tests don't break in other timezones.

The snapshot tests are to fix something I broke earlier: GitHub's CI mechanism [was broken](https://twitter.com/githubstatus/status/1131255005909049345) earlier today, so I ran the tests locally, forgetting that I had a more recent version of the Material libraries installed, which wasn't consistent with what's specified in `package.json` (being updated in PR #698).