### PR TITLE
Add device width meta tag.

### DIFF
--- a/app/resources/react_index.html.template
+++ b/app/resources/react_index.html.template
@@ -27,6 +27,7 @@
     type="text/css"
     href="/static/ui_bundles/bundle.css"
     nonce="{{ csp_nonce }}">
+  <meta name="viewport" content="width=device-width">
 </head>
 
 <body>

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -27,6 +27,7 @@
   <meta charset="utf-8">
   <title>UI Development Server</title>
   <link rel="stylesheet" type="text/css" href="../dist/bundle.css">
+  <meta name="viewport" content="width=device-width">
 </head>
 
 <body>


### PR DESCRIPTION
We've had some issues with media queries with Chrome dev tools; this fixes it.