### PR TITLE
Allow any hosts for local development server.

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -35,8 +35,7 @@ SECRET_KEY = os.urandom(30)
 if os.environ.get('SERVER_SOFTWARE', '').startswith('Development'):
     DEBUG = True
     DEBUG_PROPAGATE_EXCEPTIONS = True
-    # If DEBUG is True and ALLOWED_HOSTS is empty, Django permits localhost.
-    ALLOWED_HOSTS = []
+    ALLOWED_HOSTS = ['*']
     SECURE_SSL_REDIRECT = False
 else:
     DEBUG = False


### PR DESCRIPTION
@nworden I forgot if we have considered this, but how about allowing any hosts for local development server?

In my development environment, the browser and the server run on different machines, so I cannot access the server with "localhost". We may alternatively provide a way to explicitly specify the host name, but I'm not sure if we need such security for local development.