### PR TITLE
Revert "Skip app/vendors from compilemessages #763" PR #765

### DIFF
--- a/tools/update_messages.py
+++ b/tools/update_messages.py
@@ -189,5 +189,4 @@ if __name__ == '__main__':
 
     # Run compilemessages to generate all the .mo files.
     sys.stderr = open('/dev/null', 'w')  # suppress the listing of all files
-    django_admin('compilemessages',
-                 '--ignore=vendors')
+    django_admin('compilemessages')


### PR DESCRIPTION
This reverts commit 0af534cb46efb86b5f6a365e57b2bd9edbb068ee.

--ignore option for compilemessages is supported in greater than django 3.0.
https://docs.djangoproject.com/en/3.1/ref/django-admin/#cmdoption-compilemessages-ignore

makemessages support --ignore even on django 1.x
https://docs.djangoproject.com/en/3.1/ref/django-admin/#cmdoption-makemessages-ignore

Indeed, our django version is 1.11.29, which is the last version for Python 2.x
Django 1.11 is the last version to support Python 2.7. Support for Python 2.7 and Django 1.11 ends in 2020.
https://docs.djangoproject.com/en/3.1/faq/install/

As a result of adding the option to compilemessages, tools/update_messages started to fail with exit code of 2.
Based on an internal sync, we decided to keep the change on hold until we migrate the project to Python 3 (and consequently migrate django to 3.x as well).

This PR is a correction of https://github.com/google/personfinder/pull/767.