### PR TITLE
Add a hard dependency to rsa 4.0 specifically.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ simplejson==3.16.0
 six==1.11.0
 unidecode==0.04.20
 xlrd==1.2.0
+rsa==4.0


### PR DESCRIPTION
`rsa` is already an indirect dependency of other requirements. Its latest version no longer supports Python 2.7. So it now causes an error on `pip install`. rsa 4.0 is the last version supporting Python 2 according to its release note.