### PR TITLE
Add npm audit option to tools/ui.

### DIFF
--- a/tools/ui
+++ b/tools/ui
@@ -35,6 +35,9 @@ case "$1" in
     mv ui/dist/bundle.css app/resources/static/fixed/ui_bundles/bundle.css
     cp -r --no-clobber ui/static/static/* app/resources/static/fixed/
     ;;
+"depaudit")
+    npm audit --prefix ui
+    ;;
 *)
     echo "Specify run, test, or buildtoae."
     exit 1


### PR DESCRIPTION
I don't think it makes sense to add this to the automated tests on
GitHub, because it can fail for reasons unrelated to the code being
changed. However, I do want to add it to the pre-release tests once the
React UI is used in production, and this makes that a little more
convenient.