### PR TITLE
Update SearchBar value when props change.

### DIFF
--- a/ui/src/components/SearchBar.js
+++ b/ui/src/components/SearchBar.js
@@ -35,6 +35,12 @@ class SearchBar extends Component {
     this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.initialValue != this.props.initialValue) {
+      this.setState({value: this.props.initialValue});
+    }
+  }
+
   handleKeyDown(e) {
     if (e.key === 'Enter') {
       e.preventDefault();

--- a/ui/src/components/SearchBar_test.js
+++ b/ui/src/components/SearchBar_test.js
@@ -48,3 +48,14 @@ test('search handler should be called on "Enter" keydown', () => {
   expect(mockSearchCallback).toHaveBeenCalledWith('gilbert');
   wrapper.unmount();
 });
+
+test('value should update if props change', () => {
+  const wrapper = mountWithIntl(
+    <SearchBar initialValue='tom' />
+  );
+  expect(wrapper.find('SearchBar').state().value).toBe('tom');
+  wrapper.setProps({initialValue: 'matt'});
+  wrapper.update();
+  expect(wrapper.find('SearchBar').state().value).toBe('matt');
+  wrapper.unmount();
+});


### PR DESCRIPTION
There's currently a bug where if you make a query, make a new query, and
then hit the back button, the value in the search bar doesn't get
updated to the original query. This is because it doesn't pay attention
to updates to props. This commit fixes that.