### PR TITLE
Add an executable wrapper of tools/download_feed.py.

### DIFF
--- a/tools/download_feed
+++ b/tools/download_feed
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
+
+$PYTHON $TOOLS_DIR/download_feed.py "$@"
+


### PR DESCRIPTION
Hitting tools/download_feed.py directly doesn't work due to dependencies, so we need an wrapper.

(It used to work somehow, but I don't know how it used to work...)