### PR TITLE
Add an instruction on Application Default Credentials.

### DIFF
--- a/tools/console
+++ b/tools/console
@@ -14,6 +14,10 @@
 # limitations under the License.
 
 
+# Set up appropriate Application Default Credentials (ADC)
+# to access a production host.
+# https://cloud.google.com/sdk/gcloud/reference/auth/application-default
+
 pushd "$(dirname $0)" >/dev/null && source common.sh && popd >/dev/null
 
 export REMOTE_API_RC="from model import *"$'\n'"from setup_pf import *"


### PR DESCRIPTION
An auth error occurs when we access a production host using tools/console  unless ADCs are properly configured.
e.g. $ tools/console googlepersonfinder.appspot.com
https://github.com/google/personfinder/issues/395#issuecomment-776477763