### PR TITLE
Move ui tests to Python 3 Travis run.

### DIFF
--- a/tools/travis_tests
+++ b/tools/travis_tests
@@ -27,11 +27,11 @@ case "${TRAVIS_PYTHON_VERSION:0:1}" in
             $TOOLS_DIR/unit_tests -q && \
             $TOOLS_DIR/server_tests -q && \
             $TOOLS_DIR/python3_compatibility_check && \
-            $TOOLS_DIR/ui test && \
             echo "All Python 2.7 tests and checks passed."
         ;;
     "3")
-        $TOOLS_DIR/py3_unit_tests -q &&
+        $TOOLS_DIR/py3_unit_tests -q && \
+            $TOOLS_DIR/ui test && \
             echo "All Python 3.7 tests and checks passed."
         ;;
     *)


### PR DESCRIPTION
We have our tests split up into Python 2 and Python 3 Travis runs. It
doesn't really matter which one the UI tests run in, because they don't
involve any Python, but I think there's two reasons it's better to put
them in the Py3 run:
- There's only one Py3 run (we test with two different versions of
  Python 2), and we only need the UI tests to run once.
- The Python 3 tests are faster (because there's fewer of them). By
  moving the UI tests to the Py3 run we'll make things more balanced,
  and we won't have to wait as long to find out if a UI test is failing.