### PR TITLE
Change max retry count of all task queues from infinite to 5.

### DIFF
--- a/app/queue.yaml
+++ b/app/queue.yaml
@@ -1,12 +1,24 @@
 queue:
+- name: default
+  rate: 1/s
+  retry_parameters:
+    task_retry_limit: 5
 # Throttle mail according to quota, see
 # https://cloud.google.com/appengine/quotas?csw=1#Mail
 - name: send-mail
   rate: 5/s
+  retry_parameters:
+    task_retry_limit: 5
 # expiry query for ScanExpired tasks
 - name: expiry
   rate: 5/m
+  retry_parameters:
+    task_retry_limit: 5
 - name: datachecks
   rate: 5/m
+  retry_parameters:
+    task_retry_limit: 5
 - name: prepare-thumbnails
   rate: 5/m
+  retry_parameters:
+    task_retry_limit: 5


### PR DESCRIPTION
Tasks could continously fail for various reasons. I found it problematic
(e.g., It leaves a lot of pending tasks in the queue over time) to retry
them indefinitely.