### PR TITLE
Fix 500 error on about person finder - fix issue #752

### DIFF
--- a/app/app.yaml
+++ b/app/app.yaml
@@ -45,6 +45,10 @@ handlers:
   script: wsgi.application
 - url: /setup_datastore/?
   script: wsgi.application
+- url: /global/?
+  script: wsgi.application
+- url: /personfinder/global/?
+  script: wsgi.application
 - url: /global/home.html
   script: wsgi.application
 - url: /personfinder/global/home.html

--- a/app/urls.py
+++ b/app/urls.py
@@ -79,6 +79,8 @@ _BASE_URL_PATTERNS = [
     # The regular global homepage path is in _STARTING_SLASH_URL_PATTERNS below.
     ('enduser_global-index-altpath', r'global/home.html',
      views.enduser.global_index.GlobalIndexView.as_view),
+    ('enduser_global-index-altpath2', r'global/?',
+     views.enduser.global_index.GlobalIndexView.as_view),
     ('meta_static-howto', r'global/howto.html',
      views.meta.static_pages.HowToView.as_view),
     ('meta_static-responders', r'global/responders.html',

--- a/tests/views/test_auto_security.py
+++ b/tests/views/test_auto_security.py
@@ -201,6 +201,12 @@ class AutoSecurityTests(view_tests_base.ViewTestsBase):
             accepts_post=False,
             min_admin_level=None,
             requires_xsrf=False),
+        'enduser_global-index-altpath2':
+            path_test_info(
+                accepts_get=True,
+                accepts_post=False,
+                min_admin_level=None,
+                requires_xsrf=False),
         'frontendapi_add-note':
         path_test_info(
             accepts_get=False,


### PR DESCRIPTION
The underlying issue was the following:
1.  `global/` URL pattern was passed to `main.py`, which is outdated.
It should be handled by Django.
2.  The pattern was not configured in Django url patterns - 'urls.py`
