### PR TITLE
Fix slow server tests #763 #764

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tests/server_test_cases/.cache/
 .pytest_cache/
 .vscode/
 env/
+venv/

--- a/tools/server_tests
+++ b/tools/server_tests
@@ -31,11 +31,11 @@ pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 cd "$(dirname $0)/.."
 
 # Parse arguments and set flags
-SKIP_UPDATE_TRANSLATIONS='false'
+SKIP_UPDATE_TRANSLATIONS=false
 for arg in "$@"; do
   shift
   if [[ "${arg}" == "--skip_update_translations" ]]; then
-    SKIP_UPDATE_TRANSLATIONS='true'
+    SKIP_UPDATE_TRANSLATIONS=true
     continue
   fi
   # All arguments other than "--skip_update_translations" remains intact
@@ -44,7 +44,7 @@ done
 readonly SKIP_UPDATE_TRANSLATIONS
 
 echo
-if [[ "${SKIP_UPDATE_TRANSLATIONS}" == 'true' ]]; then
+if [[ "${SKIP_UPDATE_TRANSLATIONS}" == true ]]; then
   echo "--- Skipped updating translations"
 else
   echo "--- Updating translations"

--- a/tools/server_tests
+++ b/tools/server_tests
@@ -30,9 +30,26 @@ pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 # directory.
 cd "$(dirname $0)/.."
 
+# Parse arguments and set flags
+SKIP_UPDATE_TRANSLATIONS='false'
+for arg in "$@"; do
+  shift
+  if [[ "${arg}" == "--skip_update_translations" ]]; then
+    SKIP_UPDATE_TRANSLATIONS='true'
+    continue
+  fi
+  # All arguments other than "--skip_update_translations" remains intact
+  set -- "$@" "${arg}"
+done
+readonly SKIP_UPDATE_TRANSLATIONS
+
 echo
-echo "--- Updating translations"
-$TOOLS_DIR/update_messages
+if [[ "${SKIP_UPDATE_TRANSLATIONS}" == 'true' ]]; then
+  echo "--- Skipped updating translations"
+else
+  echo "--- Updating translations"
+  "${TOOLS_DIR}"/update_messages
+fi
 
 echo
 echo "--- Running server tests"

--- a/tools/update_messages.py
+++ b/tools/update_messages.py
@@ -189,4 +189,5 @@ if __name__ == '__main__':
 
     # Run compilemessages to generate all the .mo files.
     sys.stderr = open('/dev/null', 'w')  # suppress the listing of all files
-    django_admin('compilemessages')
+    django_admin('compilemessages',
+                 '--ignore=vendors')


### PR DESCRIPTION
Optimize server tests. The PR also includes a small fix to support `virtualenv`.
- Support an optional argument --skip_update_translations #763
- Skip app/vendors from compilemessages #763
- Add venv/ to .gitignore to support virtualenv #764

Example usage and outputs:
```
 % tools/server_tests --skip_update_translations
--- Skipped updating translations

--- Running server tests
... (server tests continue) ...
```

```
 % tools/server_tests                                                                                       

--- Updating translations
... (update translations) ...

--- Running server tests
... (server tests continue) ...
```