### PR TITLE
592: Tell users if they enter an invalid age

### DIFF
--- a/app/resources/static/fixed/forms.js
+++ b/app/resources/static/fixed/forms.js
@@ -361,6 +361,22 @@ function validate_fields() {
     }
   }
 
+  // Validate age format
+  var age_field = $('age');
+  var age_value = age_field.value;
+
+  if (age_value != "") {
+    var curated_age_value = age_value.replace(/\s/g,'');
+    var valid_age_re = /^(\d+-?)+\d+$/;
+
+    var isAgeFormatValid = valid_age_re.test(curated_age_value);
+
+    if (!isAgeFormatValid) {
+      alert("The age entered is not in a valid format.");
+      return false;
+    }
+  }
+
   return true;
 }
 


### PR DESCRIPTION
Worked on https://github.com/google/personfinder/issues/592 ;
It is its most simplest validation form (which doesn't consider the CJK or if the order of the ages is proper (i.e. "34-0" might be considered invalid if the database doesn't handle that)).